### PR TITLE
evm: Fix empty instructions for WH endpoint

### DIFF
--- a/evm/src/WormholeEndpoint.sol
+++ b/evm/src/WormholeEndpoint.sol
@@ -429,6 +429,12 @@ contract WormholeEndpoint is Endpoint, IWormholeEndpoint, IWormholeReceiver {
         pure
         returns (WormholeEndpointInstruction memory instruction)
     {
+        // If the user doesn't pass in any endpoint instructions then the default is false
+        if (encoded.length == 0) {
+            instruction.shouldSkipRelayerSend = false;
+            return instruction;
+        }
+
         uint256 offset = 0;
         (instruction.shouldSkipRelayerSend, offset) = encoded.asBoolUnchecked(offset);
         encoded.checkLength(offset);

--- a/evm/test/IntegrationStandalone.t.sol
+++ b/evm/test/IntegrationStandalone.t.sol
@@ -147,13 +147,7 @@ contract TestEndToEndBase is Test, IManagerEvents, IRateLimiterEvents {
         {
             uint256 managerBalanceBefore = token1.balanceOf(address(managerChain1));
             uint256 userBalanceBefore = token1.balanceOf(address(userA));
-            managerChain1.transfer(
-                sendingAmount,
-                chainId2,
-                bytes32(uint256(uint160(userB))),
-                false,
-                encodeEndpointInstruction(true)
-            );
+            managerChain1.transfer(sendingAmount, chainId2, bytes32(uint256(uint160(userB))));
 
             // Balance check on funds going in and out working as expected
             uint256 managerBalanceAfter = token1.balanceOf(address(managerChain1));


### PR DESCRIPTION
Currently the `transfer(uint256 amount, uint16 recipientChain, bytes32 recipient)` variant always fails with the WH endpoint since the instruction payload is 0 bytes long by default when it isn't provided. This updates the parser to exit early and default to false if no instructions are provided.