### PR TITLE
Fix incorrect bitwise comparison

### DIFF
--- a/evm/src/NttManager/NttManagerState.sol
+++ b/evm/src/NttManager/NttManagerState.sol
@@ -170,7 +170,7 @@ abstract contract NttManagerState is
     /// @inheritdoc INttManagerState
     function transceiverAttestedToMessage(bytes32 digest, uint8 index) public view returns (bool) {
         return
-            _getMessageAttestationsStorage()[digest].attestedTransceivers & uint64(1 << index) == 1;
+            _getMessageAttestationsStorage()[digest].attestedTransceivers & uint64(1 << index) > 0;
     }
 
     /// @inheritdoc INttManagerState

--- a/evm/test/NttManager.t.sol
+++ b/evm/test/NttManager.t.sol
@@ -456,10 +456,14 @@ contract TestNttManager is Test, INttManagerEvents, IRateLimiterEvents {
         // replay protection for transceiver
         vm.recordLogs();
         vm.expectRevert(
-            abi.encodeWithSignature("TransceiverAlreadyAttestedToMessage(bytes32)", 
-            TransceiverStructs.nttManagerMessageDigest(TransceiverHelpersLib.SENDING_CHAIN_ID, m)));
+            abi.encodeWithSignature(
+                "TransceiverAlreadyAttestedToMessage(bytes32)",
+                TransceiverStructs.nttManagerMessageDigest(
+                    TransceiverHelpersLib.SENDING_CHAIN_ID, m
+                )
+            )
+        );
         e2.receiveMessage(encodedEm);
-
     }
 
     // TODO:

--- a/evm/test/NttManager.t.sol
+++ b/evm/test/NttManager.t.sol
@@ -453,23 +453,13 @@ contract TestNttManager is Test, INttManagerEvents, IRateLimiterEvents {
             assertEq(token.balanceOf(address(user_B)), transferAmount.untrim(token.decimals()));
         }
 
-        // replay protection
+        // replay protection for transceiver
         vm.recordLogs();
+        vm.expectRevert(
+            abi.encodeWithSignature("TransceiverAlreadyAttestedToMessage(bytes32)", 
+            TransceiverStructs.nttManagerMessageDigest(TransceiverHelpersLib.SENDING_CHAIN_ID, m)));
         e2.receiveMessage(encodedEm);
 
-        {
-            Vm.Log[] memory entries = vm.getRecordedLogs();
-            assertEq(entries.length, 2);
-            assertEq(entries[1].topics.length, 3);
-            assertEq(entries[1].topics[0], keccak256("MessageAlreadyExecuted(bytes32,bytes32)"));
-            assertEq(entries[1].topics[1], toWormholeFormat(address(nttManager)));
-            assertEq(
-                entries[1].topics[2],
-                TransceiverStructs.nttManagerMessageDigest(
-                    TransceiverHelpersLib.SENDING_CHAIN_ID, m
-                )
-            );
-        }
     }
 
     // TODO:

--- a/evm/test/RateLimit.t.sol
+++ b/evm/test/RateLimit.t.sol
@@ -561,7 +561,9 @@ contract TestRateLimit is Test, IRateLimiterEvents {
 
         // replay protection on executeMsg
         vm.recordLogs();
-        nttManager.executeMsg(TransceiverHelpersLib.SENDING_CHAIN_ID, toWormholeFormat(address(nttManager)), m);
+        nttManager.executeMsg(
+            TransceiverHelpersLib.SENDING_CHAIN_ID, toWormholeFormat(address(nttManager)), m
+        );
 
         {
             Vm.Log[] memory entries = vm.getRecordedLogs();

--- a/evm/test/RateLimit.t.sol
+++ b/evm/test/RateLimit.t.sol
@@ -559,18 +559,18 @@ contract TestRateLimit is Test, IRateLimiterEvents {
         // assert user now has funds
         assertEq(token.balanceOf(address(user_B)), 50 * 10 ** (token.decimals() - 8));
 
-        // replay protection
+        // replay protection on executeMsg
         vm.recordLogs();
-        e2.receiveMessage(encodedEm);
+        nttManager.executeMsg(TransceiverHelpersLib.SENDING_CHAIN_ID, toWormholeFormat(address(nttManager)), m);
 
         {
             Vm.Log[] memory entries = vm.getRecordedLogs();
-            assertEq(entries.length, 2);
-            assertEq(entries[1].topics.length, 3);
-            assertEq(entries[1].topics[0], keccak256("MessageAlreadyExecuted(bytes32,bytes32)"));
-            assertEq(entries[1].topics[1], toWormholeFormat(address(nttManager)));
+            assertEq(entries.length, 1);
+            assertEq(entries[0].topics.length, 3);
+            assertEq(entries[0].topics[0], keccak256("MessageAlreadyExecuted(bytes32,bytes32)"));
+            assertEq(entries[0].topics[1], toWormholeFormat(address(nttManager)));
             assertEq(
-                entries[1].topics[2],
+                entries[0].topics[2],
                 TransceiverStructs.nttManagerMessageDigest(
                     TransceiverHelpersLib.SENDING_CHAIN_ID, m
                 )


### PR DESCRIPTION
There's a bug in the function ``transceiverAttestedToMessage()`` for indexes greater than 0.

Original code - ``_getMessageAttestationsStorage()[digest].attestedTransceivers & uint64(1 << index) == 1;`` 

* The call at the beginning is getting a bitmap of attested transceivers. So, 7 (b111) would be 3 accepted transceivers. 
* Next, we are computing the index to compare on the bitmap with transceiver index. So, if we want check the second index then 1 << 1 would work to produce 2 or the middle bit out of the 3 in the example. 
* Finally, we're comparing this with 1, which is where the bug is at. This is ONLY true if we're checking the first index. For instance, if we're checking the second index (value of 1) then we'd do ``7 & (1 << 1) == 1`` or ``7 & 2 == 1`` which is ``2 == 1`` . So, the comparison will fail on all indexes that aren't the first one (value of 0).

So, the fix is to check if the value is greater than 0. This means that if the singular bit is set, then it's already been attested to. 

Not a huge impact, since there's no running counter (we count the bits on a given digest every time) and the replay protection is somewhere else but still worth fixing in case changes are made.