### PR TITLE
Improve standalone arch

### DIFF
--- a/src/Endpoint.sol
+++ b/src/Endpoint.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.6.12 <0.9.0;
 
 import "./interfaces/IEndpoint.sol";
+import "./libraries/EndpointStructs.sol";
 
 abstract contract Endpoint is IEndpoint {
     // Mapping of siblings on other chains
@@ -13,12 +14,16 @@ abstract contract Endpoint is IEndpoint {
     ///         This function should verify the encodedVm and then call attestationReceived on the endpoint manager contract.
     function receiveMessage(bytes memory encodedMessage) external {
         bytes memory payload = _verifyMessage(encodedMessage);
-        _deliverToManager(payload);
+        EndpointStructs.EndpointManagerMessage memory parsed =
+            EndpointStructs.parseEndpointManagerMessage(payload);
+        _deliverToManager(parsed);
     }
 
     function _verifyMessage(bytes memory encodedMessage) internal virtual returns (bytes memory);
 
-    function _deliverToManager(bytes memory payload) internal virtual;
+    function _deliverToManager(EndpointStructs.EndpointManagerMessage memory payload)
+        internal
+        virtual;
 
     function _quoteDeliveryPrice(uint16 targetChain) internal view virtual returns (uint256);
 

--- a/src/EndpointAndManager.sol
+++ b/src/EndpointAndManager.sol
@@ -19,7 +19,6 @@ abstract contract EndpointAndManager is Endpoint, EndpointManager {
         internal
         override
     {
-        // TODO: this relies on the Endpoint implementation to replay protect messages.
         return _executeMsg(payload);
     }
 

--- a/src/EndpointAndManager.sol
+++ b/src/EndpointAndManager.sol
@@ -15,7 +15,10 @@ abstract contract EndpointAndManager is Endpoint, EndpointManager {
         return _sendMessage(recipientChain, payload);
     }
 
-    function _deliverToManager(bytes memory payload) internal override {
+    function _deliverToManager(EndpointStructs.EndpointManagerMessage memory payload)
+        internal
+        override
+    {
         // TODO: this relies on the Endpoint implementation to replay protect messages.
         return _executeMsg(payload);
     }

--- a/src/EndpointManager.sol
+++ b/src/EndpointManager.sol
@@ -151,13 +151,9 @@ abstract contract EndpointManager is IEndpointManager, OwnableUpgradeable, Reent
 
     /// @dev Called after a message has been sufficiently verified to execute the command in the message.
     ///      This function will decode the payload as an EndpointManagerMessage to extract the sequence, msgType, and other parameters.
-    function _executeMsg(bytes memory payload) internal {
+    function _executeMsg(EndpointStructs.EndpointManagerMessage memory message) internal {
         // verify chain has not forked
         checkFork(_evmChainId);
-
-        // parse the payload as an EndpointManagerMessage
-        EndpointStructs.EndpointManagerMessage memory message =
-            EndpointStructs.parseEndpointManagerMessage(payload);
 
         // for msgType == 1, parse the payload as a NativeTokenTransfer.
         // for other msgTypes, revert (unsupported for now)

--- a/src/EndpointManagerStandalone.sol
+++ b/src/EndpointManagerStandalone.sol
@@ -95,8 +95,11 @@ contract EndpointManagerStandalone is IEndpointManagerStandalone, EndpointManage
     /// @dev Called by an Endpoint contract to deliver a verified attestation.
     ///      This function enforces attestation threshold and replay logic for messages.
     ///      Once all validations are complete, this function calls _executeMsg to execute the command specified by the message.
-    function attestationReceived(bytes memory payload) external onlyEndpoint {
-        bytes32 managerMessageHash = computeManagerMessageHash(payload);
+    function attestationReceived(EndpointStructs.EndpointManagerMessage memory payload)
+        external
+        onlyEndpoint
+    {
+        bytes32 managerMessageHash = EndpointStructs.endpointManagerMessageDigest(payload);
 
         // set the attested flag for this endpoint.
         // TODO: this allows an endpoint to attest to a message multiple times.

--- a/src/EndpointManagerStandalone.sol
+++ b/src/EndpointManagerStandalone.sol
@@ -41,17 +41,6 @@ contract EndpointManagerStandalone is IEndpointManagerStandalone, EndpointManage
 
     // =========================================================================
 
-    // @dev Information about attestations for a given message.
-    struct AttestationInfo {
-        // bitmap of endpoints that have attested to this message (NOTE: might contain disabled endpoints)
-        uint64 attestedEndpoints;
-        // whether this message has been executed
-        bool executed;
-    }
-
-    // Maps are keyed by hash of EndpointManagerMessage.
-    mapping(bytes32 => AttestationInfo) public managerMessageAttestations;
-
     modifier onlyEndpoint() {
         if (!endpointInfos[msg.sender].enabled) {
             revert CallerNotEndpoint(msg.sender);
@@ -117,21 +106,7 @@ contract EndpointManagerStandalone is IEndpointManagerStandalone, EndpointManage
             return;
         }
 
-        _markMessageExecuted(managerMessageHash);
-
         return _executeMsg(payload);
-    }
-
-    // @dev Mark a message as executed.
-    // This function will revert if the message has already been executed.
-    function _markMessageExecuted(bytes32 digest) internal {
-        // check if this message has already been executed
-        if (managerMessageAttestations[digest].executed) {
-            revert MessageAlreadyExecuted(digest);
-        }
-
-        // mark this message as executed
-        managerMessageAttestations[digest].executed = true;
     }
 
     /// @notice Returns the number of Endpoints that must attest to a msgId for it to be considered valid and acted upon.

--- a/src/EndpointStandalone.sol
+++ b/src/EndpointStandalone.sol
@@ -33,7 +33,10 @@ abstract contract EndpointStandalone is IEndpointStandalone, Endpoint {
         return _quoteDeliveryPrice(targetChain);
     }
 
-    function _deliverToManager(bytes memory payload) internal override {
+    function _deliverToManager(EndpointStructs.EndpointManagerMessage memory payload)
+        internal
+        override
+    {
         // forward the VAA payload to the endpoint manager contract
         IEndpointManagerStandalone(_manager).attestationReceived(payload);
     }

--- a/src/interfaces/IEndpointManagerStandalone.sol
+++ b/src/interfaces/IEndpointManagerStandalone.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache 2
 pragma solidity >=0.6.12 <0.9.0;
 
+import "../libraries/EndpointStructs.sol";
+
 interface IEndpointManagerStandalone {
     error NotImplemented();
 
-    function attestationReceived(bytes memory payload) external;
+    function attestationReceived(EndpointStructs.EndpointManagerMessage memory payload) external;
 
     function getThreshold() external view returns (uint8);
 

--- a/src/libraries/EndpointStructs.sol
+++ b/src/libraries/EndpointStructs.sol
@@ -1,44 +1,123 @@
 // SPDX-License-Identifier: Apache 2
 pragma solidity >=0.6.12 <0.9.0;
 
-/// @dev The wire format is as follows:
-///     - chainId - 2 bytes
-///     - sequence - 8 bytes
-///     - msgType - 1 byte
-///     - payloadLength - 2 bytes
-///     - payload - `payloadLength` bytes
-struct EndpointManagerMessage {
-    /// @notice chainId that message originates from
-    uint16 chainId;
-    /// @notice unique sequence number
-    uint64 sequence;
-    /// @notice type of the message, which determines how the payload should be decoded.
-    uint8 msgType;
-    /// @notice payload that corresponds to the type.
-    bytes payload;
-}
+import "wormhole-solidity-sdk/libraries/BytesParsing.sol";
 
-/// Token Transfer payload corresponding to type == 1
-/// @dev The wire format is as follows:
-///    - amount - 32 bytes
-///    - toLength - 2 bytes
-///    - to - `toLength` bytes
-///    - toChain - 2 bytes
-struct NativeTokenTransfer {
-    /// @notice Amount being transferred (big-endian uint256)
-    uint256 amount;
-    /// @notice Address of the recipient.
-    bytes to;
-    /// @notice Chain ID of the recipient
-    uint16 toChain;
-}
+library EndpointStructs {
+    using BytesParsing for bytes;
 
-struct EndpointMessage {
-    /// @notice Magic string (constant value set by messaging provider) that idenfies the payload as an endpoint-emitted payload.
-    ///         Note that this is not a security critical field. It's meant to be used by messaging providers to identify which messages are Endpoint-related.
-    bytes32 endpointId;
-    /// @notice Payload provided to the Endpoint contract by the EndpointManager contract.
-    bytes managerPayload;
-    /// @notice Custom payload which messaging providers can use to pass bridge-specific information, if needed.
-    bytes endpointPayload;
+    error PayloadTooLong(uint256 size);
+
+    /// @dev The wire format is as follows:
+    ///     - chainId - 2 bytes
+    ///     - sequence - 8 bytes
+    ///     - msgType - 1 byte
+    ///     - payloadLength - 2 bytes
+    ///     - payload - `payloadLength` bytes
+    struct EndpointManagerMessage {
+        /// @notice chainId that message originates from
+        uint16 chainId;
+        /// @notice unique sequence number
+        uint64 sequence;
+        /// @notice type of the message, which determines how the payload should be decoded.
+        uint8 msgType;
+        /// @notice payload that corresponds to the type.
+        bytes payload;
+    }
+
+    function endpointManagerMessageDigest(EndpointManagerMessage memory m)
+        public
+        pure
+        returns (bytes32)
+    {
+        return keccak256(encodeEndpointManagerMessage(m));
+    }
+
+    function encodeEndpointManagerMessage(EndpointManagerMessage memory m)
+        public
+        pure
+        returns (bytes memory encoded)
+    {
+        if (m.payload.length > type(uint16).max) {
+            revert PayloadTooLong(m.payload.length);
+        }
+        uint16 payloadLength = uint16(m.payload.length);
+        return abi.encodePacked(m.chainId, m.sequence, m.msgType, payloadLength, m.payload);
+    }
+
+    /*
+     * @dev Parse a EndpointManagerMessage.
+     *
+     * @params encoded The byte array corresponding to the encoded message
+     */
+    function parseEndpointManagerMessage(bytes memory encoded)
+        public
+        pure
+        returns (EndpointManagerMessage memory managerMessage)
+    {
+        uint256 offset = 0;
+        (managerMessage.chainId, offset) = encoded.asUint16Unchecked(offset);
+        (managerMessage.sequence, offset) = encoded.asUint64Unchecked(offset);
+        (managerMessage.msgType, offset) = encoded.asUint8Unchecked(offset);
+        uint256 payloadLength;
+        (payloadLength, offset) = encoded.asUint16Unchecked(offset);
+        (managerMessage.payload, offset) = encoded.sliceUnchecked(offset, payloadLength);
+        encoded.checkLength(offset);
+    }
+
+    /// Token Transfer payload corresponding to type == 1
+    /// @dev The wire format is as follows:
+    ///    - amount - 32 bytes
+    ///    - toLength - 2 bytes
+    ///    - to - `toLength` bytes
+    ///    - toChain - 2 bytes
+    struct NativeTokenTransfer {
+        /// @notice Amount being transferred (big-endian uint256)
+        uint256 amount;
+        /// @notice Address of the recipient.
+        bytes to;
+        /// @notice Chain ID of the recipient
+        uint16 toChain;
+    }
+
+    function encodeNativeTokenTransfer(NativeTokenTransfer memory m)
+        public
+        pure
+        returns (bytes memory encoded)
+    {
+        if (m.to.length > type(uint16).max) {
+            revert PayloadTooLong(m.to.length);
+        }
+        uint16 toLength = uint16(m.to.length);
+        return abi.encodePacked(m.amount, toLength, m.to, m.toChain);
+    }
+
+    /*
+     * @dev Parse a NativeTokenTransfer.
+     *
+     * @params encoded The byte array corresponding to the encoded message
+     */
+    function parseNativeTokenTransfer(bytes memory encoded)
+        public
+        pure
+        returns (NativeTokenTransfer memory nativeTokenTransfer)
+    {
+        uint256 offset = 0;
+        (nativeTokenTransfer.amount, offset) = encoded.asUint256Unchecked(offset);
+        uint16 toLength;
+        (toLength, offset) = encoded.asUint16Unchecked(offset);
+        (nativeTokenTransfer.to, offset) = encoded.sliceUnchecked(offset, toLength);
+        (nativeTokenTransfer.toChain, offset) = encoded.asUint16Unchecked(offset);
+        encoded.checkLength(offset);
+    }
+
+    struct EndpointMessage {
+        /// @notice Magic string (constant value set by messaging provider) that idenfies the payload as an endpoint-emitted payload.
+        ///         Note that this is not a security critical field. It's meant to be used by messaging providers to identify which messages are Endpoint-related.
+        bytes32 endpointId;
+        /// @notice Payload provided to the Endpoint contract by the EndpointManager contract.
+        bytes managerPayload;
+        /// @notice Custom payload which messaging providers can use to pass bridge-specific information, if needed.
+        bytes endpointPayload;
+    }
 }

--- a/test/EndpointManager.t.sol
+++ b/test/EndpointManager.t.sol
@@ -327,6 +327,13 @@ contract TestEndpointManager is Test {
         e2.receiveMessage(message);
 
         assertEq(token.balanceOf(address(user_B)), 50 * 10 ** (decimals - 8));
+
+        // replay protection
+        bytes4 selector = bytes4(keccak256("MessageAlreadyExecuted(bytes32)"));
+        vm.expectRevert(
+            abi.encodeWithSelector(selector, endpointManager.computeManagerMessageHash(message))
+        );
+        e2.receiveMessage(message);
     }
 
     // TODO:

--- a/test/EndpointManager.t.sol
+++ b/test/EndpointManager.t.sol
@@ -225,11 +225,11 @@ contract TestEndpointManager is Test {
         (DummyEndpoint e1,) = setup_endpoints();
         endpointManager.setThreshold(2);
 
-        EndpointManagerMessage memory m = EndpointManagerMessage(
-            0, 0, 1, abi.encode(EndpointMessage("hello", "world", "payload"))
+        EndpointStructs.EndpointManagerMessage memory m = EndpointStructs.EndpointManagerMessage(
+            0, 0, 1, abi.encode(EndpointStructs.EndpointMessage("hello", "world", "payload"))
         );
 
-        bytes memory message = endpointManager.encodeEndpointManagerMessage(m);
+        bytes memory message = EndpointStructs.encodeEndpointManagerMessage(m);
 
         e1.receiveMessage(message);
 
@@ -241,11 +241,11 @@ contract TestEndpointManager is Test {
         (DummyEndpoint e1,) = setup_endpoints();
         endpointManager.setThreshold(2);
 
-        EndpointManagerMessage memory m = EndpointManagerMessage(
-            0, 0, 1, abi.encode(EndpointMessage("hello", "world", "payload"))
+        EndpointStructs.EndpointManagerMessage memory m = EndpointStructs.EndpointManagerMessage(
+            0, 0, 1, abi.encode(EndpointStructs.EndpointMessage("hello", "world", "payload"))
         );
 
-        bytes memory message = endpointManager.encodeEndpointManagerMessage(m);
+        bytes memory message = EndpointStructs.encodeEndpointManagerMessage(m);
 
         e1.receiveMessage(message);
         e1.receiveMessage(message);
@@ -259,11 +259,11 @@ contract TestEndpointManager is Test {
         (DummyEndpoint e1,) = setup_endpoints();
         endpointManager.setThreshold(2);
 
-        EndpointManagerMessage memory m = EndpointManagerMessage(
-            0, 0, 1, abi.encode(EndpointMessage("hello", "world", "payload"))
+        EndpointStructs.EndpointManagerMessage memory m = EndpointStructs.EndpointManagerMessage(
+            0, 0, 1, abi.encode(EndpointStructs.EndpointMessage("hello", "world", "payload"))
         );
 
-        bytes memory message = endpointManager.encodeEndpointManagerMessage(m);
+        bytes memory message = EndpointStructs.encodeEndpointManagerMessage(m);
 
         e1.receiveMessage(message);
         endpointManager.setThreshold(1);
@@ -299,16 +299,20 @@ contract TestEndpointManager is Test {
         assertEq(token.balanceOf(address(user_A)), 2 * 10 ** decimals);
         assertEq(token.balanceOf(address(endpointManager)), 3 * 10 ** decimals);
 
-        EndpointManagerMessage memory m = EndpointManagerMessage(
+        EndpointStructs.EndpointManagerMessage memory m = EndpointStructs.EndpointManagerMessage(
             0,
             0,
             1,
-            endpointManager.encodeNativeTokenTransfer(
-                NativeTokenTransfer({amount: 50, to: abi.encodePacked(user_B), toChain: chainId})
+            EndpointStructs.encodeNativeTokenTransfer(
+                EndpointStructs.NativeTokenTransfer({
+                    amount: 50,
+                    to: abi.encodePacked(user_B),
+                    toChain: chainId
+                })
             )
         );
 
-        bytes memory message = endpointManager.encodeEndpointManagerMessage(m);
+        bytes memory message = EndpointStructs.encodeEndpointManagerMessage(m);
 
         e1.receiveMessage(message);
 
@@ -332,10 +336,13 @@ contract TestEndpointManager is Test {
 
     // TODO: add some negative tests for unknown message types etc
 
-    function test_SerdeRoundtrip_EndpointManagerMessage(EndpointManagerMessage memory m) public {
-        bytes memory message = endpointManager.encodeEndpointManagerMessage(m);
+    function test_SerdeRoundtrip_EndpointManagerMessage(
+        EndpointStructs.EndpointManagerMessage memory m
+    ) public {
+        bytes memory message = EndpointStructs.encodeEndpointManagerMessage(m);
 
-        EndpointManagerMessage memory parsed = endpointManager.parseEndpointManagerMessage(message);
+        EndpointStructs.EndpointManagerMessage memory parsed =
+            EndpointStructs.parseEndpointManagerMessage(message);
 
         assertEq(m.chainId, parsed.chainId);
         assertEq(m.sequence, parsed.sequence);
@@ -343,8 +350,10 @@ contract TestEndpointManager is Test {
         assertEq(m.payload, parsed.payload);
     }
 
-    function test_SerdeJunk_EndpointManagerMessage(EndpointManagerMessage memory m) public {
-        bytes memory message = endpointManager.encodeEndpointManagerMessage(m);
+    function test_SerdeJunk_EndpointManagerMessage(EndpointStructs.EndpointManagerMessage memory m)
+        public
+    {
+        bytes memory message = EndpointStructs.encodeEndpointManagerMessage(m);
 
         bytes memory junk = "junk";
 
@@ -352,21 +361,26 @@ contract TestEndpointManager is Test {
         vm.expectRevert(
             abi.encodeWithSelector(selector, message.length + junk.length, message.length)
         );
-        endpointManager.parseEndpointManagerMessage(abi.encodePacked(message, junk));
+        EndpointStructs.parseEndpointManagerMessage(abi.encodePacked(message, junk));
     }
 
-    function test_SerdeRoundtrip_NativeTokenTransfer(NativeTokenTransfer memory m) public {
-        bytes memory message = endpointManager.encodeNativeTokenTransfer(m);
+    function test_SerdeRoundtrip_NativeTokenTransfer(EndpointStructs.NativeTokenTransfer memory m)
+        public
+    {
+        bytes memory message = EndpointStructs.encodeNativeTokenTransfer(m);
 
-        NativeTokenTransfer memory parsed = endpointManager.parseNativeTokenTransfer(message);
+        EndpointStructs.NativeTokenTransfer memory parsed =
+            EndpointStructs.parseNativeTokenTransfer(message);
 
         assertEq(m.amount, parsed.amount);
         assertEq(m.to, parsed.to);
         assertEq(m.toChain, parsed.toChain);
     }
 
-    function test_SerdeJunk_NativeTokenTransfer(NativeTokenTransfer memory m) public {
-        bytes memory message = endpointManager.encodeNativeTokenTransfer(m);
+    function test_SerdeJunk_NativeTokenTransfer(EndpointStructs.NativeTokenTransfer memory m)
+        public
+    {
+        bytes memory message = EndpointStructs.encodeNativeTokenTransfer(m);
 
         bytes memory junk = "junk";
 
@@ -374,7 +388,7 @@ contract TestEndpointManager is Test {
         vm.expectRevert(
             abi.encodeWithSelector(selector, message.length + junk.length, message.length)
         );
-        endpointManager.parseNativeTokenTransfer(abi.encodePacked(message, junk));
+        EndpointStructs.parseNativeTokenTransfer(abi.encodePacked(message, junk));
     }
 
     function test_bytesToAddress_roundtrip(address a) public {

--- a/test/EndpointManager.t.sol
+++ b/test/EndpointManager.t.sol
@@ -216,9 +216,14 @@ contract TestEndpointManager is Test {
         (DummyEndpoint e1,) = setup_endpoints();
         endpointManager.removeEndpoint(address(e1));
 
+        EndpointStructs.EndpointManagerMessage memory m = EndpointStructs.EndpointManagerMessage(
+            0, 0, 1, abi.encode(EndpointStructs.EndpointMessage("hello", "world", "payload"))
+        );
+        bytes memory message = EndpointStructs.encodeEndpointManagerMessage(m);
+
         bytes4 selector = bytes4(keccak256("CallerNotEndpoint(address)"));
         vm.expectRevert(abi.encodeWithSelector(selector, address(e1)));
-        e1.receiveMessage("hello");
+        e1.receiveMessage(message);
     }
 
     function test_attest() public {


### PR DESCRIPTION
This makes `_executeMsg` perform replay protection, so that the different configurations of endpoints and manager don't have to independently reimplement this logic.

Also moved the struct util functions into a library, so the commits are best view separately