### PR TITLE
evm: Check threshold invariants when adding/removing transceivers

### DIFF
--- a/evm/src/NttManager/ManagerBase.sol
+++ b/evm/src/NttManager/ManagerBase.sol
@@ -351,6 +351,8 @@ abstract contract ManagerBase is
         }
 
         emit TransceiverAdded(transceiver, _getNumTransceiversStorage().enabled, _threshold.num);
+
+        _checkThresholdInvariants();
     }
 
     /// @inheritdoc IManagerBase
@@ -365,6 +367,8 @@ abstract contract ManagerBase is
         }
 
         emit TransceiverRemoved(transceiver, _threshold.num);
+
+        _checkThresholdInvariants();
     }
 
     /// @inheritdoc IManagerBase


### PR DESCRIPTION
Note that this change prevents an admin from disabling all the transceivers from an NTT manager...there has to be at least 1 enabled transceiver at all times when `numRegisteredTransceivers > 0`.
