### PR TITLE
solana: enforce no fees have been charged

### DIFF
--- a/solana/programs/example-native-token-transfers/src/error.rs
+++ b/solana/programs/example-native-token-transfers/src/error.rs
@@ -37,4 +37,8 @@ pub enum NTTError {
     DisabledTransceiver,
     #[msg("InvalidDeployer")]
     InvalidDeployer,
+    #[msg("BadAmountAfterTransfer")]
+    BadAmountAfterTransfer,
+    #[msg("BadAmountAfterBurn")]
+    BadAmountAfterBurn,
 }


### PR DESCRIPTION
token2022 supports tokens with fees. The `transfer_checked_with_fee` function that's referenced in many places in the toke2022 documentation doesn't seem to actually exist in the sdk (or the token2022 program), and there are no helpers to perform fee calculation, so for now I've just done the defensive step of enforcing no fees by checking the transferred amount.
We could support this case once there's appropriate sdk support