### PR TITLE
evm: guarantee that rate limits are initialised

### DIFF
--- a/evm/src/NttManager/NttManagerState.sol
+++ b/evm/src/NttManager/NttManagerState.sol
@@ -70,6 +70,7 @@ abstract contract NttManagerState is
         }
         __PausedOwnable_init(msg.sender, msg.sender);
         __ReentrancyGuard_init();
+        _setOutboundLimit(TrimmedAmountLib.max(tokenDecimals_));
     }
 
     function _initialize() internal virtual override {
@@ -271,6 +272,8 @@ abstract contract NttManagerState is
 
         _getPeersStorage()[peerChainId].peerAddress = peerContract;
         _getPeersStorage()[peerChainId].tokenDecimals = decimals;
+
+        _setInboundLimit(TrimmedAmountLib.max(tokenDecimals_), peerChainId);
 
         emit PeerUpdated(
             peerChainId, oldPeer.peerAddress, oldPeer.tokenDecimals, peerContract, decimals

--- a/evm/src/libraries/RateLimiter.sol
+++ b/evm/src/libraries/RateLimiter.sol
@@ -85,7 +85,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
         RateLimitParams storage rateLimitParams
     ) internal {
         TrimmedAmount memory oldLimit = rateLimitParams.limit;
-        if (oldLimit.isZero()) {
+        if (oldLimit.isNull()) {
             rateLimitParams.currentCapacity = limit;
         } else {
             TrimmedAmount memory currentCapacity = _getCurrentCapacity(rateLimitParams);

--- a/evm/src/libraries/RateLimiter.sol
+++ b/evm/src/libraries/RateLimiter.sol
@@ -85,11 +85,14 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
         RateLimitParams storage rateLimitParams
     ) internal {
         TrimmedAmount memory oldLimit = rateLimitParams.limit;
-        TrimmedAmount memory currentCapacity = _getCurrentCapacity(rateLimitParams);
+        if (oldLimit.isZero()) {
+            rateLimitParams.currentCapacity = limit;
+        } else {
+            TrimmedAmount memory currentCapacity = _getCurrentCapacity(rateLimitParams);
+            rateLimitParams.currentCapacity =
+                _calculateNewCurrentCapacity(limit, oldLimit, currentCapacity);
+        }
         rateLimitParams.limit = limit;
-
-        rateLimitParams.currentCapacity =
-            _calculateNewCurrentCapacity(limit, oldLimit, currentCapacity);
 
         rateLimitParams.lastTxTimestamp = uint64(block.timestamp);
     }

--- a/evm/src/libraries/TrimmedAmount.sol
+++ b/evm/src/libraries/TrimmedAmount.sol
@@ -49,8 +49,7 @@ library TrimmedAmountLib {
         return a.amount < b.amount;
     }
 
-    // TODO: is this needed? let's remove it
-    function isZero(TrimmedAmount memory a) internal pure returns (bool) {
+    function isNull(TrimmedAmount memory a) internal pure returns (bool) {
         return (a.amount == 0 && a.decimals == 0);
     }
 

--- a/evm/src/libraries/TrimmedAmount.sol
+++ b/evm/src/libraries/TrimmedAmount.sol
@@ -34,14 +34,6 @@ library TrimmedAmountLib {
     }
 
     function gt(TrimmedAmount memory a, TrimmedAmount memory b) internal pure returns (bool) {
-        // on initialization
-        if (isZero(b) && !isZero(a)) {
-            return true;
-        }
-        if (isZero(a) && !isZero(b)) {
-            return false;
-        }
-
         if (a.decimals != b.decimals) {
             revert NumberOfDecimalsNotEqual(a.decimals, b.decimals);
         }
@@ -50,14 +42,6 @@ library TrimmedAmountLib {
     }
 
     function lt(TrimmedAmount memory a, TrimmedAmount memory b) internal pure returns (bool) {
-        // on initialization
-        if (isZero(b) && !isZero(a)) {
-            return false;
-        }
-        if (isZero(a) && !isZero(b)) {
-            return true;
-        }
-
         if (a.decimals != b.decimals) {
             revert NumberOfDecimalsNotEqual(a.decimals, b.decimals);
         }
@@ -74,11 +58,6 @@ library TrimmedAmountLib {
         TrimmedAmount memory a,
         TrimmedAmount memory b
     ) internal pure returns (TrimmedAmount memory) {
-        // on initialization
-        if (isZero(b)) {
-            return a;
-        }
-
         if (a.decimals != b.decimals) {
             revert NumberOfDecimalsNotEqual(a.decimals, b.decimals);
         }
@@ -90,15 +69,6 @@ library TrimmedAmountLib {
         TrimmedAmount memory a,
         TrimmedAmount memory b
     ) internal pure returns (TrimmedAmount memory) {
-        // on initialization
-        if (isZero(a)) {
-            return b;
-        }
-
-        if (isZero(b)) {
-            return a;
-        }
-
         if (a.decimals != b.decimals) {
             revert NumberOfDecimalsNotEqual(a.decimals, b.decimals);
         }
@@ -134,14 +104,6 @@ library TrimmedAmountLib {
         TrimmedAmount memory a,
         TrimmedAmount memory b
     ) public pure returns (TrimmedAmount memory) {
-        // on initialization
-        if (isZero(a) && !isZero(b)) {
-            return a;
-        }
-        if (isZero(b) && !isZero(a)) {
-            return b;
-        }
-
         if (a.decimals != b.decimals) {
             revert NumberOfDecimalsNotEqual(a.decimals, b.decimals);
         }
@@ -174,6 +136,11 @@ library TrimmedAmountLib {
         return TrimmedAmount(
             uint64(scale(amount.amount, amount.decimals, actualToDecimals)), actualToDecimals
         );
+    }
+
+    function max(uint8 decimals) internal pure returns (TrimmedAmount memory) {
+        uint8 actualDecimals = minUint8(TRIMMED_DECIMALS, decimals);
+        return TrimmedAmount(type(uint64).max, actualDecimals);
     }
 
     /// @dev trim the amount to target decimals.

--- a/evm/src/libraries/TrimmedAmount.sol
+++ b/evm/src/libraries/TrimmedAmount.sol
@@ -79,15 +79,6 @@ library TrimmedAmountLib {
         TrimmedAmount memory a,
         TrimmedAmount memory b
     ) internal pure returns (TrimmedAmount memory) {
-        // on initialization
-        if (isZero(a)) {
-            return b;
-        }
-
-        if (isZero(b)) {
-            return a;
-        }
-
         if (a.decimals != b.decimals) {
             revert NumberOfDecimalsNotEqual(a.decimals, b.decimals);
         }


### PR DESCRIPTION
Previously, the rate limits were not initialised, which was masked by the graceful handling of the trimmed arithmetic operations when they encountered zero values. That handling was wrong, as we should handle the zero case exactly where it's expected: the `setLimit` function (the old values will be zero on init).

Also added outbound limit initialisation to the manager initialiser, and inbound limit initialisation to peer registration. We could consider thaking the inbound limit as an argument when registering a peer instead of the current behaviour which is to set it to the max limit. That's what the solana implementation does.