### PR TITLE
Outbound Queue -- use `ManagerMessage.sequence` instead of Outbound Queue Sequence

### DIFF
--- a/src/interfaces/IManager.sol
+++ b/src/interfaces/IManager.sol
@@ -81,7 +81,5 @@ interface IManager {
 
     function nextMessageSequence() external view returns (uint64);
 
-    function nextOutboundQueueSequence() external view returns (uint64);
-
     function token() external view returns (address);
 }


### PR DESCRIPTION
Use message sequence for outbound queue sequence and remove separate outbound sequence storage