### PR TITLE
evm: fix deployment script

### DIFF
--- a/evm/README.md
+++ b/evm/README.md
@@ -198,6 +198,8 @@ $ cast --help
 
 #### Environment Setup
 
+Note: **All Chain IDs set in the deployment environment files and configuration files should be the Wormhold Chain ID**
+
 Copy the sample environment file located in `env/` into the target subdirectory of your choice (e.g., `testnet` or `mainnet`) and prefix the filename with your blockchain of choice:
 
 ```
@@ -206,6 +208,8 @@ cp env/.env.sample env/testnet/sepolia.env
 ```
 
 Do this for each blockchain network that the `NTTManager` and `WormholeTransceiver` contracts will be deployed to. Then configure each `.env` file and set the `RPC` variables.
+
+Currently the `MAX_OUTBOUND_LIMIT` is set to zero in the sample `.env` file. This means that all outbound transfers will be queued by the rate limiter.
 
 #### Config Setup
 
@@ -219,13 +223,17 @@ cp WormholeNttConfig.json.sample WormholeNttConfig.json
 
 Configure each network to your liking (including adding/removing networks). We will eventually add the addresses of the deployed contracts to this file. Navigate back to the `evm` directory.
 
+Currently the per-chain `inBoundLimit` is set to zero by default. This means all inbound transfers will be queued by the rate limiter. Set this value accordingly.
+
 #### Deploy
 
 Deploy the `NttManager` and `WormholeTransceiver` contracts by running the following command for each target network:
 
 ```
 bash sh/deploy_wormhole_ntt.sh -n NETWORK_TYPE -c CHAIN_NAME -k PRIVATE_KEY
+```
 
+```
 # Argument examples
 -n testnet, mainnet
 -c avalanche, ethereum, sepolia
@@ -239,13 +247,16 @@ Once all of the contracts have been deployed and the addresses have been saved, 
 
 ```
 bash sh/configure_wormhole_ntt.sh -n NETWORK_TYPE -c CHAIN_NAME -k PRIVATE_KEY
+```
 
+```
 # Argument examples
 -n testnet, mainnet
 -c avalanche, ethereum, sepolia
 ```
 
 #### Additional Notes
-Tokens powered by NTT in __burn__ mode require the `burn` method to be present. This method is not present in the standard ERC20 interface, but is found in the `ERC20Burnable` interface.
+
+Tokens powered by NTT in **burn** mode require the `burn` method to be present. This method is not present in the standard ERC20 interface, but is found in the `ERC20Burnable` interface.
 
 The `mint` and `setMinter` methods found in the [`INttToken` Interface](src/interfaces/INttToken.sol) are not found in the standard `ERC20` interface.

--- a/evm/cfg/WormholeNttConfig.json.sample
+++ b/evm/cfg/WormholeNttConfig.json.sample
@@ -3,7 +3,7 @@
         {
             "chainId": 10002,
             "decimals": 6,
-            "inboundLimit": 18446744073709551614,
+            "inboundLimit": 0,
             "isEvmChain": true,
             "isWormholeRelayingEnabled": true,
             "isSpecialRelayingEnabled": false,
@@ -13,7 +13,7 @@
         {
             "chainId": 16,
             "decimals": 6,
-            "inboundLimit": 18446744073709551614,
+            "inboundLimit": 0,
             "isEvmChain": true,
             "isWormholeRelayingEnabled": true,
             "isSpecialRelayingEnabled": false,

--- a/evm/env/.env.sample
+++ b/evm/env/.env.sample
@@ -15,8 +15,12 @@ export RELEASE_MODE=0
 export RELEASE_RATE_LIMIT_DURATION=86400
 export RELEASE_SKIP_RATE_LIMIT=false
 
-### Rolling Window Max Outbound Transfer Limit
-export RELEASE_OUTBOUND_LIMIT=18446744073709551614
+### Rolling Window Max Outbound Transfer Limit. The default value is 0 here, this means
+### that all outbound transfers will be queued by the rate limiter. This number should
+### be scaled by the native token decimals. For example, if the native token has 18 decimals,
+### and you want to set the max outbound limit to 1000 tokens, you should set this value to
+### 1000000000000000000000.
+export RELEASE_OUTBOUND_LIMIT=0
 
 # -------------------------- Wormhole --------------------------
 

--- a/evm/script/DeployWormholeNtt.s.sol
+++ b/evm/script/DeployWormholeNtt.s.sol
@@ -24,7 +24,7 @@ contract DeployWormholeNtt is Script, ParseNttConfig {
         address specialRelayerAddr;
         uint8 consistencyLevel;
         uint256 gasLimit;
-        uint64 outboundLimit;
+        uint256 outboundLimit;
     }
 
     // The minimum gas limit to verify a message on mainnet. If you're worried about saving
@@ -81,7 +81,7 @@ contract DeployWormholeNtt is Script, ParseNttConfig {
     function configureNttManager(
         address nttManager,
         address transceiver,
-        uint64 outboundLimit,
+        uint256 outboundLimit,
         bool shouldSkipRateLimiter
     ) public {
         IManagerBase(nttManager).setTransceiver(transceiver);
@@ -133,7 +133,7 @@ contract DeployWormholeNtt is Script, ParseNttConfig {
         require(params.gasLimit >= MIN_WORMHOLE_GAS_LIMIT, "Invalid gas limit");
 
         // Outbound rate limiter limit.
-        params.outboundLimit = uint64(vm.envUint("RELEASE_OUTBOUND_LIMIT"));
+        params.outboundLimit = vm.envUint("RELEASE_OUTBOUND_LIMIT");
     }
 
     function run() public {

--- a/evm/script/UpgradeWormholeTransceiver.s.sol
+++ b/evm/script/UpgradeWormholeTransceiver.s.sol
@@ -20,7 +20,7 @@ contract UpgradeWormholeTransceiver is ParseNttConfig {
         address specialRelayerAddr;
         uint8 consistencyLevel;
         uint256 gasLimit;
-        uint64 outboundLimit;
+        uint256 outboundLimit;
     }
 
     // The minimum gas limit to verify a message on mainnet. If you're worried about saving
@@ -66,7 +66,7 @@ contract UpgradeWormholeTransceiver is ParseNttConfig {
         require(params.gasLimit >= MIN_WORMHOLE_GAS_LIMIT, "Invalid gas limit");
 
         // Outbound rate limiter limit.
-        params.outboundLimit = uint64(vm.envUint("RELEASE_OUTBOUND_LIMIT"));
+        params.outboundLimit = vm.envUint("RELEASE_OUTBOUND_LIMIT");
     }
 
     function run() public {

--- a/evm/script/helpers/ParseNttConfig.sol
+++ b/evm/script/helpers/ParseNttConfig.sol
@@ -15,7 +15,7 @@ contract ParseNttConfig is Script {
     struct ChainConfig {
         uint16 chainId;
         uint8 decimals;
-        uint64 inboundLimit;
+        uint256 inboundLimit;
         bool isEvmChain;
         bool isSpecialRelayingEnabled;
         bool isWormholeRelayingEnabled;


### PR DESCRIPTION
This PR fixes the deployment/upgrade scripts. The outbound limit should be set as an untrimmed value. 