### PR TITLE
evm: Revert if manager peer is not registered

### DIFF
--- a/evm/src/NttManager/NttManager.sol
+++ b/evm/src/NttManager/NttManager.sol
@@ -246,6 +246,11 @@ contract NttManager is INttManager, NttManagerState {
         uint256 numEnabledTransceivers = enabledTransceivers.length;
         mapping(address => TransceiverInfo) storage transceiverInfos = _getTransceiverInfosStorage();
         bytes32 peerAddress = _getPeersStorage()[recipientChain].peerAddress;
+
+        if (peerAddress == bytes32(0)) {
+            revert PeerNotRegistered(recipientChain);
+        }
+
         // call into transceiver contracts to send the message
         for (uint256 i = 0; i < numEnabledTransceivers; i++) {
             address transceiverAddr = enabledTransceivers[i];

--- a/evm/src/interfaces/INttManager.sol
+++ b/evm/src/interfaces/INttManager.sol
@@ -86,6 +86,11 @@ interface INttManager is INttManagerState {
     /// @dev Selector 0x9c8d2cd2.
     error InvalidRecipient();
 
+    /// @notice Error when the manager doesn't have a peer registered for the destination chain
+    /// @dev Selector 0x3af256bc.
+    /// @param chainId The target chain id
+    error PeerNotRegistered(uint16 chainId);
+
     /// @notice Error when the amount burned is different than the balance difference,
     ///         since NTT does not support burn fees.
     /// @dev Selector 0x02156a8f.


### PR DESCRIPTION
There is no test case for this because this never gets hit...we always hit the `InvalidPeerDecimals` error first. So the test that this doesn't break anything is the fact that all the existing tests pass