### PR TITLE
evm: Make initialiser payable to allow WH transceiver registration

### DIFF
--- a/evm/src/NttManager/NttManager.sol
+++ b/evm/src/NttManager/NttManager.sol
@@ -58,6 +58,9 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
         if (msg.sender != deployer) {
             revert UnexpectedDeployer(deployer, msg.sender);
         }
+        if (msg.value != 0) {
+            revert UnexpectedMsgValue();
+        }
         __PausedOwnable_init(msg.sender, msg.sender);
         __ReentrancyGuard_init();
         _setOutboundLimit(TrimmedAmountLib.max(tokenDecimals()));

--- a/evm/src/Transceiver/WormholeTransceiver/WormholeTransceiverState.sol
+++ b/evm/src/Transceiver/WormholeTransceiver/WormholeTransceiverState.sol
@@ -80,7 +80,9 @@ abstract contract WormholeTransceiverState is IWormholeTransceiverState, Transce
             tokenAddress: toWormholeFormat(nttManagerToken),
             tokenDecimals: INttManager(nttManager).tokenDecimals()
         });
-        wormhole.publishMessage(0, TransceiverStructs.encodeTransceiverInit(init), consistencyLevel);
+        wormhole.publishMessage{value: msg.value}(
+            0, TransceiverStructs.encodeTransceiverInit(init), consistencyLevel
+        );
     }
 
     function _checkImmutables() internal view override {
@@ -195,7 +197,7 @@ abstract contract WormholeTransceiverState is IWormholeTransceiverState, Transce
     // =============== Admin ===============================================================
 
     /// @inheritdoc IWormholeTransceiverState
-    function setWormholePeer(uint16 peerChainId, bytes32 peerContract) external onlyOwner {
+    function setWormholePeer(uint16 peerChainId, bytes32 peerContract) external payable onlyOwner {
         if (peerChainId == 0) {
             revert InvalidWormholeChainIdZero();
         }
@@ -221,7 +223,7 @@ abstract contract WormholeTransceiverState is IWormholeTransceiverState, Transce
             transceiverChainId: peerChainId,
             transceiverAddress: peerContract
         });
-        wormhole.publishMessage(
+        wormhole.publishMessage{value: msg.value}(
             0, TransceiverStructs.encodeTransceiverRegistration(registration), consistencyLevel
         );
 

--- a/evm/src/interfaces/INttManager.sol
+++ b/evm/src/interfaces/INttManager.sol
@@ -123,6 +123,10 @@ interface INttManager is IManagerBase {
     /// @param sender The original sender that initiated the transfer that was queued.
     error CancellerNotSender(address canceller, address sender);
 
+    /// @notice An unexpected msg.value was passed with the call
+    /// @dev Selector 0xbd28e889.
+    error UnexpectedMsgValue();
+
     /// @notice Transfer a given amount to a recipient on a given chain. This function is called
     ///         by the user to send the token cross-chain. This function will either lock or burn the
     ///         sender's tokens. Finally, this function will call into registered `Endpoint` contracts

--- a/evm/src/interfaces/IWormholeTransceiverState.sol
+++ b/evm/src/interfaces/IWormholeTransceiverState.sol
@@ -94,7 +94,7 @@ interface IWormholeTransceiverState {
     /// @dev This function is only callable by the `owner`.
     /// @param chainId The Wormhole chain ID of the peer to set.
     /// @param peerContract The address of the peer contract on the given chain.
-    function setWormholePeer(uint16 chainId, bytes32 peerContract) external;
+    function setWormholePeer(uint16 chainId, bytes32 peerContract) external payable;
 
     /// @notice Set whether the chain is EVM compatible.
     /// @dev This function is only callable by the `owner`.

--- a/evm/src/libraries/Implementation.sol
+++ b/evm/src/libraries/Implementation.sol
@@ -58,7 +58,7 @@ abstract contract Implementation is Initializable, ERC1967Upgrade {
         }
     }
 
-    function initialize() external onlyDelegateCall initializer {
+    function initialize() external payable onlyDelegateCall initializer {
         _initialize();
     }
 


### PR DESCRIPTION
We don't query the wormhole message fee to save gas. The call will revert if the fee amount is not exact.