### PR TITLE
evm: Query wormhole fee and improve quote view

### DIFF
--- a/evm/src/interfaces/IManagerBase.sol
+++ b/evm/src/interfaces/IManagerBase.sol
@@ -111,11 +111,11 @@ interface IManagerBase {
 
     /// @notice Fetch the delivery price for a given recipient chain transfer.
     /// @param recipientChain The chain ID of the transfer destination.
-    /// @return - The delivery prices associated with each endpoint and the total price.
+    /// @param transceiverInstructions The transceiver specific instructions for quoting and sending
+    /// @return - The delivery prices associated with each enabled endpoint and the total price.
     function quoteDeliveryPrice(
         uint16 recipientChain,
-        TransceiverStructs.TransceiverInstruction[] memory transceiverInstructions,
-        address[] memory enabledTransceivers
+        bytes memory transceiverInstructions
     ) external view returns (uint256[] memory, uint256);
 
     /// @notice Sets the threshold for the number of attestations required for a message


### PR DESCRIPTION
We now query the wormhole fee to ensure NTT deployments with the Wormhole transceiver don't need to make an upgrade if the fee is changed to be non-zero.

I've also updated the public view for `quoteDeliveryPrice` to make it more useful since the caller now only has to pass in the transceiver instructions, not the list of enabled transceivers as well.