### PR TITLE
Narrow compiler range to 0.8.x

### DIFF
--- a/src/Endpoint.sol
+++ b/src/Endpoint.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "./libraries/EndpointStructs.sol";
 

--- a/src/EndpointAndManager.sol
+++ b/src/EndpointAndManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "./Endpoint.sol";
 import "./Manager.sol";

--- a/src/EndpointRegistry.sol
+++ b/src/EndpointRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 /// @dev This contract is responsible for handling the registration of Endpoints.
 abstract contract EndpointRegistry {

--- a/src/EndpointStandalone.sol
+++ b/src/EndpointStandalone.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "./Endpoint.sol";
 import "./interfaces/IManagerStandalone.sol";

--- a/src/Manager.sol
+++ b/src/Manager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/src/ManagerStandalone.sol
+++ b/src/ManagerStandalone.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "./interfaces/IManagerStandalone.sol";
 import "./interfaces/IEndpointStandalone.sol";

--- a/src/WormholeEndpoint.sol
+++ b/src/WormholeEndpoint.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "wormhole-solidity-sdk/WormholeRelayerSDK.sol";
 

--- a/src/WormholeEndpointAndManager.sol
+++ b/src/WormholeEndpointAndManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "./EndpointAndManager.sol";
 import "./WormholeEndpoint.sol";

--- a/src/WormholeEndpointStandalone.sol
+++ b/src/WormholeEndpointStandalone.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "openzeppelin-contracts/contracts/access/Ownable.sol";
 

--- a/src/interfaces/IEndpointStandalone.sol
+++ b/src/interfaces/IEndpointStandalone.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 interface IEndpointStandalone {
     error CallerNotManager(address caller);

--- a/src/interfaces/IEndpointToken.sol
+++ b/src/interfaces/IEndpointToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 interface IEndpointToken {
     function mint(address account, uint256 amount) external;

--- a/src/interfaces/IManager.sol
+++ b/src/interfaces/IManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 interface IManager {
     error DeliveryPaymentTooLow(uint256 requiredPayment, uint256 providedPayment);

--- a/src/interfaces/IManagerEvents.sol
+++ b/src/interfaces/IManagerEvents.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 interface IManagerEvents {
     event InboundTransferQueued(bytes32 digest);

--- a/src/interfaces/IManagerStandalone.sol
+++ b/src/interfaces/IManagerStandalone.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "../libraries/EndpointStructs.sol";
 

--- a/src/interfaces/IWormholeEndpoint.sol
+++ b/src/interfaces/IWormholeEndpoint.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "../libraries/EndpointStructs.sol";
 

--- a/src/libraries/EndpointHelpers.sol
+++ b/src/libraries/EndpointHelpers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 error InvalidFork(uint256 evmChainId, uint256 blockChainId);
 

--- a/src/libraries/EndpointStructs.sol
+++ b/src/libraries/EndpointStructs.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "wormhole-solidity-sdk/libraries/BytesParsing.sol";
 

--- a/src/libraries/Implementation.sol
+++ b/src/libraries/Implementation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "./external/Initializable.sol";
 import "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Upgrade.sol";

--- a/src/wormhole/Governance.sol
+++ b/src/wormhole/Governance.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "wormhole-solidity-sdk/interfaces/IWormhole.sol";
 

--- a/test/Manager.t.sol
+++ b/test/Manager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "forge-std/Test.sol";
 

--- a/test/libraries/Implementation.t.sol
+++ b/test/libraries/Implementation.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "forge-std/Test.sol";

--- a/test/libraries/Utils.sol
+++ b/test/libraries/Utils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import {Test} from "forge-std/Test.sol";
 import {VmSafe} from "forge-std/Vm.sol";

--- a/test/wormhole/Governance.t.sol
+++ b/test/wormhole/Governance.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity >=0.6.12 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "../../src/wormhole/Governance.sol";
 import "forge-std/Test.sol";


### PR DESCRIPTION
Closes https://github.com/wormhole-foundation/example-native-token-transfers/issues/38