### PR TITLE
solana: add 'dylint' security linting tool

### DIFF
--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -47,6 +47,7 @@ jobs:
           toolchain: ${{ steps.toolchain.outputs.version }}
           components: "clippy,rustfmt"
 
+
       - name: Cache rust packages / build cache
         uses: actions/cache@v3
         env:
@@ -71,6 +72,12 @@ jobs:
 
       - name: Run `cargo clippy`
         run: cargo clippy --workspace --tests --manifest-path solana/Cargo.toml
+
+      - name: Install cargo dylint
+        run: cargo install cargo-dylint dylint-link
+          
+      - name: Run `cargo dylint --all --workspace`
+        run: cargo dylint --workspace --all --manifest-path solana/Cargo.toml
 
       - name: Cache solana tools
         id: cache-solana

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -27,3 +27,9 @@ codegen-units = 1
 opt-level = 3
 incremental = false
 codegen-units = 1
+
+# Linting tool for vulnerable anchor patterns
+[workspace.metadata.dylint]
+libraries = [
+    { git = "https://github.com/crytic/solana-lints", pattern = "lints/*" },
+]

--- a/solana/Makefile
+++ b/solana/Makefile
@@ -22,3 +22,8 @@ node_modules: package-lock.json
 clean:
 	anchor clean
 	rm -rf .anchor node_modules
+
+# To run, install dependencies:  `cargo install cargo-dylint dylint-link`
+.PHONY: lint
+lint:
+	cargo dylint --all --workspace


### PR DESCRIPTION
Add support for the dylint tool. Configures Cargo.toml to use lints designed to help identify issues in Solana/Anchor code.

This tool adds extra functionality to `clippy` to allow it to flag security issues for us:

```
...
warning: this Account struct is used but there is no check on its owner field
   --> programs/wormhole-governance/src/instructions/governance.rs:134:26
    |
134 |             acc.pubkey = ctx.accounts.governance.key();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(missing_owner_check)]` on by default
...
```

Integrating this tool could provide helpful, proactive security benefits.

I think it would be good for us to resolve these warnings or else mark them explicitly as false positives and thereby have clippy ignore them.

After that initial effort is done, we can integrate this tool into CI. We can upgrade from warnings to errors, and optionally choose to have our CI pipeline reject any unaddressed discoveries. 