### PR TITLE
solana: pass token_program to ATA (support token22)

### DIFF
--- a/solana/programs/example-native-token-transfers/src/instructions/initialize.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/initialize.rs
@@ -65,6 +65,7 @@ pub struct Initialize<'info> {
         payer = payer,
         associated_token::mint = mint,
         associated_token::authority = token_authority,
+        associated_token::token_program = token_program,
     )]
     /// The custody account that holds tokens in locking mode.
     /// NOTE: the account is unconditionally initialized, but not used in

--- a/solana/programs/example-native-token-transfers/src/instructions/release_inbound.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/release_inbound.rs
@@ -21,7 +21,8 @@ pub struct ReleaseInbound<'info> {
     #[account(
         mut,
         associated_token::authority = inbox_item.recipient_address,
-        associated_token::mint = mint
+        associated_token::mint = mint,
+        associated_token::token_program = token_program,
     )]
     pub recipient: InterfaceAccount<'info, token_interface::TokenAccount>,
 


### PR DESCRIPTION
The associated token program instructions default to the legacy SPL token program. We pass the token_program as an argument to support token2022 tokens too.