### PR TITLE
solana: Configure clippy to deny possible truncation

### DIFF
--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -50,7 +50,7 @@ jobs:
         run: cargo check --workspace --tests --manifest-path Cargo.toml
 
       - name: Run `cargo clippy`
-        run: cargo clippy --workspace --tests --manifest-path Cargo.toml -- -Dclippy::cast_possible_truncation
+        run: cargo clippy --workspace --tests --manifest-path solana/Cargo.toml -- -Dclippy::cast_possible_truncation
 
       - name: Cache solana tools
         id: cache-solana

--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -50,7 +50,7 @@ jobs:
         run: cargo check --workspace --tests --manifest-path Cargo.toml
 
       - name: Run `cargo clippy`
-        run: cargo clippy --workspace --tests --manifest-path Cargo.toml
+        run: cargo clippy --workspace --tests --manifest-path Cargo.toml -- -Dclippy::cast_possible_truncation
 
       - name: Cache solana tools
         id: cache-solana

--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -50,7 +50,7 @@ jobs:
         run: cargo check --workspace --tests --manifest-path Cargo.toml
 
       - name: Run `cargo clippy`
-        run: cargo clippy --workspace --tests --manifest-path solana/Cargo.toml -- -Dclippy::cast_possible_truncation
+        run: cargo clippy --workspace --tests --manifest-path Cargo.toml -- -Dclippy::cast_possible_truncation
 
       - name: Cache solana tools
         id: cache-solana

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -12,7 +12,7 @@ warnings = "deny"
 [workspace.lints.clippy]
 # The following rules should be enabled but conflict with other open PRs.
 # TODO enable the commented rules below
-# cast_possible_truncation = "deny"
+cast_possible_truncation = "deny"
 # cast_lossless= "deny"
 # as_conversions = "deny"
 # arithmetic_side_effects = "deny"

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -10,7 +10,6 @@ warnings = "deny"
 
 # Lints to improve security
 [workspace.lints.clippy]
-# The following rules should be enabled but conflict with other open PRs.
 # TODO enable the commented rules below
 cast_possible_truncation = "deny"
 # cast_lossless= "deny"

--- a/solana/programs/example-native-token-transfers/src/bitmap.rs
+++ b/solana/programs/example-native-token-transfers/src/bitmap.rs
@@ -41,7 +41,6 @@ impl Bitmap {
         Ok(BM::<128>::from_value(self.map).get(usize::from(index)))
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     pub fn count_enabled_votes(&self, enabled: Bitmap) -> u8 {
         let bm = BM::<128>::from_value(self.map) & BM::<128>::from_value(enabled.map);
         bm.len()

--- a/solana/programs/example-native-token-transfers/src/bitmap.rs
+++ b/solana/programs/example-native-token-transfers/src/bitmap.rs
@@ -41,10 +41,9 @@ impl Bitmap {
         Ok(BM::<128>::from_value(self.map).get(usize::from(index)))
     }
 
+    #[allow(clippy::cast_possible_truncation)]
     pub fn count_enabled_votes(&self, enabled: Bitmap) -> u8 {
         let bm = BM::<128>::from_value(self.map) & BM::<128>::from_value(enabled.map);
-        // Conversion from usize to u8 is safe here. The Bitmap uses u128, so its maximum length
-        // (number of true bits) is 128.
         bm.len()
             .try_into()
             .expect("Bitmap length must not exceed the bounds of u8")

--- a/solana/programs/wormhole-governance/src/instructions/governance.rs
+++ b/solana/programs/wormhole-governance/src/instructions/governance.rs
@@ -162,7 +162,9 @@ impl GovernanceMessage {
             acc.is_signer.write(writer)?;
             acc.is_writable.write(writer)?;
         }
-        (data.len() as u16).write(writer)?;
+        u16::try_from(data.len())
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "data length overflow"))?
+            .write(writer)?;
         writer.write_all(data)
     }
 }


### PR DESCRIPTION
Adds a [clippy rule](https://rust-lang.github.io/rust-clippy/master/index.html#/cast_possible_truncation) that blocks the inclusion of code that can result in truncation problems (i.e. denies `<T> as <U>` conversions where T has a greater capacity than U)

Adds linting directive to existing instances in the code and add comments about why they are safe

Also adds some unit test on the bitmap struct to make its edge-cases more legible.