### PR TITLE
evm: Make Wormhole chainId the canonical chainId

### DIFF
--- a/evm/src/NttManager/ManagerBase.sol
+++ b/evm/src/NttManager/ManagerBase.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.8 <0.9.0;
 
 import "wormhole-solidity-sdk/Utils.sol";
 import "wormhole-solidity-sdk/libraries/BytesParsing.sol";
+import "wormhole-solidity-sdk/interfaces/IWormhole.sol";
 
 import "../libraries/external/OwnableUpgradeable.sol";
 import "../libraries/external/ReentrancyGuardUpgradeable.sol";
@@ -33,10 +34,10 @@ abstract contract ManagerBase is
 
     // =============== Setup =================================================================
 
-    constructor(address _token, Mode _mode, uint16 _chainId) {
+    constructor(address _token, Mode _mode, address _wormhole) {
         token = _token;
         mode = _mode;
-        chainId = _chainId;
+        chainId = IWormhole(_wormhole).chainId();
         evmChainId = block.chainid;
         // save the deployer (check this on initialization)
         deployer = msg.sender;

--- a/evm/src/NttManager/NttManager.sol
+++ b/evm/src/NttManager/NttManager.sol
@@ -43,10 +43,10 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
     constructor(
         address _token,
         Mode _mode,
-        uint16 _chainId,
+        address _wormhole,
         uint64 _rateLimitDuration,
         bool _skipRateLimiting
-    ) RateLimiter(_rateLimitDuration, _skipRateLimiting) ManagerBase(_token, _mode, _chainId) {}
+    ) RateLimiter(_rateLimitDuration, _skipRateLimiting) ManagerBase(_token, _mode, _wormhole) {}
 
     function __NttManager_init() internal onlyInitializing {
         // check if the owner is the deployer of this contract

--- a/evm/test/IntegrationRelayer.t.sol
+++ b/evm/test/IntegrationRelayer.t.sol
@@ -97,8 +97,17 @@ contract TestEndToEndRelayer is
         vm.deal(userA, 1 ether);
         DummyToken t1 = new DummyToken();
 
+        vm.mockCall(
+            address(chainInfosTestnet[chainId1].wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId1)
+        );
         NttManager implementation = new MockNttManagerContract(
-            address(t1), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+            address(t1),
+            IManagerBase.Mode.LOCKING,
+            address(chainInfosTestnet[chainId1].wormhole),
+            1 days,
+            false
         );
 
         nttManagerChain1 =
@@ -131,8 +140,17 @@ contract TestEndToEndRelayer is
 
         // Chain 2 setup
         DummyToken t2 = new DummyTokenMintAndBurn();
+        vm.mockCall(
+            address(chainInfosTestnet[chainId2].wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId2)
+        );
         NttManager implementationChain2 = new MockNttManagerContract(
-            address(t2), IManagerBase.Mode.BURNING, chainId2, 1 days, false
+            address(t2),
+            IManagerBase.Mode.BURNING,
+            address(chainInfosTestnet[chainId2].wormhole),
+            1 days,
+            false
         );
 
         nttManagerChain2 =
@@ -483,8 +501,13 @@ contract TestRelayerEndToEndManual is TestEndToEndRelayerBase, IRateLimiterEvent
 
         vm.chainId(chainId1);
         DummyToken t1 = new DummyToken();
+        vm.mockCall(
+            address(wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId1)
+        );
         NttManager implementation = new MockNttManagerContract(
-            address(t1), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+            address(t1), IManagerBase.Mode.LOCKING, address(wormhole), 1 days, false
         );
 
         nttManagerChain1 =
@@ -511,8 +534,13 @@ contract TestRelayerEndToEndManual is TestEndToEndRelayerBase, IRateLimiterEvent
         // Chain 2 setup
         vm.chainId(chainId2);
         DummyToken t2 = new DummyTokenMintAndBurn();
+        vm.mockCall(
+            address(wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId2)
+        );
         NttManager implementationChain2 = new MockNttManagerContract(
-            address(t2), IManagerBase.Mode.BURNING, chainId2, 1 days, false
+            address(t2), IManagerBase.Mode.BURNING, address(wormhole), 1 days, false
         );
 
         nttManagerChain2 =

--- a/evm/test/IntegrationStandalone.t.sol
+++ b/evm/test/IntegrationStandalone.t.sol
@@ -63,8 +63,13 @@ contract TestEndToEndBase is Test, IRateLimiterEvents {
 
         vm.chainId(chainId1);
         DummyToken t1 = new DummyToken();
+        vm.mockCall(
+            address(wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId1)
+        );
         NttManager implementation = new MockNttManagerContract(
-            address(t1), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+            address(t1), IManagerBase.Mode.LOCKING, address(wormhole), 1 days, false
         );
 
         nttManagerChain1 =
@@ -100,8 +105,13 @@ contract TestEndToEndBase is Test, IRateLimiterEvents {
         // Chain 2 setup
         vm.chainId(chainId2);
         DummyToken t2 = new DummyTokenMintAndBurn();
+        vm.mockCall(
+            address(wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId2)
+        );
         NttManager implementationChain2 = new MockNttManagerContract(
-            address(t2), IManagerBase.Mode.BURNING, chainId2, 1 days, false
+            address(t2), IManagerBase.Mode.BURNING, address(wormhole), 1 days, false
         );
 
         nttManagerChain2 =

--- a/evm/test/Ownership.t.sol
+++ b/evm/test/Ownership.t.sol
@@ -8,15 +8,22 @@ import "../src/interfaces/IManagerBase.sol";
 import "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {DummyTransceiver} from "./NttManager.t.sol";
 import {DummyToken} from "./NttManager.t.sol";
+import "wormhole-solidity-sdk/interfaces/IWormhole.sol";
 
 contract OwnershipTests is Test {
     NttManager nttManager;
     uint16 constant chainId = 7;
 
     function setUp() public {
+        IWormhole wormhole = IWormhole(0x4a8bc80Ed5a4067f1CCf107057b8270E0cC11A78);
         DummyToken t = new DummyToken();
+        vm.mockCall(
+            address(wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId)
+        );
         NttManager implementation = new MockNttManagerContract(
-            address(t), IManagerBase.Mode.LOCKING, chainId, 1 days, false
+            address(t), IManagerBase.Mode.LOCKING, address(wormhole), 1 days, false
         );
 
         nttManager = MockNttManagerContract(address(new ERC1967Proxy(address(implementation), "")));

--- a/evm/test/RateLimit.t.sol
+++ b/evm/test/RateLimit.t.sol
@@ -38,8 +38,13 @@ contract TestRateLimit is Test, IRateLimiterEvents {
         guardian = new WormholeSimulator(address(wormhole), DEVNET_GUARDIAN_PK);
 
         DummyToken t = new DummyToken();
+        vm.mockCall(
+            address(wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId)
+        );
         NttManager implementation = new MockNttManagerContract(
-            address(t), IManagerBase.Mode.LOCKING, chainId, 1 days, false
+            address(t), IManagerBase.Mode.LOCKING, address(wormhole), 1 days, false
         );
 
         nttManager = MockNttManagerContract(address(new ERC1967Proxy(address(implementation), "")));

--- a/evm/test/Upgrades.t.sol
+++ b/evm/test/Upgrades.t.sol
@@ -62,8 +62,13 @@ contract TestUpgrades is Test, IRateLimiterEvents {
 
         vm.chainId(chainId1);
         DummyToken t1 = new DummyToken();
+        vm.mockCall(
+            address(wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId1)
+        );
         NttManager implementation = new MockNttManagerContract(
-            address(t1), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+            address(t1), IManagerBase.Mode.LOCKING, address(wormhole), 1 days, false
         );
 
         nttManagerChain1 =
@@ -90,8 +95,13 @@ contract TestUpgrades is Test, IRateLimiterEvents {
         // Chain 2 setup
         vm.chainId(chainId2);
         DummyToken t2 = new DummyTokenMintAndBurn();
+        vm.mockCall(
+            address(wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId2)
+        );
         NttManager implementationChain2 = new MockNttManagerContract(
-            address(t2), IManagerBase.Mode.BURNING, chainId2, 1 days, false
+            address(t2), IManagerBase.Mode.BURNING, address(wormhole), 1 days, false
         );
 
         nttManagerChain2 =
@@ -143,8 +153,17 @@ contract TestUpgrades is Test, IRateLimiterEvents {
 
     function test_basicUpgradeNttManager() public {
         // Basic call to upgrade with the same contact as ewll
+        vm.mockCall(
+            address(wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId1)
+        );
         NttManager newImplementation = new MockNttManagerContract(
-            address(nttManagerChain1.token()), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+            address(nttManagerChain1.token()),
+            IManagerBase.Mode.LOCKING,
+            address(wormhole),
+            1 days,
+            false
         );
         nttManagerChain1.upgrade(address(newImplementation));
 
@@ -170,14 +189,27 @@ contract TestUpgrades is Test, IRateLimiterEvents {
     // Confirm that we can handle multiple upgrades as a nttManager
     function test_doubleUpgradeNttManager() public {
         // Basic call to upgrade with the same contact as ewll
+        vm.mockCall(
+            address(wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId1)
+        );
         NttManager newImplementation = new MockNttManagerContract(
-            address(nttManagerChain1.token()), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+            address(nttManagerChain1.token()),
+            IManagerBase.Mode.LOCKING,
+            address(wormhole),
+            1 days,
+            false
         );
         nttManagerChain1.upgrade(address(newImplementation));
         basicFunctionality();
 
         newImplementation = new MockNttManagerContract(
-            address(nttManagerChain1.token()), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+            address(nttManagerChain1.token()),
+            IManagerBase.Mode.LOCKING,
+            address(wormhole),
+            1 days,
+            false
         );
         nttManagerChain1.upgrade(address(newImplementation));
 
@@ -207,8 +239,17 @@ contract TestUpgrades is Test, IRateLimiterEvents {
 
     function test_storageSlotNttManager() public {
         // Basic call to upgrade with the same contact as ewll
+        vm.mockCall(
+            address(wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId1)
+        );
         NttManager newImplementation = new MockNttManagerStorageLayoutChange(
-            address(nttManagerChain1.token()), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+            address(nttManagerChain1.token()),
+            IManagerBase.Mode.LOCKING,
+            address(wormhole),
+            1 days,
+            false
         );
         nttManagerChain1.upgrade(address(newImplementation));
 
@@ -244,8 +285,17 @@ contract TestUpgrades is Test, IRateLimiterEvents {
 
     function test_callMigrateNttManager() public {
         // Basic call to upgrade with the same contact as ewll
+        vm.mockCall(
+            address(wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId1)
+        );
         NttManager newImplementation = new MockNttManagerMigrateBasic(
-            address(nttManagerChain1.token()), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+            address(nttManagerChain1.token()),
+            IManagerBase.Mode.LOCKING,
+            address(wormhole),
+            1 days,
+            false
         );
 
         vm.expectRevert("Proper migrate called");
@@ -277,7 +327,7 @@ contract TestUpgrades is Test, IRateLimiterEvents {
 
         // Basic call to upgrade with the same contact as ewll
         NttManager newImplementation = new MockNttManagerImmutableCheck(
-            address(tnew), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+            address(tnew), IManagerBase.Mode.LOCKING, address(wormhole), 1 days, false
         );
 
         vm.expectRevert(); // Reverts with a panic on the assert. So, no way to tell WHY this happened.
@@ -314,8 +364,13 @@ contract TestUpgrades is Test, IRateLimiterEvents {
         DummyToken tnew = new DummyToken();
 
         // Basic call to upgrade with the same contact as ewll
+        vm.mockCall(
+            address(wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId1)
+        );
         NttManager newImplementation = new MockNttManagerImmutableRemoveCheck(
-            address(tnew), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+            address(tnew), IManagerBase.Mode.LOCKING, address(wormhole), 1 days, false
         );
 
         // Allow an upgrade, since we enabled the ability to edit the immutables within the code
@@ -353,8 +408,17 @@ contract TestUpgrades is Test, IRateLimiterEvents {
         nttManagerChain1.upgrade(address(0x1));
 
         // Basic call to upgrade so that we can get the real implementation.
+        vm.mockCall(
+            address(wormhole),
+            abi.encodeWithSelector(bytes4(keccak256("chainId()"))),
+            abi.encode(chainId1)
+        );
         NttManager newImplementation = new MockNttManagerContract(
-            address(nttManagerChain1.token()), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+            address(nttManagerChain1.token()),
+            IManagerBase.Mode.LOCKING,
+            address(wormhole),
+            1 days,
+            false
         );
         nttManagerChain1.upgrade(address(newImplementation));
 
@@ -624,7 +688,7 @@ contract TestInitialize is Test {
         vm.chainId(chainId1);
         DummyToken t1 = new DummyToken();
         NttManager implementation = new MockNttManagerContract(
-            address(t1), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+            address(t1), IManagerBase.Mode.LOCKING, address(wormhole), 1 days, false
         );
 
         nttManagerChain1 =
@@ -645,7 +709,7 @@ contract TestInitialize is Test {
         vm.chainId(chainId1);
         DummyToken t1 = new DummyToken();
         NttManager implementation = new MockNttManagerContract(
-            address(t1), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+            address(t1), IManagerBase.Mode.LOCKING, address(wormhole), 1 days, false
         );
 
         nttManagerChain1 =

--- a/evm/test/mocks/MockNttManager.sol
+++ b/evm/test/mocks/MockNttManager.sol
@@ -8,10 +8,10 @@ contract MockNttManagerContract is NttManager {
     constructor(
         address token,
         Mode mode,
-        uint16 chainId,
+        address wormhole,
         uint64 rateLimitDuration,
         bool skipRateLimiting
-    ) NttManager(token, mode, chainId, rateLimitDuration, skipRateLimiting) {}
+    ) NttManager(token, mode, wormhole, rateLimitDuration, skipRateLimiting) {}
 
     /// We create a dummy storage variable here with standard solidity slot assignment.
     /// Then we check that its assigned slot is 0, i.e. that the super contract doesn't
@@ -31,10 +31,10 @@ contract MockNttManagerMigrateBasic is NttManager {
     constructor(
         address token,
         Mode mode,
-        uint16 chainId,
+        address wormhole,
         uint64 rateLimitDuration,
         bool skipRateLimiting
-    ) NttManager(token, mode, chainId, rateLimitDuration, skipRateLimiting) {}
+    ) NttManager(token, mode, wormhole, rateLimitDuration, skipRateLimiting) {}
 
     function _migrate() internal view override {
         _checkThresholdInvariants();
@@ -48,10 +48,10 @@ contract MockNttManagerImmutableCheck is NttManager {
     constructor(
         address token,
         Mode mode,
-        uint16 chainId,
+        address wormhole,
         uint64 rateLimitDuration,
         bool skipRateLimiting
-    ) NttManager(token, mode, chainId, rateLimitDuration, skipRateLimiting) {}
+    ) NttManager(token, mode, wormhole, rateLimitDuration, skipRateLimiting) {}
 }
 
 contract MockNttManagerImmutableRemoveCheck is NttManager {
@@ -59,10 +59,10 @@ contract MockNttManagerImmutableRemoveCheck is NttManager {
     constructor(
         address token,
         Mode mode,
-        uint16 chainId,
+        address wormhole,
         uint64 rateLimitDuration,
         bool skipRateLimiting
-    ) NttManager(token, mode, chainId, rateLimitDuration, skipRateLimiting) {}
+    ) NttManager(token, mode, wormhole, rateLimitDuration, skipRateLimiting) {}
 
     // Turns on the capability to EDIT the immutables
     function _migrate() internal override {
@@ -79,10 +79,10 @@ contract MockNttManagerStorageLayoutChange is NttManager {
     constructor(
         address token,
         Mode mode,
-        uint16 chainId,
+        address wormhole,
         uint64 rateLimitDuration,
         bool skipRateLimiting
-    ) NttManager(token, mode, chainId, rateLimitDuration, skipRateLimiting) {}
+    ) NttManager(token, mode, wormhole, rateLimitDuration, skipRateLimiting) {}
 
     function setData() public {
         a = address(0x1);


### PR DESCRIPTION
This probably needs some more discussion since it does tie us to Wormhole supported chains. However it does reduce the risk of a misconfig where an admin specified chain id isn't the same as the wormhole chain id for that chain.

We would also need to update the deployment scripts to support this change