### PR TITLE
Fix Wormhole Standard Relaying Integration

### DIFF
--- a/src/Endpoint.sol
+++ b/src/Endpoint.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.6.12 <0.9.0;
 import "./libraries/EndpointStructs.sol";
 
 abstract contract Endpoint {
-    function _sendMessage(uint16 recipientChain, bytes memory payload) internal virtual;
+    function _sendMessage(uint16 recipientChain, bytes memory managerMessage) internal virtual;
 
     function _deliverToManager(EndpointStructs.ManagerMessage memory payload) internal virtual;
 

--- a/src/EndpointAndManager.sol
+++ b/src/EndpointAndManager.sol
@@ -44,9 +44,9 @@ abstract contract EndpointAndManager is Endpoint, Manager, Implementation {
 
     function _sendMessageToEndpoint(
         uint16 recipientChain,
-        bytes memory payload
+        bytes memory managerMessage
     ) internal override {
-        return _sendMessage(recipientChain, payload);
+        return _sendMessage(recipientChain, managerMessage);
     }
 
     function _deliverToManager(EndpointStructs.ManagerMessage memory payload) internal override {

--- a/src/EndpointStandalone.sol
+++ b/src/EndpointStandalone.sol
@@ -47,9 +47,9 @@ abstract contract EndpointStandalone is
     /// @notice Called by the BridgeManager contract to send a cross-chain message.
     function sendMessage(
         uint16 recipientChain,
-        bytes memory payload
+        bytes memory managerMessage
     ) external payable nonReentrant onlyManager {
-        _sendMessage(recipientChain, payload);
+        _sendMessage(recipientChain, managerMessage);
     }
 
     function quoteDeliveryPrice(uint16 targetChain) external view override returns (uint256) {

--- a/src/Manager.sol
+++ b/src/Manager.sol
@@ -161,7 +161,10 @@ abstract contract Manager is
     function quoteDeliveryPrice(uint16 recipientChain) public view virtual returns (uint256);
 
     /// @dev This will either cross-call or internal call, depending on whether the contract is standalone or not.
-    function _sendMessageToEndpoint(uint16 recipientChain, bytes memory payload) internal virtual;
+    function _sendMessageToEndpoint(
+        uint16 recipientChain,
+        bytes memory managerMessage
+    ) internal virtual;
 
     // TODO: do we want additional information (like chain etc)
     function isMessageApproved(bytes32 digest) public view virtual returns (bool);

--- a/src/WormholeEndpoint.sol
+++ b/src/WormholeEndpoint.sol
@@ -21,19 +21,6 @@ abstract contract WormholeEndpoint is Endpoint, IWormholeEndpoint, IWormholeRece
     ///         Note that this is not a security critical field. It's meant to be used by messaging providers to identify which messages are Endpoint-related.
     bytes4 constant WH_ENDPOINT_PAYLOAD_PREFIX = 0x9945FF10;
 
-    event ReceivedMessage(
-        bytes32 digest, uint16 emitterChainId, bytes32 emitterAddress, uint64 sequence
-    );
-
-    event SendEndpointMessage(uint16 recipientChain, EndpointStructs.EndpointMessage message);
-    event SetWormholeSibling(uint16 chainId, bytes32 oldSiblingContract, bytes32 siblingContract);
-
-    error InvalidVaa(string reason);
-    error InvalidWormholeSibling(uint16 chainId, bytes32 siblingAddress);
-    error TransferAlreadyCompleted(bytes32 vaaHash);
-    error InvalidWormholeSiblingZeroAddress();
-    error InvalidWormholeSiblingChainIdZero();
-
     IWormhole public immutable wormhole;
     IWormholeRelayer public immutable wormholeRelayer;
     uint256 public immutable wormholeEndpoint_evmChainId;

--- a/src/WormholeEndpoint.sol
+++ b/src/WormholeEndpoint.sol
@@ -98,7 +98,15 @@ abstract contract WormholeEndpoint is Endpoint, IWormholeEndpoint, IWormholeRece
         wormholeEndpoint_evmChainId = block.chainid;
     }
 
+    function checkInvalidRelayingConfig(uint16 chainId) public view {
+        bool invalidConfig = isWormholeRelayingEnabled(chainId) && !isWormholeEvmChain(chainId);
+        if (invalidConfig) {
+            revert InvalidRelayingConfig(chainId);
+        }
+    }
+
     function shouldRelayViaStandardRelaying(uint16 chainId) public view returns (bool) {
+        checkInvalidRelayingConfig(chainId);
         return isWormholeRelayingEnabled(chainId) && isWormholeEvmChain(chainId);
     }
 

--- a/src/WormholeEndpointAndManager.sol
+++ b/src/WormholeEndpointAndManager.sol
@@ -23,4 +23,12 @@ contract WormholeEndpointAndManager is EndpointAndManager, WormholeEndpoint {
     ) external onlyOwner {
         _setWormholeSibling(siblingChainId, siblingContract);
     }
+
+    function setIsWormholeRelayingEnabled(uint16 chainId, bool isEnabled) external onlyOwner {
+        _setIsWormholeRelayingEnabled(chainId, isEnabled);
+    }
+
+    function setIsWormholeEvmChain(uint16 chainId) external onlyOwner {
+        _setIsWormholeEvmChain(chainId);
+    }
 }

--- a/src/WormholeEndpointStandalone.sol
+++ b/src/WormholeEndpointStandalone.sol
@@ -13,4 +13,19 @@ contract WormholeEndpointStandalone is WormholeEndpoint, EndpointStandalone, Own
         address wormholeCoreBridge,
         address wormholeRelayerAddr
     ) EndpointStandalone(manager) WormholeEndpoint(wormholeCoreBridge, wormholeRelayerAddr) {}
+
+    function setWormholeSibling(
+        uint16 siblingChainId,
+        bytes32 siblingContract
+    ) external onlyOwner {
+        _setWormholeSibling(siblingChainId, siblingContract);
+    }
+
+    function setIsWormholeRelayingEnabled(uint16 chainId, bool isEnabled) external onlyOwner {
+        _setIsWormholeRelayingEnabled(chainId, isEnabled);
+    }
+
+    function setIsWormholeEvmChain(uint16 chainId) external onlyOwner {
+        _setIsWormholeEvmChain(chainId);
+    }
 }

