### PR TITLE
evm: Check forks on all entrypoints

### DIFF
--- a/evm/src/NttManager/NttManager.sol
+++ b/evm/src/NttManager/NttManager.sol
@@ -196,9 +196,6 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
         bytes32 sourceNttManagerAddress,
         TransceiverStructs.NttManagerMessage memory message
     ) public whenNotPaused {
-        // verify chain has not forked
-        checkFork(evmChainId);
-
         (bytes32 digest, bool alreadyExecuted) =
             _isMessageExecuted(sourceChainId, sourceNttManagerAddress, message);
 
@@ -394,6 +391,9 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
                 revert NotEnoughCapacity(getCurrentOutboundCapacity(), amount);
             }
             if (shouldQueue && isAmountRateLimited) {
+                // verify chain has not forked
+                checkFork(evmChainId);
+
                 // emit an event to notify the user that the transfer is rate limited
                 emit OutboundTransferRateLimited(
                     msg.sender, sequence, amount, getCurrentOutboundCapacity()
@@ -444,6 +444,9 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
         address sender,
         bytes memory transceiverInstructions
     ) internal returns (uint64 msgSequence) {
+        // verify chain has not forked
+        checkFork(evmChainId);
+
         (
             address[] memory enabledTransceivers,
             TransceiverStructs.TransceiverInstruction[] memory instructions,
@@ -503,6 +506,9 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
         TrimmedAmount amount,
         bool cancelled
     ) internal {
+        // verify chain has not forked
+        checkFork(evmChainId);
+
         // calculate proper amount of tokens to unlock/mint to recipient
         // untrim the amount
         uint256 untrimmedAmount = amount.untrim(tokenDecimals());

--- a/evm/test/IntegrationStandalone.t.sol
+++ b/evm/test/IntegrationStandalone.t.sol
@@ -529,6 +529,7 @@ contract TestEndToEndBase is Test, IRateLimiterEvents {
         vm.startPrank(userA);
         token1.approve(address(nttManagerChain1), sendingAmount);
 
+        vm.chainId(chainId1);
         vm.recordLogs();
 
         // Send token through standard means (not relayer)


### PR DESCRIPTION
There was a very unlikely scenario whereby a source chain could fork, wormhole supports this forked chain, and the admin of the forked NTT manager updates the chain id and supports this new peer. Any queued transfers could then be played twice, once from the original chain, and once from the forked chain. You'd double your money on the destination chain.

This change adds a fork check on all the key entry and exit points:
- When queuing a transfer
- When sending both a queued and non-queued transfer
- When releasing funds on execution of a message
- When trying to cancel a queued outbound transfer