### PR TITLE
solana: Add anchor linting to CI

### DIFF
--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -134,3 +134,12 @@ jobs:
         - name: Run tests
           run: anchor test
           shell: bash
+        - name: Set default Rust toolchain
+          run: rustup default stable
+          working-directory: ./solana
+        - name: anchor lint
+          run: make anchor-lint
+          working-directory: ./solana
+        - name: anchor test --arch sbf
+          run: make anchor-test
+          working-directory: ./solana

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,11 @@ fix-format:
 test-evm:
 	cd evm && forge test -vvv
 
+.PHONY: anchor-lint
+anchor-lint:
+	cd solana && make anchor-lint
+
+
 # Verify that the contracts do not include PUSH0 opcodes
 test-push0:
 	forge build --extra-output evm.bytecode.opcodes

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test-evm:
 
 .PHONY: anchor-lint
 anchor-lint:
-	cd solana && make anchor-lint
+	make -C solana anchor-lint
 
 
 # Verify that the contracts do not include PUSH0 opcodes

--- a/solana/Makefile
+++ b/solana/Makefile
@@ -22,7 +22,7 @@ anchor-test:
 
 .PHONY: anchor-lint
 anchor-lint:
-	sh scripts/anchor-lint.sh
+	bash scripts/anchor-lint.sh
 
 node_modules: package-lock.json
 	npm ci

--- a/solana/Makefile
+++ b/solana/Makefile
@@ -15,6 +15,15 @@ _anchor-build:
 anchor-test:
 	anchor test
 
+# Run anchor's linter on all Rust files in the current directory via `anchor idl parse`
+# Results written to /dev/null because we're just calling parse for the linting capabilities and we don't care about
+# the JSON output.
+# anchor-cli v0.29.0 doesn't seem to do linting on the command-line during the build process so this is a workaround
+
+.PHONY: anchor-lint
+anchor-lint:
+	sh scripts/anchor-lint.sh
+
 node_modules: package-lock.json
 	npm ci
 
@@ -22,3 +31,4 @@ node_modules: package-lock.json
 clean:
 	anchor clean
 	rm -rf .anchor node_modules
+

--- a/solana/programs/example-native-token-transfers/src/instructions/admin.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/admin.rs
@@ -33,13 +33,14 @@ pub struct TransferOwnership<'info> {
     pub owner: Signer<'info>,
 
     /// CHECK: This account will be the signer in the [claim_ownership] instruction.
-    new_owner: AccountInfo<'info>,
+    new_owner: UncheckedAccount<'info>,
 
     #[account(
         seeds = [b"upgrade_lock"],
         bump,
     )]
-    upgrade_lock: AccountInfo<'info>,
+    /// CHECK: The seeds constraint enforces that this is the correct address
+    upgrade_lock: UncheckedAccount<'info>,
 
     #[account(
         mut,
@@ -89,7 +90,8 @@ pub struct ClaimOwnership<'info> {
         seeds = [b"upgrade_lock"],
         bump,
     )]
-    upgrade_lock: AccountInfo<'info>,
+    /// CHECK: The seeds constraint enforces that this is the correct address
+    upgrade_lock: UncheckedAccount<'info>,
 
     pub new_owner: Signer<'info>,
 
@@ -204,7 +206,9 @@ pub struct RegisterTransceiver<'info> {
     pub payer: Signer<'info>,
 
     #[account(executable)]
-    pub transceiver: AccountInfo<'info>,
+    /// CHECK: transceiver is meant to be a transceiver program. Arguably a `Program` constraint could be
+    /// used here that wraps the Transceiver account type.
+    pub transceiver: UncheckedAccount<'info>,
 
     #[account(
         init,

--- a/solana/programs/example-native-token-transfers/src/instructions/initialize.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/initialize.rs
@@ -58,7 +58,10 @@ pub struct Initialize<'info> {
         seeds = [crate::TOKEN_AUTHORITY_SEED],
         bump,
     )]
-    pub token_authority: AccountInfo<'info>,
+    /// CHECK: [`token_authority`] is checked against the custody account and the [`mint`]'s mint_authority
+    /// In any case, this function is used to set the Config and initialize the program so we
+    /// assume the caller of this function will have total control over the program.
+    pub token_authority: UncheckedAccount<'info>,
 
     #[account(
         init_if_needed,
@@ -73,7 +76,7 @@ pub struct Initialize<'info> {
     /// function if  the token account has already been created.
     pub custody: InterfaceAccount<'info, token_interface::TokenAccount>,
 
-    /// CHECK: checked to be the appropriate token progrem when initialising the
+    /// CHECK: checked to be the appropriate token program when initialising the
     /// associated token account for the given mint.
     pub token_program: Interface<'info, token_interface::TokenInterface>,
     pub associated_token_program: Program<'info, AssociatedToken>,

--- a/solana/programs/example-native-token-transfers/src/instructions/release_inbound.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/release_inbound.rs
@@ -29,7 +29,8 @@ pub struct ReleaseInbound<'info> {
         seeds = [crate::TOKEN_AUTHORITY_SEED],
         bump,
     )]
-    pub token_authority: AccountInfo<'info>,
+    /// CHECK The seeds constraint ensures that this is the correct address
+    pub token_authority: UncheckedAccount<'info>,
 
     #[account(
         mut,
