### PR TITLE
Evm: format with nightly forge

### DIFF
--- a/evm/test/IntegrationManual.t.sol
+++ b/evm/test/IntegrationManual.t.sol
@@ -239,7 +239,7 @@ contract TestRelayerEndToEndManual is IntegrationHelpers, IRateLimiterEvents {
             nttManagerChain1.transfer{
                 value: wormholeTransceiverChain1.quoteDeliveryPrice(
                     chainId2, buildTransceiverInstruction(false)
-                    )
+                )
             }(
                 sendingAmount,
                 chainId2,

--- a/evm/test/IntegrationRelayer.t.sol
+++ b/evm/test/IntegrationRelayer.t.sol
@@ -355,7 +355,7 @@ contract TestEndToEndRelayer is IntegrationHelpers, IRateLimiterEvents, Wormhole
             nttManagerChain1.transfer{
                 value: wormholeTransceiverChain1.quoteDeliveryPrice(
                     chainId2, buildTransceiverInstruction(false)
-                    )
+                )
             }(
                 sendingAmount,
                 chainId2,
@@ -409,7 +409,7 @@ contract TestEndToEndRelayer is IntegrationHelpers, IRateLimiterEvents, Wormhole
             nttManagerChain2.transfer{
                 value: wormholeTransceiverChain2.quoteDeliveryPrice(
                     chainId1, buildTransceiverInstruction(false)
-                    )
+                )
             }(
                 sendingAmount,
                 chainId1,


### PR DESCRIPTION
Results of running `forge fmt` in the evm directory


Note: running `forge fmt` with the version I had installed didn't change anything, I had to `foundryup` for it to provide the same changes as [CI which uses](https://github.com/wormhole-foundation/example-native-token-transfers/blob/main/.github/workflows/evm.yml#L26-L28) `nightly` 