--- a/src/interfaces/IEndpointStandalone.sol
+++ b/src/interfaces/IEndpointStandalone.sol
@@ -6,7 +6,7 @@ interface IEndpointStandalone {
 
     function quoteDeliveryPrice(uint16 recipientChain) external view returns (uint256);
 
-    function sendMessage(uint16 recipientChain, bytes memory payload) external payable;
+    function sendMessage(uint16 recipientChain, bytes memory managerMessage) external payable;
 
     function upgrade(address newImplementation) external;
 }

--- a/src/interfaces/IWormholeEndpoint.sol
+++ b/src/interfaces/IWormholeEndpoint.sol
@@ -11,9 +11,10 @@ interface IWormholeEndpoint {
 
     event SendEndpointMessage(uint16 recipientChain, EndpointStructs.EndpointMessage message);
     event SetWormholeSibling(uint16 chainId, bytes32 oldSiblingContract, bytes32 siblingContract);
+    event SetIsWormholeRelayingEnabled(uint16 chainId, bool isRelayingEnabled);
+    event SetIsWormholeEvmChain(uint16 chainId);
 
     error CallerNotRelayer(address caller);
-    error RelayingNotImplemented(uint16 recipientChain);
     error UnexpectedAdditionalMessages();
     error InvalidVaa(string reason);
     error InvalidWormholeSibling(uint16 chainId, bytes32 siblingAddress);

--- a/src/interfaces/IWormholeEndpoint.sol
+++ b/src/interfaces/IWormholeEndpoint.sol
@@ -14,6 +14,7 @@ interface IWormholeEndpoint {
     event SetIsWormholeRelayingEnabled(uint16 chainId, bool isRelayingEnabled);
     event SetIsWormholeEvmChain(uint16 chainId);
 
+    error InvalidRelayingConfig(uint16 chainId);
     error CallerNotRelayer(address caller);
     error UnexpectedAdditionalMessages();
     error InvalidVaa(string reason);

--- a/src/interfaces/IWormholeEndpoint.sol
+++ b/src/interfaces/IWormholeEndpoint.sol
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: Apache 2
 pragma solidity >=0.6.12 <0.9.0;
 
+import "../libraries/EndpointStructs.sol";
+
 interface IWormholeEndpoint {
     event ReceivedRelayedMessage(bytes32 digest, uint16 emitterChainId, bytes32 emitterAddress);
     event ReceivedMessage(
         bytes32 digest, uint16 emitterChainId, bytes32 emitterAddress, uint64 sequence
     );
+
+    event SendEndpointMessage(uint16 recipientChain, EndpointStructs.EndpointMessage message);
+    event SetWormholeSibling(uint16 chainId, bytes32 oldSiblingContract, bytes32 siblingContract);
 
     error CallerNotRelayer(address caller);
     error RelayingNotImplemented(uint16 recipientChain);

--- a/src/interfaces/IWormholeEndpoint.sol
+++ b/src/interfaces/IWormholeEndpoint.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity >=0.6.12 <0.9.0;
+
+interface IWormholeEndpoint {
+    event ReceivedRelayedMessage(bytes32 digest, uint16 emitterChainId, bytes32 emitterAddress);
+    event ReceivedMessage(
+        bytes32 digest, uint16 emitterChainId, bytes32 emitterAddress, uint64 sequence
+    );
+
+    error CallerNotRelayer(address caller);
+    error RelayingNotImplemented(uint16 recipientChain);
+    error UnexpectedAdditionalMessages();
+    error InvalidVaa(string reason);
+    error InvalidWormholeSibling(uint16 chainId, bytes32 siblingAddress);
+    error TransferAlreadyCompleted(bytes32 vaaHash);
+    error InvalidWormholeSiblingZeroAddress();
+    error InvalidWormholeChainIdZero();
+
+    function isVAAConsumed(bytes32 hash) external view returns (bool);
+    function getWormholeSibling(uint16 chainId) external view returns (bytes32);
+    function isWormholeRelayingEnabled(uint16 chainId) external view returns (bool);
+    function isWormholeEvmChain(uint16 chainId) external view returns (bool);
+}

--- a/src/libraries/EndpointStructs.sol
+++ b/src/libraries/EndpointStructs.sol
@@ -13,15 +13,16 @@ library EndpointStructs {
     ///      This is 0x99'N''T''T'
     bytes4 constant NTT_PREFIX = 0x994E5454;
 
-    /// @dev The wire format is as follows:
-    ///     - chainId - 2 bytes
-    ///     - sequence - 8 bytes
-    ///     - sourceManagerLength - 2 bytes
-    ///     - sourceManager - `sourceManagerLength` bytes
-    ///     - senderLength - 2 bytes
-    ///     - sender - `senderLength` bytes
-    ///     - payloadLength - 2 bytes
-    ///     - payload - `payloadLength` bytes
+    /// @dev Message emitted and received by the manager contract.
+    ///      The wire format is as follows:
+    ///      - chainId - 2 bytes
+    ///      - sequence - 8 bytes
+    ///      - sourceManagerLength - 2 bytes
+    ///      - sourceManager - `sourceManagerLength` bytes
+    ///      - senderLength - 2 bytes
+    ///      - sender - `senderLength` bytes
+    ///      - payloadLength - 2 bytes
+    ///      - payload - `payloadLength` bytes
     struct ManagerMessage {
         /// @notice chainId that message originates from
         uint16 chainId;
@@ -93,15 +94,15 @@ library EndpointStructs {
         encoded.checkLength(offset);
     }
 
-    /// Token Transfer payload corresponding to type == 1
-    /// @dev The wire format is as follows:
-    ///    - NTT_PREFIX - 4 bytes
-    ///    - amount - 32 bytes
-    ///    - sourceTokenLength - 2 bytes
-    ///    - sourceToken - `sourceTokenLength` bytes
-    ///    - toLength - 2 bytes
-    ///    - to - `toLength` bytes
-    ///    - toChain - 2 bytes
+    /// @dev Native Token Transfer payload.
+    ///      The wire format is as follows:
+    ///      - NTT_PREFIX - 4 bytes
+    ///      - amount - 32 bytes
+    ///      - sourceTokenLength - 2 bytes
+    ///      - sourceToken - `sourceTokenLength` bytes
+    ///      - toLength - 2 bytes
+    ///      - to - `toLength` bytes
+    ///      - toChain - 2 bytes
     struct NativeTokenTransfer {
         /// @notice Amount being transferred (big-endian uint256)
         uint256 amount;


### PR DESCRIPTION
Fix Wormhole standard relaying integration to properly receive messages and flexibly adapt to new evm chains.

This PR:
1. Uses Wormhole standard relaying when the target chain is EVM and supported by standard relaying.
2. Directly emits Wormhole messages via the core bridge when the conditions for (1) are not met.

A couple important things to note about the integration:
1. This change does not implement the case to handle a caller requesting for a transfer to not be emitted via Standard Relaying even if the target chain is EVM + relaying-supported. I'm playing around with local changes on how exactly to implement this, it requires some new structs and interface changes.
2. I've disallowed relayer deliveries with additionalMessages populated, since this contract never expects to receive a delivery from the relayer with additional messages to verify and deliver.