### PR TITLE
Add NttNormalizer abstract contract

### DIFF
--- a/src/NttNormalizer.sol
+++ b/src/NttNormalizer.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity >=0.8.8 <0.9.0;
+
+import "./libraries/NormalizedAmount.sol";
+
+abstract contract NttNormalizer {
+    using NormalizedAmountLib for uint256;
+    using NormalizedAmountLib for NormalizedAmount;
+
+    uint8 immutable tokenDecimals;
+
+    constructor(address _token) {
+        tokenDecimals = _tokenDecimals(_token);
+    }
+
+    function _tokenDecimals(address token) internal view returns (uint8) {
+        (, bytes memory queriedDecimals) = token.staticcall(abi.encodeWithSignature("decimals()"));
+        return abi.decode(queriedDecimals, (uint8));
+    }
+
+    function nttNormalize(uint256 amount) public view returns (NormalizedAmount memory) {
+        return amount.normalize(tokenDecimals);
+    }
+
+    function nttDenormalize(NormalizedAmount memory amount) public view returns (uint256) {
+        return amount.denormalize(tokenDecimals);
+    }
+
+    /// @dev Shift decimals of `amount` to match the token decimals
+    function nttFixDecimals(NormalizedAmount memory amount)
+        public
+        view
+        returns (NormalizedAmount memory)
+    {
+        return nttNormalize(nttDenormalize(amount));
+    }
+}

--- a/src/libraries/NormalizedAmount.sol
+++ b/src/libraries/NormalizedAmount.sol
@@ -132,7 +132,7 @@ library NormalizedAmountLib {
         return a.amount < b.amount ? a : b;
     }
 
-    /// @dev scale the amount from origDecimals to normDecimals (base 10)
+    /// @dev scale the amount from original decimals to target decimals (base 10)
     function scale(
         uint256 amount,
         uint8 fromDecimals,
@@ -140,8 +140,10 @@ library NormalizedAmountLib {
     ) internal pure returns (uint256) {
         if (fromDecimals > toDecimals) {
             return amount / (10 ** (fromDecimals - toDecimals));
-        } else {
+        } else if (fromDecimals < toDecimals) {
             return amount * (10 ** (toDecimals - fromDecimals));
+        } else {
+            return amount;
         }
     }
 

--- a/src/libraries/NormalizedAmount.sol
+++ b/src/libraries/NormalizedAmount.sol
@@ -138,12 +138,14 @@ library NormalizedAmountLib {
         uint8 fromDecimals,
         uint8 toDecimals
     ) internal pure returns (uint256) {
+        if (fromDecimals == toDecimals) {
+            return amount;
+        }
+
         if (fromDecimals > toDecimals) {
             return amount / (10 ** (fromDecimals - toDecimals));
-        } else if (fromDecimals < toDecimals) {
-            return amount * (10 ** (toDecimals - fromDecimals));
         } else {
-            return amount;
+            return amount * (10 ** (toDecimals - fromDecimals));
         }
     }
 

--- a/src/libraries/RateLimiter.sol
+++ b/src/libraries/RateLimiter.sol
@@ -180,7 +180,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
             difference = oldLimit.sub(newLimit);
             newCurrentCapacity = currentCapacity.gt(difference)
                 ? currentCapacity.sub(difference)
-                : NormalizedAmount(0, 0);
+                : NormalizedAmount(0, currentCapacity.decimals);
         } else {
             difference = newLimit.sub(oldLimit);
             newCurrentCapacity = currentCapacity.add(difference);

--- a/test/Manager.t.sol
+++ b/test/Manager.t.sol
@@ -446,14 +446,17 @@ contract TestManager is Test, IManagerEvents, IRateLimiterEvents {
     // === storage
 
     function test_noAutomaticSlot() public {
-        ManagerContract c = new ManagerContract(address(0x123), Manager.Mode.LOCKING, 1, 1 days);
+        DummyToken t = new DummyToken();
+        ManagerContract c = new ManagerContract(address(t), Manager.Mode.LOCKING, 1, 1 days);
         assertEq(c.lastSlot(), 0x0);
     }
 
     function test_constructor() public {
+        DummyToken t = new DummyToken();
+
         vm.startStateDiffRecording();
 
-        new ManagerStandalone(address(0x123), Manager.Mode.LOCKING, 1, 1 days);
+        new ManagerStandalone(address(t), Manager.Mode.LOCKING, 1, 1 days);
 
         Utils.assertSafeUpgradeableConstructor(vm.stopAndReturnStateDiff());
     }


### PR DESCRIPTION
- Shift decimals to match the native token decimals when receiving an NTT transfer.
- Use `NttNormalizer` wrapper lib to enforce all NTT-related normalize/denormalize operations always use the proper decimals.