### PR TITLE
solana: Add check for no registered transceivers

### DIFF
--- a/solana/idl/json/dummy_transfer_hook.json
+++ b/solana/idl/json/dummy_transfer_hook.json
@@ -31,11 +31,6 @@
           "isSigner": false
         },
         {
-          "name": "counter",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false
@@ -78,11 +73,6 @@
           "docs": [
             "computes and the on-chain code correctly passes on the PDA."
           ]
-        },
-        {
-          "name": "counter",
-          "isMut": true,
-          "isSigner": false
         }
       ],
       "args": [
@@ -93,21 +83,7 @@
       ]
     }
   ],
-  "accounts": [
-    {
-      "name": "Counter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "count",
-            "type": "u64"
-          }
-        ]
-      }
-    }
-  ],
   "metadata": {
-    "address": "BgabMDLaxsyB7eGMBt9L22MSk9KMrL4zY2iNe14kyFP5"
+    "address": "7R368vaW4Ztt8ShPuBRaaCqSTumLCVMbc1na4ajR5y4G"
   }
 }

--- a/solana/idl/json/example_native_token_transfers.json
+++ b/solana/idl/json/example_native_token_transfers.json
@@ -1765,6 +1765,11 @@
       "code": 6022,
       "name": "BitmapIndexOutOfBounds",
       "msg": "BitmapIndexOutOfBounds"
+    },
+    {
+      "code": 6023,
+      "name": "NoRegisteredTransceivers",
+      "msg": "NoRegisteredTransceivers"
     }
   ]
 }

--- a/solana/idl/ts/dummy_transfer_hook.ts
+++ b/solana/idl/ts/dummy_transfer_hook.ts
@@ -31,11 +31,6 @@ export type DummyTransferHook = {
           "isSigner": false
         },
         {
-          "name": "counter",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false
@@ -78,11 +73,6 @@ export type DummyTransferHook = {
           "docs": [
             "computes and the on-chain code correctly passes on the PDA."
           ]
-        },
-        {
-          "name": "counter",
-          "isMut": true,
-          "isSigner": false
         }
       ],
       "args": [
@@ -91,20 +81,6 @@ export type DummyTransferHook = {
           "type": "u64"
         }
       ]
-    }
-  ],
-  "accounts": [
-    {
-      "name": "counter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "count",
-            "type": "u64"
-          }
-        ]
-      }
     }
   ]
 };
@@ -142,11 +118,6 @@ export const IDL: DummyTransferHook = {
           "isSigner": false
         },
         {
-          "name": "counter",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false
@@ -189,11 +160,6 @@ export const IDL: DummyTransferHook = {
           "docs": [
             "computes and the on-chain code correctly passes on the PDA."
           ]
-        },
-        {
-          "name": "counter",
-          "isMut": true,
-          "isSigner": false
         }
       ],
       "args": [
@@ -202,20 +168,6 @@ export const IDL: DummyTransferHook = {
           "type": "u64"
         }
       ]
-    }
-  ],
-  "accounts": [
-    {
-      "name": "counter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "count",
-            "type": "u64"
-          }
-        ]
-      }
     }
   ]
 };

--- a/solana/idl/ts/example_native_token_transfers.ts
+++ b/solana/idl/ts/example_native_token_transfers.ts
@@ -1876,6 +1876,11 @@ export type ExampleNativeTokenTransfers = {
       "code": 6022,
       "name": "BitmapIndexOutOfBounds",
       "msg": "BitmapIndexOutOfBounds"
+    },
+    {
+      "code": 6023,
+      "name": "NoRegisteredTransceivers",
+      "msg": "NoRegisteredTransceivers"
     }
   ]
 };
@@ -3758,6 +3763,11 @@ export const IDL: ExampleNativeTokenTransfers = {
       "code": 6022,
       "name": "BitmapIndexOutOfBounds",
       "msg": "BitmapIndexOutOfBounds"
+    },
+    {
+      "code": 6023,
+      "name": "NoRegisteredTransceivers",
+      "msg": "NoRegisteredTransceivers"
     }
   ]
 };

--- a/solana/programs/example-native-token-transfers/src/bitmap.rs
+++ b/solana/programs/example-native-token-transfers/src/bitmap.rs
@@ -49,6 +49,14 @@ impl Bitmap {
             .try_into()
             .expect("Bitmap length must not exceed the bounds of u8")
     }
