### PR TITLE
solana: Deny rust clippy warnings in Cargo.toml

### DIFF
--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -5,6 +5,9 @@ members = [
 ]
 resolver = "2"
 
+[workspace.lints.rust]
+warnings = "deny"
+
 # Lints to improve security
 [workspace.lints.clippy]
 # The following rules should be enabled but conflict with other open PRs.
@@ -63,6 +66,7 @@ cfg-if = "1.0"
 overflow-checks = true
 lto = "fat"
 codegen-units = 1
+
 [profile.release.build-override]
 opt-level = 3
 incremental = false


### PR DESCRIPTION
This is currently enabled as a flag in the github CI workflow so this commit causes this to be reflected within the project itself