### PR TITLE
evm: Always fetch token decimals rather than caching

### DIFF
--- a/evm/src/NttManager/NttManager.sol
+++ b/evm/src/NttManager/NttManager.sol
@@ -155,9 +155,9 @@ contract NttManager is INttManager, NttManagerState {
         if (nativeTokenTransfer.toChain != chainId) {
             revert InvalidTargetChain(nativeTokenTransfer.toChain, chainId);
         }
-        uint8 tokenDecimals = tokenDecimals();
-        TrimmedAmount memory nativeTransferAmount =
-            (nativeTokenTransfer.amount.untrim(tokenDecimals)).trim(tokenDecimals, tokenDecimals);
+        uint8 toDecimals = tokenDecimals();
+        TrimmedAmount nativeTransferAmount =
+            (nativeTokenTransfer.amount.untrim(toDecimals)).trim(toDecimals, toDecimals);
 
         address transferRecipient = fromWormholeFormat(nativeTokenTransfer.to);
 
@@ -314,8 +314,8 @@ contract NttManager is INttManager, NttManagerState {
         }
 
         // trim amount after burning to ensure transfer amount matches (amount - fee)
-        TrimmedAmount memory trimmedAmount = _trimTransferAmount(amount, recipientChain);
-        TrimmedAmount memory internalAmount = trimmedAmount.shift(tokenDecimals());
+        TrimmedAmount trimmedAmount = _trimTransferAmount(amount, recipientChain);
+        TrimmedAmount internalAmount = trimmedAmount.shift(tokenDecimals());
 
         // get the sequence for this transfer
         uint64 sequence = _useMessageSequence();

--- a/evm/src/mocks/DummyToken.sol
+++ b/evm/src/mocks/DummyToken.sol
@@ -3,8 +3,9 @@
 pragma solidity >=0.8.8 <0.9.0;
 
 import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
-contract DummyToken is ERC20 {
+contract DummyToken is ERC20, ERC1967Upgrade {
     constructor() ERC20("DummyToken", "DTKN") {}
 
     // NOTE: this is purposefully not called mint() to so we can test that in
@@ -24,6 +25,10 @@ contract DummyToken is ERC20 {
     function burn(address, uint256) public virtual {
         revert("Locking nttManager should not call 'burn()'");
     }
+
+    function upgrade(address newImplementation) public {
+        _upgradeTo(newImplementation);
+    }
 }
 
 contract DummyTokenMintAndBurn is DummyToken {
@@ -35,5 +40,17 @@ contract DummyTokenMintAndBurn is DummyToken {
     function burn(uint256 amount) public {
         // TODO - add access control here?
         _burn(msg.sender, amount);
+    }
+}
+
+contract DummyTokenDifferentDecimals is DummyTokenMintAndBurn {
+    uint8 private immutable _decimals;
+
+    constructor(uint8 newDecimals) {
+        _decimals = newDecimals;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
     }
 }

--- a/evm/test/NttManager.t.sol
+++ b/evm/test/NttManager.t.sol
@@ -709,7 +709,7 @@ contract TestNttManager is Test, INttManagerEvents, IRateLimiterEvents {
         newNttManager.initialize();
         // register nttManager peer
         bytes32 peer = toWormholeFormat(address(nttManager));
-        newNttManager.setPeer(TransceiverHelpersLib.SENDING_CHAIN_ID, peer, 9);
+        newNttManager.setPeer(TransceiverHelpersLib.SENDING_CHAIN_ID, peer, 9, type(uint64).max);
 
         address user_A = address(0x123);
         address user_B = address(0x456);
@@ -734,7 +734,7 @@ contract TestNttManager is Test, INttManagerEvents, IRateLimiterEvents {
         bytes memory transceiverMessage;
         bytes memory tokenTransferMessage;
 
-        TrimmedAmount memory transferAmount = TrimmedAmount(100, 8);
+        TrimmedAmount transferAmount = packTrimmedAmount(100, 8);
 
         tokenTransferMessage = TransceiverStructs.encodeNativeTokenTransfer(
             TransceiverStructs.NativeTokenTransfer({
@@ -784,9 +784,7 @@ contract TestNttManager is Test, INttManagerEvents, IRateLimiterEvents {
         t.upgrade(address(dummy3));
 
         vm.startPrank(user_A);
-        vm.expectRevert(
-            abi.encodeWithSelector(TrimmedAmountLib.NumberOfDecimalsNotEqual.selector, 8, 7)
-        );
+        vm.expectRevert(abi.encodeWithSelector(NumberOfDecimalsNotEqual.selector, 8, 7));
         newNttManager.transfer(
             1 * 10 ** 7,
             TransceiverHelpersLib.SENDING_CHAIN_ID,
@@ -803,9 +801,7 @@ contract TestNttManager is Test, INttManagerEvents, IRateLimiterEvents {
             toWormholeFormat(address(newNttManager)),
             tokenTransferMessage
         );
-        vm.expectRevert(
-            abi.encodeWithSelector(TrimmedAmountLib.NumberOfDecimalsNotEqual.selector, 8, 7)
-        );
+        vm.expectRevert(abi.encodeWithSelector(NumberOfDecimalsNotEqual.selector, 8, 7));
         e1.receiveMessage(transceiverMessage);
     }
 }


### PR DESCRIPTION
Previously we cached the token decimals to save gas. However if the token linked to an NttManager was an upgradeable contract and the number of decimals of the token changed, then we'd be working with an out-of-date decimal amount and minting/unlocking orders of magnitude too many/few tokens.

This change forces us to always fetch the actual token decimals from the token contract when needed. If the decimals of the token do change, then all transfers will fail due to the decimal check on the rate limiting logic (assuming rate limiting is enabled and until the rate limiting configuration is updated). In the case where rate limiting is disabled, the impact is that dust is lost when trimming from the source chain until the peer configuration is updated.

The failure case is recoverable with a contract upgrade that explicitly changes some of the rate limiter decimal checks, but this isn't a pattern we will explicitly support (changing token decimals on the fly)