### PR TITLE
swap `sender` and `msgType` in `ManagerMessage`

### DIFF
--- a/src/Manager.sol
+++ b/src/Manager.sol
@@ -511,7 +511,7 @@ abstract contract Manager is
         bytes memory senderBytes = abi.encodePacked(msg.sender);
         bytes memory encodedManagerPayload = EndpointStructs.encodeManagerMessage(
             EndpointStructs.ManagerMessage(
-                _chainId, sequence, 1, sourceManagerBytes, senderBytes, encodedTransferPayload
+                _chainId, sequence, sourceManagerBytes, senderBytes, 1, encodedTransferPayload
             )
         );
 

--- a/src/libraries/EndpointStructs.sol
+++ b/src/libraries/EndpointStructs.sol
@@ -11,11 +11,11 @@ library EndpointStructs {
     /// @dev The wire format is as follows:
     ///     - chainId - 2 bytes
     ///     - sequence - 8 bytes
-    ///     - msgType - 1 byte
     ///     - sourceManagerLength - 2 bytes
     ///     - sourceManager - `sourceManagerLength` bytes
     ///     - senderLength - 2 bytes
     ///     - sender - `senderLength` bytes
+    ///     - msgType - 1 byte
     ///     - payloadLength - 2 bytes
     ///     - payload - `payloadLength` bytes
     struct ManagerMessage {
@@ -23,12 +23,12 @@ library EndpointStructs {
         uint16 chainId;
         /// @notice unique sequence number
         uint64 sequence;
-        /// @notice type of the message, which determines how the payload should be decoded.
-        uint8 msgType;
         /// @notice manager contract address that this message originates from.
         bytes sourceManager;
         /// @notice original message sender address.
         bytes sender;
+        /// @notice type of the message, which determines how the payload should be decoded.
+        uint8 msgType;
         /// @notice payload that corresponds to the type.
         bytes payload;
     }
@@ -57,11 +57,11 @@ library EndpointStructs {
         return abi.encodePacked(
             m.chainId,
             m.sequence,
-            m.msgType,
             sourceManagerLength,
             m.sourceManager,
             senderLength,
             m.sender,
+            m.msgType,
             payloadLength,
             m.payload
         );
@@ -80,13 +80,13 @@ library EndpointStructs {
         uint256 offset = 0;
         (managerMessage.chainId, offset) = encoded.asUint16Unchecked(offset);
         (managerMessage.sequence, offset) = encoded.asUint64Unchecked(offset);
-        (managerMessage.msgType, offset) = encoded.asUint8Unchecked(offset);
         uint256 sourceManagerLength;
         (sourceManagerLength, offset) = encoded.asUint16Unchecked(offset);
         (managerMessage.sourceManager, offset) = encoded.sliceUnchecked(offset, sourceManagerLength);
         uint256 senderLength;
         (senderLength, offset) = encoded.asUint16Unchecked(offset);
         (managerMessage.sender, offset) = encoded.sliceUnchecked(offset, senderLength);
+        (managerMessage.msgType, offset) = encoded.asUint8Unchecked(offset);
         uint256 payloadLength;
         (payloadLength, offset) = encoded.asUint16Unchecked(offset);
         (managerMessage.payload, offset) = encoded.sliceUnchecked(offset, payloadLength);

--- a/test/Manager.t.sol
+++ b/test/Manager.t.sol
@@ -321,9 +321,9 @@ contract TestManager is Test, IManagerEvents {
         EndpointStructs.ManagerMessage memory m = EndpointStructs.ManagerMessage(
             SENDING_CHAIN_ID,
             sequence,
-            1,
             abi.encodePacked(address(manager)),
             abi.encodePacked(from),
+            1,
             EndpointStructs.encodeNativeTokenTransfer(
                 EndpointStructs.NativeTokenTransfer({
                     amount: 50,
@@ -350,9 +350,9 @@ contract TestManager is Test, IManagerEvents {
         EndpointStructs.ManagerMessage memory m = EndpointStructs.ManagerMessage(
             0,
             0,
-            1,
             abi.encodePacked(address(manager)),
             abi.encodePacked(address(0)),
+            1,
             abi.encode(EndpointStructs.EndpointMessage("hello", "world", "payload"))
         );
         bytes memory message = EndpointStructs.encodeManagerMessage(m);
@@ -368,9 +368,9 @@ contract TestManager is Test, IManagerEvents {
         EndpointStructs.ManagerMessage memory m = EndpointStructs.ManagerMessage(
             0,
             0,
-            1,
             abi.encodePacked(address(manager)),
             abi.encodePacked(address(0)),
+            1,
             abi.encode(EndpointStructs.EndpointMessage("hello", "world", "payload"))
         );
 
@@ -389,9 +389,9 @@ contract TestManager is Test, IManagerEvents {
         EndpointStructs.ManagerMessage memory m = EndpointStructs.ManagerMessage(
             0,
             0,
-            1,
             abi.encodePacked(address(manager)),
             abi.encodePacked(address(0)),
+            1,
             abi.encode(EndpointStructs.EndpointMessage("hello", "world", "payload"))
         );
 


### PR DESCRIPTION
It makes more sense for the discriminator to directly precede the payload