### PR TITLE
add tests for EndpointManager

### DIFF
--- a/src/EndpointAndManager.sol
+++ b/src/EndpointAndManager.sol
@@ -8,9 +8,8 @@ abstract contract EndpointAndManager is Endpoint, EndpointManager {
     constructor(
         address token,
         bool isLockingMode,
-        uint16 chainId,
-        uint256 evmChainId
-    ) EndpointManager(token, isLockingMode, chainId, evmChainId) {}
+        uint16 chainId
+    ) EndpointManager(token, isLockingMode, chainId) {}
 
     function quoteDeliveryPrice(uint16 recipientChain) public view override returns (uint256) {
         return _quoteDeliveryPrice(recipientChain);

--- a/src/EndpointAndManager.sol
+++ b/src/EndpointAndManager.sol
@@ -5,11 +5,7 @@ import "./Endpoint.sol";
 import "./EndpointManager.sol";
 
 abstract contract EndpointAndManager is Endpoint, EndpointManager {
-    constructor(
-        address token,
-        bool isLockingMode,
-        uint16 chainId
-    ) EndpointManager(token, isLockingMode, chainId) {}
+    constructor(address token, Mode mode, uint16 chainId) EndpointManager(token, mode, chainId) {}
 
     function quoteDeliveryPrice(uint16 recipientChain) public view override returns (uint256) {
         return _quoteDeliveryPrice(recipientChain);

--- a/src/EndpointAndManager.sol
+++ b/src/EndpointAndManager.sol
@@ -20,6 +20,7 @@ abstract contract EndpointAndManager is Endpoint, EndpointManager {
     }
 
     function _deliverToManager(bytes memory payload) internal override {
+        // TODO: this relies on the Endpoint implementation to replay protect messages.
         return _executeMsg(payload);
     }
 

--- a/src/EndpointManager.sol
+++ b/src/EndpointManager.sol
@@ -26,11 +26,16 @@ abstract contract EndpointManager is IEndpointManager, OwnableUpgradeable, Reent
 
     uint64 _sequence;
 
-    constructor(address token, bool isLockingMode, uint16 chainId, uint256 evmChainId) {
+    constructor(address token, bool isLockingMode, uint16 chainId) {
         _token = token;
         _isLockingMode = isLockingMode;
         _chainId = chainId;
-        _evmChainId = evmChainId;
+        _evmChainId = block.chainid;
+    }
+
+    function initialize() public initializer {
+        // TODO: shouldn't be msg.sender but a separate (contract) address that's passed in the initializer
+        __Ownable_init(msg.sender);
     }
 
     /// @dev This will either cross-call or internal call, depending on whether the contract is standalone or not.

--- a/src/EndpointManager.sol
+++ b/src/EndpointManager.sol
@@ -109,8 +109,9 @@ abstract contract EndpointManager is IEndpointManager, OwnableUpgradeable, Reent
 
         // construct the ManagerMessage payload
         _sequence = useSequence();
-        bytes memory encodedManagerPayload =
-            encodeEndpointManagerMessage(_chainId, _sequence, 1, encodedTransferPayload);
+        bytes memory encodedManagerPayload = encodeEndpointManagerMessage(
+            EndpointManagerMessage(_chainId, _sequence, 1, encodedTransferPayload)
+        );
 
         // send the message
         sendMessage(recipientChain, encodedManagerPayload);
@@ -185,15 +186,14 @@ abstract contract EndpointManager is IEndpointManager, OwnableUpgradeable, Reent
         _sequence++;
     }
 
-    function encodeEndpointManagerMessage(
-        uint16 chainId,
-        uint64 sequence,
-        uint8 msgType,
-        bytes memory payload
-    ) public pure returns (bytes memory encoded) {
+    function encodeEndpointManagerMessage(EndpointManagerMessage memory m)
+        public
+        pure
+        returns (bytes memory encoded)
+    {
         // TODO -- should we check payload length here?
         // for example, CCTP integration checks payload is <= max(uint16)
-        return abi.encodePacked(chainId, sequence, msgType, payload);
+        return abi.encodePacked(m.chainId, m.sequence, m.msgType, m.payload);
     }
 
     /*

--- a/src/EndpointManagerStandalone.sol
+++ b/src/EndpointManagerStandalone.sol
@@ -172,7 +172,9 @@ contract EndpointManagerStandalone is IEndpointManagerStandalone, EndpointManage
         uint64 updatedEnabledEndpointBitmap =
             _enabledEndpointBitmap | uint64(1 << endpointInfos[endpoint].index);
         // ensure that this actually changed the bitmap
-        assert(updatedEnabledEndpointBitmap > _enabledEndpointBitmap);
+        if (updatedEnabledEndpointBitmap == _enabledEndpointBitmap) {
+            revert EndpointAlreadyEnabled(endpoint);
+        }
         _enabledEndpointBitmap = updatedEnabledEndpointBitmap;
 
         emit EndpointAdded(endpoint);
@@ -181,6 +183,9 @@ contract EndpointManagerStandalone is IEndpointManagerStandalone, EndpointManage
     }
 
     function removeEndpoint(address endpoint) external onlyOwner {
+        // TODO: should this reduce the threshold if the threshold is greater
+        // than the number of enabled endpoints after this one is removed?
+
         if (endpoint == address(0)) {
             revert InvalidEndpointZeroAddress();
         }

--- a/src/EndpointManagerStandalone.sol
+++ b/src/EndpointManagerStandalone.sol
@@ -59,11 +59,7 @@ contract EndpointManagerStandalone is IEndpointManagerStandalone, EndpointManage
         _;
     }
 
-    constructor(
-        address token,
-        bool isLockingMode,
-        uint16 chainId
-    ) EndpointManager(token, isLockingMode, chainId) {
+    constructor(address token, Mode mode, uint16 chainId) EndpointManager(token, mode, chainId) {
         _checkEndpointsInvariants();
     }
 

--- a/src/EndpointManagerStandalone.sol
+++ b/src/EndpointManagerStandalone.sol
@@ -62,9 +62,8 @@ contract EndpointManagerStandalone is IEndpointManagerStandalone, EndpointManage
     constructor(
         address token,
         bool isLockingMode,
-        uint16 chainId,
-        uint256 evmChainId
-    ) EndpointManager(token, isLockingMode, chainId, evmChainId) {
+        uint16 chainId
+    ) EndpointManager(token, isLockingMode, chainId) {
         _checkEndpointsInvariants();
     }
 

--- a/src/WormholeEndpoint.sol
+++ b/src/WormholeEndpoint.sol
@@ -26,10 +26,10 @@ abstract contract WormholeEndpoint is Endpoint {
     error InvalidSibling(uint16 chainId, bytes32 siblingAddress);
     error TransferAlreadyCompleted(bytes32 vaaHash);
 
-    constructor(address wormholeCoreBridge, address wormholeRelayerAddr, uint256 evmChainId) {
+    constructor(address wormholeCoreBridge, address wormholeRelayerAddr) {
         _wormholeCoreBridge = wormholeCoreBridge;
         _wormholeRelayerAddr = wormholeRelayerAddr;
-        _wormholeEndpoint_evmChainId = evmChainId;
+        _wormholeEndpoint_evmChainId = block.chainid;
     }
 
     function _quoteDeliveryPrice(uint16 targetChain)

--- a/src/WormholeEndpointAndManager.sol
+++ b/src/WormholeEndpointAndManager.sol
@@ -9,11 +9,10 @@ contract WormholeEndpointAndManager is EndpointAndManager, WormholeEndpoint {
         address token,
         bool isLockingMode,
         uint16 chainId,
-        uint256 evmChainId,
         address wormholeCoreBridge,
         address wormholeRelayerAddr
     )
-        EndpointAndManager(token, isLockingMode, chainId, evmChainId)
-        WormholeEndpoint(wormholeCoreBridge, wormholeRelayerAddr, evmChainId)
+        EndpointAndManager(token, isLockingMode, chainId)
+        WormholeEndpoint(wormholeCoreBridge, wormholeRelayerAddr)
     {}
 }

--- a/src/WormholeEndpointAndManager.sol
+++ b/src/WormholeEndpointAndManager.sol
@@ -7,12 +7,12 @@ import "./WormholeEndpoint.sol";
 contract WormholeEndpointAndManager is EndpointAndManager, WormholeEndpoint {
     constructor(
         address token,
-        bool isLockingMode,
+        Mode mode,
         uint16 chainId,
         address wormholeCoreBridge,
         address wormholeRelayerAddr
     )
-        EndpointAndManager(token, isLockingMode, chainId)
+        EndpointAndManager(token, mode, chainId)
         WormholeEndpoint(wormholeCoreBridge, wormholeRelayerAddr)
     {}
 }

--- a/src/WormholeEndpointStandalone.sol
+++ b/src/WormholeEndpointStandalone.sol
@@ -11,10 +11,6 @@ contract WormholeEndpointStandalone is WormholeEndpoint, EndpointStandalone, Own
     constructor(
         address manager,
         address wormholeCoreBridge,
-        address wormholeRelayerAddr,
-        uint256 evmChainId
-    )
-        EndpointStandalone(manager)
-        WormholeEndpoint(wormholeCoreBridge, wormholeRelayerAddr, evmChainId)
-    {}
+        address wormholeRelayerAddr
+    ) EndpointStandalone(manager) WormholeEndpoint(wormholeCoreBridge, wormholeRelayerAddr) {}
 }

--- a/src/WormholeEndpointStandalone.sol
+++ b/src/WormholeEndpointStandalone.sol
@@ -6,6 +6,7 @@ import "openzeppelin-contracts/contracts/access/Ownable.sol";
 import "./WormholeEndpoint.sol";
 import "./EndpointStandalone.sol";
 
+// TODO: we shouldn't use Ownable from openzeppelin as it uses a non-deterministic storage slot
 contract WormholeEndpointStandalone is WormholeEndpoint, EndpointStandalone, Ownable {
     constructor(
         address manager,

--- a/src/interfaces/IEndpointManager.sol
+++ b/src/interfaces/IEndpointManager.sol
@@ -13,6 +13,8 @@ interface IEndpointManager {
     error NonRegisteredEndpoint(address endpoint);
     error DisabledEndpoint(address endpoint);
     error TooManyEndpoints();
+    error ZeroThreshold();
+    error ThresholdTooHigh(uint256 threshold, uint256 endpoints);
 
     event EndpointAdded(address endpoint);
     event EndpointRemoved(address endpoint);

--- a/src/interfaces/IEndpointManager.sol
+++ b/src/interfaces/IEndpointManager.sol
@@ -9,7 +9,7 @@ interface IEndpointManager {
     error UnexpectedEndpointManagerMessageType(uint8 msgType);
     error InvalidTargetChain(uint16 targetChain, uint16 thisChain);
     error InvalidEndpointZeroAddress();
-    error AlreadyRegisteredEndpoint(address endpoint);
+    error EndpointAlreadyEnabled(address endpoint);
     error NonRegisteredEndpoint(address endpoint);
     error DisabledEndpoint(address endpoint);
     error TooManyEndpoints();

--- a/src/interfaces/IEndpointManager.sol
+++ b/src/interfaces/IEndpointManager.sol
@@ -9,6 +9,7 @@ interface IEndpointManager {
     error UnexpectedEndpointManagerMessageType(uint8 msgType);
     error InvalidTargetChain(uint16 targetChain, uint16 thisChain);
     error InvalidEndpointZeroAddress();
+    error ZeroAmount();
     error EndpointAlreadyEnabled(address endpoint);
     error NonRegisteredEndpoint(address endpoint);
     error DisabledEndpoint(address endpoint);
@@ -30,4 +31,6 @@ interface IEndpointManager {
     function setSibling(uint16 siblingChainId, bytes32 siblingContract) external;
 
     function nextSequence() external view returns (uint64);
+
+    function token() external view returns (address);
 }

--- a/src/libraries/EndpointStructs.sol
+++ b/src/libraries/EndpointStructs.sol
@@ -17,6 +17,7 @@ struct NativeTokenTransfer {
     /// @notice Amount being transferred (big-endian uint256)
     uint256 amount;
     /// @notice Address of the token. Left-zero-padded if shorter than 32 bytes
+    // TODO: this field is not needed.
     bytes32 tokenAddress;
     /// @notice Address of the recipient. Left-zero-padded if shorter than 32 bytes
     bytes32 to;

--- a/test/EndpointManager.t.sol
+++ b/test/EndpointManager.t.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.6.12 <0.9.0;
 import "forge-std/Test.sol";
 
 import "../src/EndpointManagerStandalone.sol";
+import "../src/EndpointStandalone.sol";
 
 // @dev A non-abstract EndpointManager contract
 contract EndpointManagerContract is EndpointManagerStandalone {
@@ -14,16 +15,36 @@ contract EndpointManagerContract is EndpointManagerStandalone {
     ) EndpointManagerStandalone(token, isLockingMode, chainId) {}
 }
 
+contract DummyEndpoint is EndpointStandalone {
+    constructor(address manager) EndpointStandalone(manager) {}
+
+    function _quoteDeliveryPrice(uint16 /* recipientChain */ )
+        internal
+        pure
+        override
+        returns (uint256)
+    {
+        return 0;
+    }
+
+    function _sendMessage(uint16 recipientChain, bytes memory payload) internal pure override {
+        // do nothing
+    }
+
+    function _verifyMessage(bytes memory encodedMessage)
+        internal
+        pure
+        override
+        returns (bytes memory)
+    {
+        return encodedMessage;
+    }
+}
+
+// TODO: set this up so the common functionality tests can be run against both
+// the standalone and the integrated version of the endpoint manager
 contract TestEndpointManager is Test {
     EndpointManagerStandalone endpointManager;
-
-    function test_countSetBits() public {
-        assertEq(endpointManager.countSetBits(5), 2);
-        assertEq(endpointManager.countSetBits(0), 0);
-        assertEq(endpointManager.countSetBits(15), 4);
-        assertEq(endpointManager.countSetBits(16), 1);
-        assertEq(endpointManager.countSetBits(65535), 16);
-    }
 
     function setUp() public {
         endpointManager = new EndpointManagerContract(address(0), false, 0);
@@ -34,5 +55,235 @@ contract TestEndpointManager is Test {
         // deploy endpoint contracts
         // instantiate endpoint manager contract
         // endpointManager = new EndpointManagerContract();
+    }
+
+    // === pure unit tests
+
+    function test_countSetBits() public {
+        assertEq(endpointManager.countSetBits(5), 2);
+        assertEq(endpointManager.countSetBits(0), 0);
+        assertEq(endpointManager.countSetBits(15), 4);
+        assertEq(endpointManager.countSetBits(16), 1);
+        assertEq(endpointManager.countSetBits(65535), 16);
+    }
+
+    // === ownership
+
+    function test_owner() public {
+        // TODO: implement separate governance contract
+        assertEq(endpointManager.owner(), address(this));
+    }
+
+    function test_transferOwnership() public {
+        address newOwner = address(0x123);
+        endpointManager.transferOwnership(newOwner);
+        assertEq(endpointManager.owner(), newOwner);
+    }
+
+    function test_onlyOwnerCanTransferOwnership() public {
+        address notOwner = address(0x123);
+        vm.startPrank(notOwner);
+
+        bytes4 selector = bytes4(keccak256("OwnableUnauthorizedAccount(address)"));
+        vm.expectRevert(abi.encodeWithSelector(selector, notOwner));
+        endpointManager.transferOwnership(address(0x456));
+    }
+
+    // === endpoint registration
+
+    function test_registerEndpoint() public {
+        DummyEndpoint e = new DummyEndpoint(address(endpointManager));
+        endpointManager.setEndpoint(address(e));
+    }
+
+    function test_onlyOwnerCanModifyEndpoints() public {
+        DummyEndpoint e = new DummyEndpoint(address(endpointManager));
+        endpointManager.setEndpoint(address(e));
+
+        address notOwner = address(0x123);
+        vm.startPrank(notOwner);
+
+        bytes4 selector = bytes4(keccak256("OwnableUnauthorizedAccount(address)"));
+        vm.expectRevert(abi.encodeWithSelector(selector, notOwner));
+        endpointManager.setEndpoint(address(e));
+
+        vm.expectRevert(abi.encodeWithSelector(selector, notOwner));
+        endpointManager.removeEndpoint(address(e));
+    }
+
+    function test_cantEnableEndpointTwice() public {
+        DummyEndpoint e = new DummyEndpoint(address(endpointManager));
+        endpointManager.setEndpoint(address(e));
+
+        bytes4 selector = bytes4(keccak256("EndpointAlreadyEnabled(address)"));
+        vm.expectRevert(abi.encodeWithSelector(selector, address(e)));
+        endpointManager.setEndpoint(address(e));
+    }
+
+    function test_disableReenableEndpoint() public {
+        DummyEndpoint e = new DummyEndpoint(address(endpointManager));
+        endpointManager.setEndpoint(address(e));
+        endpointManager.removeEndpoint(address(e));
+        endpointManager.setEndpoint(address(e));
+    }
+
+    function test_multipleEndpoints() public {
+        DummyEndpoint e1 = new DummyEndpoint(address(endpointManager));
+        DummyEndpoint e2 = new DummyEndpoint(address(endpointManager));
+
+        endpointManager.setEndpoint(address(e1));
+        endpointManager.setEndpoint(address(e2));
+    }
+
+    function test_endpointIncompatibleManager() public {
+        // TODO: this is accepted currently. should we include a check to ensure
+        // only endpoints whose manager is us can be registered? (this would be
+        // a convenience check, not a security one)
+        DummyEndpoint e = new DummyEndpoint(address(0xBEEF));
+        endpointManager.setEndpoint(address(e));
+    }
+
+    function test_notEndpoint() public {
+        // TODO: this is accepted currently. should we include a check to ensure
+        // only endpoints can be registered? (this would be a convenience check, not a security one)
+        endpointManager.setEndpoint(address(0x123));
+    }
+
+    // == threshold
+
+    function test_cantSetThresholdTooHigh() public {
+        // no endpoints set, so can't set threshold to 1
+        vm.expectRevert("threshold <= enabledEndpoints.length");
+        endpointManager.setThreshold(1);
+    }
+
+    function test_canSetThreshold() public {
+        DummyEndpoint e1 = new DummyEndpoint(address(endpointManager));
+        DummyEndpoint e2 = new DummyEndpoint(address(endpointManager));
+        endpointManager.setEndpoint(address(e1));
+        endpointManager.setEndpoint(address(e2));
+
+        endpointManager.setThreshold(1);
+        endpointManager.setThreshold(2);
+        endpointManager.setThreshold(0);
+        endpointManager.setThreshold(1);
+    }
+
+    function test_onlyOwnerCanSetThreshold() public {
+        address notOwner = address(0x123);
+        vm.startPrank(notOwner);
+
+        bytes4 selector = bytes4(keccak256("OwnableUnauthorizedAccount(address)"));
+        vm.expectRevert(abi.encodeWithSelector(selector, notOwner));
+        endpointManager.setThreshold(1);
+    }
+
+    // === attestation
+
+    function setup_endpoints() internal returns (DummyEndpoint, DummyEndpoint) {
+        DummyEndpoint e1 = new DummyEndpoint(address(endpointManager));
+        DummyEndpoint e2 = new DummyEndpoint(address(endpointManager));
+        endpointManager.setEndpoint(address(e1));
+        endpointManager.setEndpoint(address(e2));
+        return (e1, e2);
+    }
+
+    function test_onlyEnabledEndpointsCanAttest() public {
+        (DummyEndpoint e1,) = setup_endpoints();
+        endpointManager.removeEndpoint(address(e1));
+
+        bytes4 selector = bytes4(keccak256("CallerNotEndpoint(address)"));
+        vm.expectRevert(abi.encodeWithSelector(selector, address(e1)));
+        e1.receiveMessage("hello");
+    }
+
+    function test_attest() public {
+        (DummyEndpoint e1,) = setup_endpoints();
+        endpointManager.setThreshold(2);
+
+        EndpointManagerMessage memory m = EndpointManagerMessage(
+            0, 0, 1, abi.encode(EndpointMessage("hello", "world", "payload"))
+        );
+
+        bytes memory message = endpointManager.encodeEndpointManagerMessage(m);
+
+        e1.receiveMessage(message);
+
+        bytes32 hash = endpointManager.computeManagerMessageHash(message);
+        assertEq(endpointManager.messageAttestations(hash), 1);
+    }
+
+    function test_attestTwice() public {
+        (DummyEndpoint e1,) = setup_endpoints();
+        endpointManager.setThreshold(2);
+
+        EndpointManagerMessage memory m = EndpointManagerMessage(
+            0, 0, 1, abi.encode(EndpointMessage("hello", "world", "payload"))
+        );
+
+        bytes memory message = endpointManager.encodeEndpointManagerMessage(m);
+
+        e1.receiveMessage(message);
+        e1.receiveMessage(message);
+
+        bytes32 hash = endpointManager.computeManagerMessageHash(message);
+        // can't double vote
+        assertEq(endpointManager.messageAttestations(hash), 1);
+    }
+
+    function test_attestDisabled() public {
+        (DummyEndpoint e1,) = setup_endpoints();
+        endpointManager.setThreshold(2);
+
+        EndpointManagerMessage memory m = EndpointManagerMessage(
+            0, 0, 1, abi.encode(EndpointMessage("hello", "world", "payload"))
+        );
+
+        bytes memory message = endpointManager.encodeEndpointManagerMessage(m);
+
+        e1.receiveMessage(message);
+        endpointManager.setThreshold(1);
+        endpointManager.removeEndpoint(address(e1));
+
+        bytes32 hash = endpointManager.computeManagerMessageHash(message);
+        // a disabled endpoint's vote no longer counts
+        assertEq(endpointManager.messageAttestations(hash), 0);
+
+        endpointManager.setEndpoint(address(e1));
+        // it counts again when reenabled
+        assertEq(endpointManager.messageAttestations(hash), 1);
+    }
+
+    // TODO: add tests cases for actually handling the quorum case.
+    // doing that requires setting up the token etc.
+    // currently there is no way to test the threshold logic and the duplicate
+    // protection logic without setting up the business logic as well.
+    //
+    // we should separate the business logic out from the endpoint handling.
+    // that way the functionality could be tested separately (and the contracts
+    // would also be more reusable)
+
+    // === message encoding/decoding
+
+    // TODO: add some negative for unknown message types etc
+
+    function testSerdeRoundtrip(EndpointManagerMessage memory m) public {
+        bytes memory message = endpointManager.encodeEndpointManagerMessage(m);
+
+        EndpointManagerMessage memory parsed = endpointManager.parseEndpointManagerMessage(message);
+
+        assertEq(m.chainId, parsed.chainId);
+        assertEq(m.sequence, parsed.sequence);
+        assertEq(m.msgType, parsed.msgType);
+        assertEq(m.payload, parsed.payload);
+    }
+
+    function test_SerdeJunk(EndpointManagerMessage memory m) public view {
+        bytes memory message = endpointManager.encodeEndpointManagerMessage(m);
+
+        bytes memory junk = "junk";
+
+        // TODO: this should revert. we should add a length prefix to the payload
+        endpointManager.parseEndpointManagerMessage(abi.encodePacked(message, junk));
     }
 }

--- a/test/EndpointManager.t.sol
+++ b/test/EndpointManager.t.sol
@@ -10,9 +10,8 @@ contract EndpointManagerContract is EndpointManagerStandalone {
     constructor(
         address token,
         bool isLockingMode,
-        uint16 chainId,
-        uint256 evmChainId
-    ) EndpointManagerStandalone(token, isLockingMode, chainId, evmChainId) {}
+        uint16 chainId
+    ) EndpointManagerStandalone(token, isLockingMode, chainId) {}
 }
 
 contract TestEndpointManager is Test {
@@ -27,7 +26,8 @@ contract TestEndpointManager is Test {
     }
 
     function setUp() public {
-        endpointManager = new EndpointManagerContract(address(0), false, 0, 0);
+        endpointManager = new EndpointManagerContract(address(0), false, 0);
+        endpointManager.initialize();
         // deploy sample token contract
         // deploy wormhole contract
         // wormhole = deployWormholeForTest();

--- a/test/EndpointManager.t.sol
+++ b/test/EndpointManager.t.sol
@@ -153,7 +153,8 @@ contract TestEndpointManager is Test {
 
     function test_cantSetThresholdTooHigh() public {
         // no endpoints set, so can't set threshold to 1
-        vm.expectRevert("threshold <= enabledEndpoints.length");
+        bytes4 selector = bytes4(keccak256("ThresholdTooHigh(uint256,uint256)"));
+        vm.expectRevert(abi.encodeWithSelector(selector, 1, 0));
         endpointManager.setThreshold(1);
     }
 
@@ -165,8 +166,16 @@ contract TestEndpointManager is Test {
 
         endpointManager.setThreshold(1);
         endpointManager.setThreshold(2);
-        endpointManager.setThreshold(0);
         endpointManager.setThreshold(1);
+    }
+
+    function test_cantSetThresholdToZero() public {
+        DummyEndpoint e = new DummyEndpoint(address(endpointManager));
+        endpointManager.setEndpoint(address(e));
+
+        bytes4 selector = bytes4(keccak256("ZeroThreshold()"));
+        vm.expectRevert(abi.encodeWithSelector(selector));
+        endpointManager.setThreshold(0);
     }
 
     function test_onlyOwnerCanSetThreshold() public {

--- a/test/EndpointManager.t.sol
+++ b/test/EndpointManager.t.sol
@@ -10,9 +10,9 @@ import "../src/EndpointStandalone.sol";
 contract EndpointManagerContract is EndpointManagerStandalone {
     constructor(
         address token,
-        bool isLockingMode,
+        Mode mode,
         uint16 chainId
-    ) EndpointManagerStandalone(token, isLockingMode, chainId) {}
+    ) EndpointManagerStandalone(token, mode, chainId) {}
 }
 
 contract DummyEndpoint is EndpointStandalone {
@@ -47,7 +47,7 @@ contract TestEndpointManager is Test {
     EndpointManagerStandalone endpointManager;
 
     function setUp() public {
-        endpointManager = new EndpointManagerContract(address(0), false, 0);
+        endpointManager = new EndpointManagerContract(address(0), EndpointManager.Mode.BURNING, 0);
         endpointManager.initialize();
         // deploy sample token contract
         // deploy wormhole contract

--- a/test/EndpointManager.t.sol
+++ b/test/EndpointManager.t.sol
@@ -274,9 +274,9 @@ contract TestEndpointManager is Test {
 
     // === message encoding/decoding
 
-    // TODO: add some negative for unknown message types etc
+    // TODO: add some negative tests for unknown message types etc
 
-    function testSerdeRoundtrip(EndpointManagerMessage memory m) public {
+    function test_SerdeRoundtrip_EndpointManagerMessage(EndpointManagerMessage memory m) public {
         bytes memory message = endpointManager.encodeEndpointManagerMessage(m);
 
         EndpointManagerMessage memory parsed = endpointManager.parseEndpointManagerMessage(message);
@@ -287,12 +287,35 @@ contract TestEndpointManager is Test {
         assertEq(m.payload, parsed.payload);
     }
 
-    function test_SerdeJunk(EndpointManagerMessage memory m) public view {
+    function test_SerdeJunk_EndpointManagerMessage(EndpointManagerMessage memory m) public view {
         bytes memory message = endpointManager.encodeEndpointManagerMessage(m);
 
         bytes memory junk = "junk";
 
         // TODO: this should revert. we should add a length prefix to the payload
         endpointManager.parseEndpointManagerMessage(abi.encodePacked(message, junk));
+    }
+
+    function test_SerdeRoundtrip_NativeTokenTransfer(NativeTokenTransfer memory m) public {
+        bytes memory message = endpointManager.encodeNativeTokenTransfer(m);
+
+        NativeTokenTransfer memory parsed = endpointManager.parseNativeTokenTransfer(message);
+
+        assertEq(m.amount, parsed.amount);
+        assertEq(m.tokenAddress, parsed.tokenAddress);
+        assertEq(m.to, parsed.to);
+        assertEq(m.toChain, parsed.toChain);
+    }
+
+    function test_SerdeJunk_NativeTokenTransfer(NativeTokenTransfer memory m) public {
+        bytes memory message = endpointManager.encodeNativeTokenTransfer(m);
+
+        bytes memory junk = "junk";
+
+        bytes4 selector = bytes4(keccak256("LengthMismatch(uint256,uint256)"));
+        vm.expectRevert(
+            abi.encodeWithSelector(selector, message.length + junk.length, message.length)
+        );
+        endpointManager.parseNativeTokenTransfer(abi.encodePacked(message, junk));
     }
 }


### PR DESCRIPTION
Added tests for the `EndpointManager` against a dummy endpoint that just blindly forwards messages. 

We should factor out some of the tests so they can run against the standalone endpoint&manager contract too. Specifically, the endpoint&manager currently implements no replay protection and assumes that the endpoint does it, which I think is not right. For now I've left a TODO about it.

The tests also don't cover the case where quorum is reached and the message needs to be handled, because doing so would require setting up a token and other stuff for the business logic. I also left a TODO about this in the tests file (specifically that we should separate the business logic from the endpoint manager so the two can be tested separately & the contracts are more reusable that way too).

NOTE: I made a couple of other small changes too, the commits are best reviewed separately (they are atomic)