### PR TITLE
solana: specify target network

### DIFF
--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -101,8 +101,8 @@ jobs:
 
           mkdir -p "${BPF_OUT_DIR}"
 
-          cargo build-sbf
-          cargo test-sbf
+          cargo build-sbf --features "mainnet"
+          cargo test-sbf --features "mainnet"
           cargo test
   anchor-test:
     name: Anchor Test

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -13,7 +13,7 @@ anchor-lang = "0.29.0"
 anchor-spl = "0.29.0"
 solana-program = "=1.17.2"
 
-wormhole-anchor-sdk = "0.29.0-alpha.1"
+wormhole-anchor-sdk = { version = "0.29.0-alpha.1", default-features = false }
 wormhole-sdk = { git = "https://github.com/wormhole-foundation/wormhole", rev = "eee4641" }
 serde_wormhole = { git = "https://github.com/wormhole-foundation/wormhole", rev = "eee4641" }
 

--- a/solana/programs/example-native-token-transfers/Cargo.toml
+++ b/solana/programs/example-native-token-transfers/Cargo.toml
@@ -9,17 +9,21 @@ crate-type = ["cdylib", "lib"]
 name = "example_native_token_transfers"
 
 [features]
+default = ["mainnet"]
 no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
-default = []
 idl-build = [
   "anchor-lang/idl-build",
   "anchor-spl/idl-build"
 ]
 # cargo-test-sbf will pass this along
 test-sbf = []
+# networks
+mainnet = [ "wormhole-anchor-sdk/mainnet" ]
+solana-devnet = [ "wormhole-anchor-sdk/solana-devnet" ]
+tilt-devnet = [ "wormhole-anchor-sdk/tilt-devnet" ]
 
 [dependencies]
 ahash = "=0.8.5"

--- a/solana/programs/wormhole-governance/Cargo.toml
+++ b/solana/programs/wormhole-governance/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "lib"]
 name = "wormhole_governance"
 
 [features]
+default = ["mainnet"]
 no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
@@ -16,6 +17,10 @@ cpi = ["no-entrypoint"]
 idl-build = [
   "anchor-lang/idl-build",
 ]
+
+mainnet = [ "wormhole-anchor-sdk/mainnet" ]
+solana-devnet = [ "wormhole-anchor-sdk/solana-devnet" ]
+tilt-devnet = [ "wormhole-anchor-sdk/tilt-devnet" ]
 
 [dependencies]
 anchor-lang.workspace = true


### PR DESCRIPTION
previously, the wormhole-anchor-sdk just built against the mainnet addresses