@@ -84,7 +85,7 @@ pub fn release_inbound_mint(
                 token_interface::MintTo {
                     mint: ctx.accounts.common.mint.to_account_info(),
                     to: ctx.accounts.common.recipient.to_account_info(),
-                    authority: ctx.accounts.common.token_authority.clone(),
+                    authority: ctx.accounts.common.token_authority.to_account_info(),
                 },
                 &[&[
                     crate::TOKEN_AUTHORITY_SEED,
@@ -143,7 +144,7 @@ pub fn release_inbound_unlock(
                 token_interface::TransferChecked {
                     from: ctx.accounts.custody.to_account_info(),
                     to: ctx.accounts.common.recipient.to_account_info(),
-                    authority: ctx.accounts.common.token_authority.clone(),
+                    authority: ctx.accounts.common.token_authority.to_account_info(),
                     mint: ctx.accounts.common.mint.to_account_info(),
                 },
                 &[&[

--- a/solana/programs/example-native-token-transfers/src/instructions/transfer.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/transfer.rs
@@ -109,7 +109,8 @@ pub struct TransferBurn<'info> {
         ],
         bump,
     )]
-    pub session_authority: AccountInfo<'info>,
+    /// CHECK: The seeds constraint enforces that this is the correct account
+    pub session_authority: UncheckedAccount<'info>,
 }
 
 pub fn transfer_burn(ctx: Context<TransferBurn>, args: TransferArgs) -> Result<()> {
@@ -206,7 +207,8 @@ pub struct TransferLock<'info> {
         ],
         bump,
     )]
-    pub session_authority: AccountInfo<'info>,
+    /// CHECK: The seeds constraint enforces that this is the correct account
+    pub session_authority: UncheckedAccount<'info>,
 
     #[account(
         mut,

--- a/solana/programs/example-native-token-transfers/src/transceivers/wormhole/instructions/broadcast_id.rs
+++ b/solana/programs/example-native-token-transfers/src/transceivers/wormhole/instructions/broadcast_id.rs
@@ -24,6 +24,7 @@ pub struct BroadcastId<'info> {
         seeds = [b"emitter"],
         bump
     )]
+    /// CHECK: The seeds constraint ensures that this is the correct address
     pub emitter: UncheckedAccount<'info>,
 
     pub wormhole: WormholeAccounts<'info>,

--- a/solana/programs/example-native-token-transfers/src/transceivers/wormhole/instructions/broadcast_peer.rs
+++ b/solana/programs/example-native-token-transfers/src/transceivers/wormhole/instructions/broadcast_peer.rs
@@ -28,6 +28,7 @@ pub struct BroadcastPeer<'info> {
         seeds = [b"emitter"],
         bump
     )]
+    /// CHECK: The seeds constraint ensures that this is the correct address
     pub emitter: UncheckedAccount<'info>,
 
     pub wormhole: WormholeAccounts<'info>,

--- a/solana/programs/wormhole-governance/src/instructions/governance.rs
+++ b/solana/programs/wormhole-governance/src/instructions/governance.rs
@@ -42,8 +42,8 @@ pub struct Governance<'info> {
         seeds = [b"governance"],
         bump,
     )]
-    /// CHECK: TODO
-    pub governance: AccountInfo<'info>,
+    /// CHECK: This account is validated by Wormhole, not this program.
+    pub governance: UncheckedAccount<'info>,
 
     #[account(
         constraint = vaa.emitter_chain() == Into::<u16>::into(Chain::Solana) @ GovernanceError::InvalidGovernanceChain,
@@ -52,7 +52,8 @@ pub struct Governance<'info> {
     pub vaa: Account<'info, PostedVaa<GovernanceMessage>>,
 
     #[account(executable)]
-    pub program: AccountInfo<'info>,
+    /// CHECK: This account is validated by Wormhole, not this program.
+    pub program: UncheckedAccount<'info>,
 
     #[account(
         init,

--- a/solana/scripts/anchor-lint.sh
+++ b/solana/scripts/anchor-lint.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 TARGET=${SCRIPT_DIR}/../programs
-RESULTS=$(find "${TARGET}" -name "*.rs" -type f -exec anchor idl parse -o /dev/null --file {} \; 2>&1 | grep -v 'Program module not found')
-# echo $RESULTS
-if [ -n "$RESULTS" ]; then
+RESULTS=$(find "${TARGET}" -name "*.rs" -type f -exec anchor idl parse -o /dev/null --file {} \; 2>&1 | grep -v '^Error: Program module not found$')
+if [[ -n "$RESULTS" ]]; then
 	echo "${RESULTS}"
 	exit 1
 fi

--- a/solana/scripts/anchor-lint.sh
+++ b/solana/scripts/anchor-lint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+TARGET=${SCRIPT_DIR}/../programs
+RESULTS=$(find "${TARGET}" -name "*.rs" -type f -exec anchor idl parse -o /dev/null --file {} \; 2>&1 | grep -v 'Program module not found')
+# echo $RESULTS
+if [ -n "$RESULTS" ]; then
+	echo "${RESULTS}"
+	exit 1
+fi


### PR DESCRIPTION
Add a bash script to manually run anchor linting commands as it does not occur automatically in anchor-cli 0.29.0
Add Makefile targets that point to the new script
Add CI step to run the new make command