### PR TITLE
evm: Always allow re-enabling a previously registered transceiver

### DIFF
--- a/evm/src/NttManager/TransceiverRegistry.sol
+++ b/evm/src/NttManager/TransceiverRegistry.sol
@@ -120,13 +120,13 @@ abstract contract TransceiverRegistry {
             revert InvalidTransceiverZeroAddress();
         }
 
-        if (_numTransceivers.registered >= MAX_TRANSCEIVERS) {
-            revert TooManyTransceivers();
-        }
-
         if (transceiverInfos[transceiver].registered) {
             transceiverInfos[transceiver].enabled = true;
         } else {
+            if (_numTransceivers.registered >= MAX_TRANSCEIVERS) {
+                revert TooManyTransceivers();
+            }
+
             transceiverInfos[transceiver] = TransceiverInfo({
                 registered: true,
                 enabled: true,


### PR DESCRIPTION
Previously we'd revert if trying to re-enable a transceiver that's already been registered when we hit the 64 registered transceiver cap. This change allows the transceiver to be re-enabled.