+
+    pub fn len(self) -> usize {
+        BM::<128>::from_value(self.map).len()
+    }
+
+    pub fn is_empty(self) -> bool {
+        BM::<128>::from_value(self.map).is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/solana/programs/example-native-token-transfers/src/error.rs
+++ b/solana/programs/example-native-token-transfers/src/error.rs
@@ -51,6 +51,8 @@ pub enum NTTError {
     OverflowScaledAmount,
     #[msg("BitmapIndexOutOfBounds")]
     BitmapIndexOutOfBounds,
+    #[msg("NoRegisteredTransceivers")]
+    NoRegisteredTransceivers,
 }
 
 impl From<ScalingError> for NTTError {

--- a/solana/programs/example-native-token-transfers/src/instructions/redeem.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/redeem.rs
@@ -24,6 +24,8 @@ pub struct Redeem<'info> {
     // NOTE: this works when the contract is paused
     #[account(
         constraint = config.threshold > 0 @ NTTError::ZeroThreshold,
+        constraint = config.next_transceiver_id != 0 @ NTTError::NoRegisteredTransceivers,
+        constraint = !config.enabled_transceivers.is_empty() @ NTTError::NoRegisteredTransceivers,
     )]
     pub config: Account<'info, Config>,
 

--- a/solana/programs/example-native-token-transfers/src/instructions/transfer.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/transfer.rs
@@ -22,6 +22,11 @@ pub struct Transfer<'info> {
     #[account(mut)]
     pub payer: Signer<'info>,
 
+    // Ensure that there exists at least one enabled transceiver
+    #[account(
+        constraint = config.next_transceiver_id != 0 @ NTTError::NoRegisteredTransceivers,
+        constraint = !config.enabled_transceivers.is_empty() @ NTTError::NoRegisteredTransceivers,
+    )]
     pub config: NotPausedConfig<'info>,
 
     #[account(
@@ -120,6 +125,7 @@ pub fn transfer_burn(ctx: Context<TransferBurn>, args: TransferArgs) -> Result<(
     );
 
     let accs = ctx.accounts;
+
     let TransferArgs {
         mut amount,
         recipient_chain,
@@ -223,6 +229,7 @@ pub fn transfer_lock(ctx: Context<TransferLock>, args: TransferArgs) -> Result<(
     );
 
     let accs = ctx.accounts;
+
     let TransferArgs {
         mut amount,
         recipient_chain,

--- a/solana/tests/example-native-token-transfer.ts
+++ b/solana/tests/example-native-token-transfer.ts
@@ -95,20 +95,28 @@ describe("example-native-token-transfers", () => {
         mode: "locking",
       });
 
-      await ntt.registerTransceiver({
+      const transceiver = await ntt.registerTransceiver({
         payer,
         owner: payer,
         transceiver: ntt.program.programId,
       });
 
-      await ntt.setWormholeTransceiverPeer({
+      if (transceiver === null) {
+        throw new Error('did not register transceiver')
+      }
+
+      const transceiverPeer = await ntt.setWormholeTransceiverPeer({
         payer,
         owner: payer,
         chain: "ethereum",
         address: Buffer.from("transceiver".padStart(32, "\0")),
       });
 
-      await ntt.setPeer({
+      if (transceiverPeer === null) {
+        throw new Error('did not set transceiver peer')
+      }
+
+      const peer = await ntt.setPeer({
         payer,
         owner: payer,
         chain: "ethereum",
@@ -116,6 +124,11 @@ describe("example-native-token-transfers", () => {
         limit: new BN(1000000),
         tokenDecimals: 18,
       });
+
+      if (peer === null) {
+        throw new Error('did not set peer')
+      }
+
     });
 
     it("Can send tokens", async () => {


### PR DESCRIPTION
Add guard on transfer instructions to prevent a transfer from being processed when no transceivers are registered. This is done by checking the `next_transceiver_id` field in the Config. This field auto-increments when a transceiver is added. If this value is 0, then the program is in a state where no transceivers have been registered.

See also https://github.com/wormhole-foundation/example-native-token-transfers/pull/289 for equivalent checks on the EVM side.

Note that, at this point, [there is no ability for Transceivers to be disabled within the Solana implementation](https://github.com/wormhole-foundation/example-native-token-transfers/issues/251). This reduces the risk explored in #289 as the only moment where no Transceivers are registered occurs just after deployment.