### PR TITLE
solana: Clippy: allow unwrap/expect in tests

### DIFF
--- a/solana/clippy.toml
+++ b/solana/clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true


### PR DESCRIPTION
These rules should help prevent linting noise. Unfortunately `allow-panic-in-tests` doesn't exist.