### PR TITLE
solana: Fix logic error in Inbox release process

### DIFF
--- a/solana/programs/example-native-token-transfers/src/queue/inbox.rs
+++ b/solana/programs/example-native-token-transfers/src/queue/inbox.rs
@@ -29,12 +29,23 @@ impl InboxItem {
     pub const SEED_PREFIX: &'static [u8] = b"inbox_item";
 
     /// Attempt to release the transfer.
-    /// Returns true if the transfer was released, false if it was not yet time to release it.
+    /// If the inbox item status is [`ReleaseStatus::ReleaseAfter`], this function returns true if the current timestamp
+    /// is newer than the one stored in the release status. If the timestamp is in the future,
+    /// returns false.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors when the item cannot be released, i.e. when its status is not
+    /// `ReleaseAfter`:
+    /// - returns [`NTTError::TransferNotApproved`] if [`ReleaseStatus::NotApproved`]
+    /// - returns [`NTTError::TransferAlreadyRedeemed`] if [`ReleaseStatus::Released`]. This is
+    /// important to prevent a single transfer from being redeemed multiple times, which would
+    /// result in minting arbitrary amounts of the token.
     pub fn try_release(&mut self) -> Result<bool> {
         let now = current_timestamp();
 
         match self.release_status {
-            ReleaseStatus::NotApproved => Ok(false),
+            ReleaseStatus::NotApproved => Err(NTTError::TransferNotApproved.into()),
             ReleaseStatus::ReleaseAfter(release_timestamp) => {
                 if release_timestamp > now {
                     return Ok(false);


### PR DESCRIPTION
There are a few suspicious aspects of the inbox release logic:
1. `release_inbound_unlock` takes a flag that determines whether a `false` result from `try_release` should cause an error. The flag indicates that it should revert on delay. However, `try_release` can also return `false` when a transaction has not been approved. If the flag is set, the transaction will not return an error when a user tries to release a transaction that is not approved even though whether a transaction is approved has nothing to do with its expected behaviour when it is delayed

Context:

**`try_release()` returns `Ok(false)` when a transfer is not approved**
https://github.com/wormhole-foundation/example-native-token-transfers/blob/93350abef9c3b520a01dd150a1b09a603c1e1160/solana/programs/example-native-token-transfers/src/queue/inbox.rs#L33-L47

**`release_inbound_mint` (and `release_inbound_unlock`) return `Ok(())` when transfer not approved and the `revert_on_delay` flag is false**
https://github.com/wormhole-foundation/example-native-token-transfers/blob/93350abef9c3b520a01dd150a1b09a603c1e1160/solana/programs/example-native-token-transfers/src/instructions/release_inbound.rs#L63-L79

2. The custom error `TransferNotApproved` is defined but unused in the codebase

Taken together, I believe `try_release()` should revert with the TransferNotApproved error. This would disambiguate the various 'false' results and provide more intuitive behaviour when a user tries to release a transaction that is not approved.

Current behaviour:
- if `revert_on_delay == false` and `ReleaseStatus::NotApproved`, `try_release()` returns `Ok(())`
- if `revert_on_delay == true` and `ReleaseStatus::NotApproved`, `try_release()` reverts with `CantReleaseYet`

New behaviour:
- if `revert_on_delay == false` and `ReleaseStatus::NotApproved`, `try_release()` reverts with `TransferNotApproved`
- if `revert_on_delay == true` and `ReleaseStatus::NotApproved`, `try_release()` reverts with `TransferNotApproved`