### PR TITLE
evm: modify trimmed amt struct -> uint72

### DIFF
--- a/evm/src/NttManager/NttManager.sol
+++ b/evm/src/NttManager/NttManager.sol
@@ -138,7 +138,7 @@ contract NttManager is INttManager, NttManagerState {
         if (nativeTokenTransfer.toChain != chainId) {
             revert InvalidTargetChain(nativeTokenTransfer.toChain, chainId);
         }
-        TrimmedAmount memory nativeTransferAmount =
+        TrimmedAmount nativeTransferAmount =
             (nativeTokenTransfer.amount.untrim(tokenDecimals_)).trim(tokenDecimals_, tokenDecimals_);
 
         address transferRecipient = fromWormholeFormat(nativeTokenTransfer.to);
@@ -296,8 +296,8 @@ contract NttManager is INttManager, NttManagerState {
         }
 
         // trim amount after burning to ensure transfer amount matches (amount - fee)
-        TrimmedAmount memory trimmedAmount = _trimTransferAmount(amount, recipientChain);
-        TrimmedAmount memory internalAmount = trimmedAmount.shift(tokenDecimals_);
+        TrimmedAmount trimmedAmount = _trimTransferAmount(amount, recipientChain);
+        TrimmedAmount internalAmount = trimmedAmount.shift(tokenDecimals_);
 
         // get the sequence for this transfer
         uint64 sequence = _useMessageSequence();
@@ -345,7 +345,7 @@ contract NttManager is INttManager, NttManagerState {
 
     function _transfer(
         uint64 sequence,
-        TrimmedAmount memory amount,
+        TrimmedAmount amount,
         uint16 recipientChain,
         bytes32 recipient,
         address sender,
@@ -394,7 +394,7 @@ contract NttManager is INttManager, NttManagerState {
         );
 
         // push it on the stack again to avoid a stack too deep error
-        TrimmedAmount memory amt = amount;
+        TrimmedAmount amt = amount;
         uint16 destinationChain = recipientChain;
 
         emit TransferSent(
@@ -408,7 +408,7 @@ contract NttManager is INttManager, NttManagerState {
     function _mintOrUnlockToRecipient(
         bytes32 digest,
         address recipient,
-        TrimmedAmount memory amount
+        TrimmedAmount amount
     ) internal {
         // calculate proper amount of tokens to unlock/mint to recipient
         // untrim the amount
@@ -447,14 +447,14 @@ contract NttManager is INttManager, NttManagerState {
     function _trimTransferAmount(
         uint256 amount,
         uint16 toChain
-    ) internal view returns (TrimmedAmount memory) {
+    ) internal view returns (TrimmedAmount) {
         uint8 toDecimals = _getPeersStorage()[toChain].tokenDecimals;
 
         if (toDecimals == 0) {
             revert InvalidPeerDecimals();
         }
 
-        TrimmedAmount memory trimmedAmount;
+        TrimmedAmount trimmedAmount;
         {
             trimmedAmount = amount.trim(tokenDecimals_, toDecimals);
             // don't deposit dust that can not be bridged due to the decimal shift

--- a/evm/src/libraries/TransceiverStructs.sol
+++ b/evm/src/libraries/TransceiverStructs.sol
@@ -101,7 +101,7 @@ library TransceiverStructs {
         pure
         returns (bytes memory encoded)
     {
-        TrimmedAmount memory transferAmount = m.amount;
+        TrimmedAmount transferAmount = m.amount;
         return abi.encodePacked(
             NTT_PREFIX,
             transferAmount.getDecimals(),
@@ -131,7 +131,7 @@ library TransceiverStructs {
         (numDecimals, offset) = encoded.asUint8Unchecked(offset);
         uint64 amount;
         (amount, offset) = encoded.asUint64Unchecked(offset);
-        nativeTokenTransfer.amount = TrimmedAmount(amount, numDecimals);
+        nativeTokenTransfer.amount = packTrimmedAmount(amount, numDecimals);
 
         (nativeTokenTransfer.sourceToken, offset) = encoded.asBytes32Unchecked(offset);
         (nativeTokenTransfer.to, offset) = encoded.asBytes32Unchecked(offset);

--- a/evm/test/NttManager.t.sol
+++ b/evm/test/NttManager.t.sol
@@ -390,8 +390,8 @@ contract TestNttManager is Test, INttManagerEvents, IRateLimiterEvents {
             chainId,
             nttManager,
             nttManagerOther,
-            TrimmedAmount(50, 8),
-            TrimmedAmount(type(uint64).max, 8),
+            packTrimmedAmount(50, 8),
+            packTrimmedAmount(type(uint64).max, 8),
             transceivers
         );
 
@@ -416,7 +416,7 @@ contract TestNttManager is Test, INttManagerEvents, IRateLimiterEvents {
         uint8 decimals = token.decimals();
 
         nttManager.setPeer(chainId, toWormholeFormat(address(0x1)), 9);
-        nttManager.setOutboundLimit(TrimmedAmount(type(uint64).max, 8).untrim(decimals));
+        nttManager.setOutboundLimit(packTrimmedAmount(type(uint64).max, 8).untrim(decimals));
 
         token.mintDummy(address(user_A), 5 * 10 ** decimals);
 
@@ -445,7 +445,7 @@ contract TestNttManager is Test, INttManagerEvents, IRateLimiterEvents {
         (DummyTransceiver e1, DummyTransceiver e2) =
             TransceiverHelpersLib.setup_transceivers(nttManagerOther);
 
-        TrimmedAmount memory transferAmount = TrimmedAmount(50, 8);
+        TrimmedAmount transferAmount = packTrimmedAmount(50, 8);
 
         TransceiverStructs.NttManagerMessage memory m;
         bytes memory encodedEm;
@@ -462,7 +462,7 @@ contract TestNttManager is Test, INttManagerEvents, IRateLimiterEvents {
                 nttManager,
                 nttManagerOther,
                 transferAmount,
-                TrimmedAmount(type(uint64).max, 8),
+                packTrimmedAmount(type(uint64).max, 8),
                 transceivers
             );
             encodedEm = TransceiverStructs.encodeTransceiverMessage(
@@ -529,9 +529,9 @@ contract TestNttManager is Test, INttManagerEvents, IRateLimiterEvents {
         uint256 maxAmount = 5 * 10 ** decimals;
         token.mintDummy(from, maxAmount);
         nttManager.setPeer(chainId, toWormholeFormat(address(0x1)), 9);
-        nttManager.setOutboundLimit(TrimmedAmount(type(uint64).max, 8).untrim(decimals));
+        nttManager.setOutboundLimit(packTrimmedAmount(type(uint64).max, 8).untrim(decimals));
         nttManager.setInboundLimit(
-            TrimmedAmount(type(uint64).max, 8).untrim(decimals),
+            packTrimmedAmount(type(uint64).max, 8).untrim(decimals),
             TransceiverHelpersLib.SENDING_CHAIN_ID
         );
 
@@ -580,7 +580,7 @@ contract TestNttManager is Test, INttManagerEvents, IRateLimiterEvents {
 
         address user_B = address(0x456);
         DummyToken token = DummyToken(nttManager.token());
-        TrimmedAmount memory transferAmount = TrimmedAmount(50, 8);
+        TrimmedAmount transferAmount = packTrimmedAmount(50, 8);
         (ITransceiverReceiver e1, ITransceiverReceiver e2) =
             TransceiverHelpersLib.setup_transceivers(nttManagerOther);
 
@@ -600,7 +600,7 @@ contract TestNttManager is Test, INttManagerEvents, IRateLimiterEvents {
                 nttManager,
                 nttManagerOther,
                 transferAmount,
-                TrimmedAmount(type(uint64).max, 8),
+                packTrimmedAmount(type(uint64).max, 8),
                 transceivers
             );
             encodedEm = TransceiverStructs.encodeTransceiverMessage(
@@ -623,7 +623,7 @@ contract TestNttManager is Test, INttManagerEvents, IRateLimiterEvents {
             nttManager, // this is the proxy
             nttManagerOther, // this is the proxy
             transferAmount,
-            TrimmedAmount(type(uint64).max, 8),
+            packTrimmedAmount(type(uint64).max, 8),
             transceivers
         );
 

--- a/evm/test/TransceiverStructs.t.sol
+++ b/evm/test/TransceiverStructs.t.sol
@@ -76,7 +76,7 @@ contract TestTransceiverStructs is Test {
 
     function test_serialize_TransceiverMessage() public {
         TransceiverStructs.NativeTokenTransfer memory ntt = TransceiverStructs.NativeTokenTransfer({
-            amount: TrimmedAmount({amount: 1234567, decimals: 7}),
+            amount: packTrimmedAmount(uint64(1234567), 7),
             sourceToken: hex"BEEFFACE",
             to: hex"FEEBCAFE",
             toChain: 17

--- a/evm/test/TrimmedAmount.t.sol
+++ b/evm/test/TrimmedAmount.t.sol
@@ -167,4 +167,54 @@ contract TrimmingTest is Test {
 
         assertEq(expectedRoundTrip, amountRoundTrip);
     }
+
+    function testFuzz_AddOperatorOverload(TrimmedAmount a, TrimmedAmount b) public {
+        vm.assume(a.getDecimals() == b.getDecimals());
+
+        // check if the add operation reverts on an overflow.
+        // if it overflows, discard the input
+        uint256 largeSum = uint256(a.getAmount()) + uint256(b.getAmount());
+        vm.assume(largeSum <= type(uint64).max);
+
+        // check if the sum matches the expected sum if no overflow
+        TrimmedAmount sum = a + b;
+        TrimmedAmount expectedSum = add(a, b);
+
+        assertEq(expectedSum.getAmount(), sum.getAmount());
+        assertEq(expectedSum.getDecimals(), sum.getDecimals());
+    }
+
+    function testFuzz_SubOperatorOverload(TrimmedAmount a, TrimmedAmount b) public {
+        vm.assume(a.getDecimals() == b.getDecimals());
+        vm.assume(a.getAmount() >= b.getAmount());
+
+        TrimmedAmount subAmt = a - b;
+        TrimmedAmount expectedSub = sub(a, b);
+
+        assertEq(expectedSub.getAmount(), subAmt.getAmount());
+        assertEq(expectedSub.getDecimals(), subAmt.getDecimals());
+    }
+
+    function testFuzz_EqOperatorOverload(TrimmedAmount a, TrimmedAmount b) public {
+        bool isEqual = a == b;
+        bool expectedIsEqual = eq(a, b);
+
+        assertEq(expectedIsEqual, isEqual);
+    }
+
+    function testFuzz_GtOperatorOverload(TrimmedAmount a, TrimmedAmount b) public {
+        vm.assume(a.getDecimals() == b.getDecimals());
+        bool isGt = a > b;
+        bool expectedIsGt = gt(a, b);
+
+        assertEq(expectedIsGt, isGt);
+    }
+
+    function testFuzz_LtOperatorOverload(TrimmedAmount a, TrimmedAmount b) public {
+        vm.assume(a.getDecimals() == b.getDecimals());
+        bool isLt = a > b;
+        bool expectedIsLt = gt(a, b);
+
+        assertEq(expectedIsLt, isLt);
+    }
 }

--- a/evm/test/libraries/NttManagerHelpers.sol
+++ b/evm/test/libraries/NttManagerHelpers.sol
@@ -11,7 +11,7 @@ library NttManagerHelpersLib {
     using TrimmedAmountLib for TrimmedAmount;
 
     function setConfigs(
-        TrimmedAmount memory inboundLimit,
+        TrimmedAmount inboundLimit,
         NttManager nttManager,
         NttManager recipientNttManager,
         uint8 decimals

--- a/evm/test/libraries/TransceiverHelpers.sol
+++ b/evm/test/libraries/TransceiverHelpers.sol
@@ -33,8 +33,8 @@ library TransceiverHelpersLib {
         uint16 toChain,
         NttManager nttManager,
         NttManager recipientNttManager,
-        TrimmedAmount memory amount,
-        TrimmedAmount memory inboundLimit,
+        TrimmedAmount amount,
+        TrimmedAmount inboundLimit,
         ITransceiverReceiver[] memory transceivers
     )
         internal
@@ -72,7 +72,7 @@ library TransceiverHelpersLib {
         bytes32 id,
         uint16 toChain,
         NttManager nttManager,
-        TrimmedAmount memory amount
+        TrimmedAmount amount
     ) internal view returns (TransceiverStructs.NttManagerMessage memory) {
         DummyToken token = DummyToken(nttManager.token());
 
@@ -93,8 +93,8 @@ library TransceiverHelpersLib {
     function prepTokenReceive(
         NttManager nttManager,
         NttManager recipientNttManager,
-        TrimmedAmount memory amount,
-        TrimmedAmount memory inboundLimit
+        TrimmedAmount amount,
+        TrimmedAmount inboundLimit
     ) internal {
         DummyToken token = DummyToken(nttManager.token());
         token.mintDummy(address(recipientNttManager), amount.untrim(token.decimals()));


### PR DESCRIPTION
Fixes #231. 

This PR modifies the current TrimmedAmount struct to a bit-packed representation of a token amount and its decimals.   
```
/// @dev 64 bytes: [0 - 64] amount
/// @dev 8 bytes: [64 - 72] decimals
type TrimmedAmount is uint72; 
```  
This representation is advantageous for two reasons: (1) Less runtime overhead (since structs point to memory, calldata, or storage). Using a user-defined value type allows the trimmed amounts to be stack-allocated; (2) the ability to overload the traditional arithmetic binary operators (+/-/*, etc..) for operations on trimmed amounts.

The use of `uint72` instead of larger unsigned integer types ensures that extra words are not allocated downstream for other data types that contain `TrimmedAmounts` (e.g. `RateLimitParams`)