### PR TITLE
Unilateral pause implementation

### DIFF
--- a/evm/src/NttManager/ManagerBase.sol
+++ b/evm/src/NttManager/ManagerBase.sol
@@ -15,6 +15,7 @@ import "../interfaces/ITransceiver.sol";
 import "../interfaces/IManagerBase.sol";
 
 import "./TransceiverRegistry.sol";
+import "forge-std/console.sol"; // TODO - remove this - MAX
 
 abstract contract ManagerBase is
     IManagerBase,
@@ -42,6 +43,27 @@ abstract contract ManagerBase is
         deployer = msg.sender;
     }
 
+    modifier inboundNotPaused(){
+        if(_getUnilateralPauseStorage().inbound){
+            revert InboundPaused();
+        }
+        _;
+    }
+
+    modifier outboundNotPaused(){
+        if(_getUnilateralPauseStorage().outbound){
+            revert OutboundPaused();
+        }
+        _;
+    }
+
+    modifier outboundWhenPaused(){
+        if(_getUnilateralPauseStorage().outbound == false){
+            revert NotPausedForUpdate();
+        }
+        _;
+    }
+
     function _migrate() internal virtual override {
         _checkThresholdInvariants();
         _checkTransceiversInvariants();
@@ -57,8 +79,17 @@ abstract contract ManagerBase is
 
     bytes32 private constant THRESHOLD_SLOT = bytes32(uint256(keccak256("ntt.threshold")) - 1);
 
+    bytes32 private constant UNILATERAL_PAUSE_SLOT = bytes32(uint256(keccak256("ntt.unilateral_pause")) - 1);
+
     // =============== Storage Getters/Setters ==============================================
 
+    function _getUnilateralPauseStorage() internal pure returns (UnilateralPause storage $) {
+        uint256 slot = uint256(UNILATERAL_PAUSE_SLOT);
+        assembly ("memory-safe") {
+            $.slot := slot
+        }
+    }
+    
     function _getThresholdStorage() private pure returns (_Threshold storage $) {
         uint256 slot = uint256(THRESHOLD_SLOT);
         assembly ("memory-safe") {
@@ -274,6 +305,16 @@ abstract contract ManagerBase is
     }
 
     /// @inheritdoc IManagerBase
+    function getUnilateralPause() public view returns (UnilateralPause memory) {
+        UnilateralPause storage u  = _getUnilateralPauseStorage();
+
+        return UnilateralPause({
+            inbound: u.inbound, 
+            outbound: u.outbound
+        });
+    }
+
+    /// @inheritdoc IManagerBase
     function isMessageApproved(bytes32 digest) public view returns (bool) {
         uint8 threshold = getThreshold();
         return messageAttestations(digest) >= threshold && threshold > 0;
@@ -316,6 +357,14 @@ abstract contract ManagerBase is
         _unpause();
     }
 
+    function setInboundPauseStatus(bool status) external onlyOwnerOrPauser(){
+        _getUnilateralPauseStorage().inbound = status;
+    }
+
+    function setOutboundPauseStatus(bool status) external onlyOwnerOrPauser(){
+        _getUnilateralPauseStorage().outbound = status;
+    }
+
     /// @notice Transfer ownership of the Manager contract and all Transceiver contracts to a new owner.
     function transferOwnership(address newOwner) public override onlyOwner {
         super.transferOwnership(newOwner);
@@ -356,7 +405,7 @@ abstract contract ManagerBase is
     }
 
     /// @inheritdoc IManagerBase
-    function removeTransceiver(address transceiver) external onlyOwner {
+    function removeTransceiver(address transceiver) external onlyOwner outboundWhenPaused {
         _removeTransceiver(transceiver);
 
         _Threshold storage _threshold = _getThresholdStorage();
@@ -372,7 +421,7 @@ abstract contract ManagerBase is
     }
 
     /// @inheritdoc IManagerBase
-    function setThreshold(uint8 threshold) external onlyOwner {
+    function setThreshold(uint8 threshold) external onlyOwner outboundWhenPaused {
         if (threshold == 0) {
             revert ZeroThreshold();
         }

--- a/evm/src/interfaces/IManagerBase.sol
+++ b/evm/src/interfaces/IManagerBase.sol
@@ -31,6 +31,12 @@ interface IManagerBase {
         uint8 num;
     }
 
+    /// @dev Structure for storing pause information for inbound and outbound transfers
+    struct UnilateralPause {
+        bool inbound; 
+        bool outbound; 
+    }
+
     /// @notice Emitted when a message has been attested to.
     /// @dev Topic0
     ///      0x35a2101eaac94b493e0dfca061f9a7f087913fde8678e7cde0aca9897edba0e5.
@@ -109,6 +115,19 @@ interface IManagerBase {
     /// @param chainId The target chain id
     error PeerNotRegistered(uint16 chainId);
 
+    /// @notice Error when the receiving message on inbound call when inbound calls are paused
+    /// @dev Selector 0xab6e758b
+    error InboundPaused();
+
+    /// @notice Error when sending a message when outbound transfers are paused
+    /// @dev Selector 0xe741d03c
+    error OutboundPaused();
+
+    /// @notice Error when trying to update sensitive values when the outbound is not paused
+    /// @dev Select 0x37291df0
+    error NotPausedForUpdate();
+
+
     /// @notice Fetch the delivery price for a given recipient chain transfer.
     /// @param recipientChain The chain ID of the transfer destination.
     /// @param transceiverInstructions The transceiver specific instructions for quoting and sending
@@ -164,6 +183,10 @@ interface IManagerBase {
     /// @notice Returns the number of Transceivers that must attest to a msgId for
     /// it to be considered valid and acted upon.
     function getThreshold() external view returns (uint8);
+
+    /// @notice Returns the inbound and outbound pause information for the manager. 
+    /// This is seperate to the general pause feature
+    function getUnilateralPause() external view returns (UnilateralPause memory);
 
     /// @notice Returns a boolean indicating if the transceiver has attested to the message.
     function transceiverAttestedToMessage(

--- a/evm/test/IntegrationManual.t.sol
+++ b/evm/test/IntegrationManual.t.sol
@@ -66,7 +66,7 @@ contract TestRelayerEndToEndManual is IntegrationHelpers, IRateLimiterEvents {
             address(new ERC1967Proxy(address(wormholeTransceiverChain1), ""))
         );
         wormholeTransceiverChain1.initialize();
-
+        
         nttManagerChain1.setTransceiver(address(wormholeTransceiverChain1));
         nttManagerChain1.setOutboundLimit(type(uint64).max);
         nttManagerChain1.setInboundLimit(type(uint64).max, chainId2);
@@ -108,6 +108,12 @@ contract TestRelayerEndToEndManual is IntegrationHelpers, IRateLimiterEvents {
     }
 
     function test_relayerTransceiverAuth() public {
+
+        nttManagerChain1.setInboundPauseStatus(false);
+        nttManagerChain1.setOutboundPauseStatus(false);
+        nttManagerChain2.setInboundPauseStatus(false);
+        nttManagerChain2.setOutboundPauseStatus(false);
+
         // Set up sensible WH transceiver peers
         _setTransceiverPeers(
             [wormholeTransceiverChain1, wormholeTransceiverChain2],
@@ -143,7 +149,9 @@ contract TestRelayerEndToEndManual is IntegrationHelpers, IRateLimiterEvents {
         vm.chainId(chainId2);
 
         // Set bad manager peer (0x1)
+        nttManagerChain2.setOutboundPauseStatus(true); 
         nttManagerChain2.setPeer(chainId1, toWormholeFormat(address(0x1)), 9, type(uint64).max);
+        nttManagerChain2.setOutboundPauseStatus(false); 
 
         vm.startPrank(relayer);
 
@@ -158,7 +166,9 @@ contract TestRelayerEndToEndManual is IntegrationHelpers, IRateLimiterEvents {
         );
         vm.stopPrank();
 
+        nttManagerChain2.setOutboundPauseStatus(true); 
         _setManagerPeer(nttManagerChain2, nttManagerChain1, chainId1, 9, type(uint64).max);
+        nttManagerChain2.setOutboundPauseStatus(false); 
 
         // Wrong caller - aka not relayer contract
         vm.prank(userD);
@@ -215,6 +225,15 @@ contract TestRelayerEndToEndManual is IntegrationHelpers, IRateLimiterEvents {
     }
 
     function test_relayerWithInvalidWHTransceiver() public {
+
+        require(nttManagerChain1.getUnilateralPause().inbound == true, "Inbound pause not true by default");
+        require(nttManagerChain1.getUnilateralPause().outbound == true, "Outbound pause not true by default");
+
+        nttManagerChain1.setInboundPauseStatus(false);
+        nttManagerChain1.setOutboundPauseStatus(false);
+        nttManagerChain2.setInboundPauseStatus(false);
+        nttManagerChain2.setOutboundPauseStatus(false);
+
         // Set up dodgy wormhole transceiver peers
         wormholeTransceiverChain2.setWormholePeer(chainId1, bytes32(uint256(uint160(address(0x1)))));
         wormholeTransceiverChain1.setWormholePeer(

--- a/evm/test/IntegrationRelayer.t.sol
+++ b/evm/test/IntegrationRelayer.t.sol
@@ -98,6 +98,9 @@ contract TestEndToEndRelayer is IntegrationHelpers, IRateLimiterEvents, Wormhole
         nttManagerChain1.setOutboundLimit(type(uint64).max);
         nttManagerChain1.setInboundLimit(type(uint64).max, chainId2);
         nttManagerChain1.setThreshold(1);
+
+        nttManagerChain1.setInboundPauseStatus(false);
+        nttManagerChain1.setOutboundPauseStatus(false);
     }
 
     // Setup the chain to relay to of the network
@@ -145,8 +148,10 @@ contract TestEndToEndRelayer is IntegrationHelpers, IRateLimiterEvents, Wormhole
         nttManagerChain2.setTransceiver(address(wormholeTransceiverChain2Other));
         nttManagerChain2.setOutboundLimit(type(uint64).max);
         nttManagerChain2.setInboundLimit(type(uint64).max, chainId1);
-
         nttManagerChain2.setThreshold(1);
+
+        nttManagerChain2.setInboundPauseStatus(false);
+        nttManagerChain2.setOutboundPauseStatus(false);
     }
 
     function test_chainToChainReverts() public {
@@ -158,9 +163,28 @@ contract TestEndToEndRelayer is IntegrationHelpers, IRateLimiterEvents, Wormhole
         wormholeTransceiverChain2.setWormholePeer(
             chainId1, bytes32(uint256(uint160(address(wormholeTransceiverChain1))))
         );
+
+        // Ensure that the enforcement for changing the peer is in place.
+        vm.expectRevert(
+            abi.encodeWithSelector(IManagerBase.NotPausedForUpdate.selector)
+        );
         nttManagerChain2.setPeer(
             chainId1, bytes32(uint256(uint160(address(nttManagerChain1)))), 9, type(uint64).max
         );
+
+        // Test that the threshold must be changed while in the paused state
+        vm.expectRevert(
+            abi.encodeWithSelector(IManagerBase.NotPausedForUpdate.selector)
+        );
+        nttManagerChain2.setThreshold(1);
+
+        // Set the peer
+        nttManagerChain2.setOutboundPauseStatus(true);
+        nttManagerChain2.setPeer(
+            chainId1, bytes32(uint256(uint160(address(nttManagerChain1)))), 9, type(uint64).max
+        );
+        nttManagerChain2.setOutboundPauseStatus(false);
+
         DummyToken token2 = DummyTokenMintAndBurn(nttManagerChain2.token());
         wormholeTransceiverChain2.setIsWormholeRelayingEnabled(chainId1, true);
         wormholeTransceiverChain2.setIsWormholeEvmChain(chainId1, true);
@@ -171,9 +195,12 @@ contract TestEndToEndRelayer is IntegrationHelpers, IRateLimiterEvents, Wormhole
         wormholeTransceiverChain1.setWormholePeer(
             chainId2, bytes32(uint256(uint160((address(wormholeTransceiverChain2)))))
         );
+
+        nttManagerChain1.setOutboundPauseStatus(true);
         nttManagerChain1.setPeer(
             chainId2, bytes32(uint256(uint160(address(nttManagerChain2)))), 7, type(uint64).max
         );
+        nttManagerChain1.setOutboundPauseStatus(false);
 
         // Enable general relaying on the chain to transfer for the funds.
         wormholeTransceiverChain1.setIsWormholeRelayingEnabled(chainId2, true);
@@ -265,7 +292,32 @@ contract TestEndToEndRelayer is IntegrationHelpers, IRateLimiterEvents, Wormhole
                 instructions
             );
 
+            // Test whether a random caller can set the inbound or outbound pause status
+            vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.InvalidPauser.selector, userA));
+            nttManagerChain1.setOutboundPauseStatus(true);
+            vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.InvalidPauser.selector, userA));
+            nttManagerChain1.setInboundPauseStatus(true);
+
+            // Pause outbound transfers and see if this still succeeds
+            vm.stopPrank();
+            nttManagerChain1.setOutboundPauseStatus(true);
+            vm.startPrank(userA);
+
+            vm.expectRevert(abi.encodeWithSelector(IManagerBase.OutboundPaused.selector));
             // Do the payment with slightly more gas than needed. This should result in a *payback* of 1 wei.
+            nttManagerChain1.transfer{value: priceQuote1 + 1}(
+                sendingAmount,
+                chainId2,
+                bytes32(uint256(uint160(userB))),
+                bytes32(uint256(uint160(userB))),
+                false,
+                instructions
+            );
+
+            // Unpause then to do the transfer
+            vm.stopPrank();
+            nttManagerChain1.setOutboundPauseStatus(false);
+            vm.startPrank(userA);
             nttManagerChain1.transfer{value: priceQuote1 + 1}(
                 sendingAmount,
                 chainId2,
@@ -319,18 +371,24 @@ contract TestEndToEndRelayer is IntegrationHelpers, IRateLimiterEvents, Wormhole
         wormholeTransceiverChain2.setWormholePeer(
             chainId1, bytes32(uint256(uint160(address(wormholeTransceiverChain1))))
         );
+
+        nttManagerChain2.setOutboundPauseStatus(true);
         nttManagerChain2.setPeer(
             chainId1, bytes32(uint256(uint160(address(nttManagerChain1)))), 9, type(uint64).max
         );
+        nttManagerChain2.setOutboundPauseStatus(false);
+
         DummyToken token2 = DummyTokenMintAndBurn(nttManagerChain2.token());
         wormholeTransceiverChain2.setIsWormholeRelayingEnabled(chainId1, true);
         wormholeTransceiverChain2.setIsWormholeEvmChain(chainId1, true);
 
         // Register peer contracts for the nttManager and transceiver. Transceivers and nttManager each have the concept of peers here.
         vm.selectFork(sourceFork);
+        nttManagerChain1.setOutboundPauseStatus(true);
         nttManagerChain1.setPeer(
             chainId2, bytes32(uint256(uint160(address(nttManagerChain2)))), 7, type(uint64).max
         );
+        nttManagerChain1.setOutboundPauseStatus(false);
         wormholeTransceiverChain1.setWormholePeer(
             chainId2, bytes32(uint256(uint160((address(wormholeTransceiverChain2)))))
         );
@@ -476,9 +534,12 @@ contract TestEndToEndRelayer is IntegrationHelpers, IRateLimiterEvents, Wormhole
             [wormholeTransceiverChain1, wormholeTransceiverChain1Other],
             [chainId1, chainId1]
         );
+
+        nttManagerChain2.setOutboundPauseStatus(true);
         nttManagerChain2.setPeer(
             chainId1, toWormholeFormat(address(nttManagerChain1)), 9, type(uint64).max
         );
+        nttManagerChain2.setOutboundPauseStatus(false);
 
         // setup token
         DummyToken token2 = DummyTokenMintAndBurn(nttManagerChain2.token());
@@ -493,10 +554,11 @@ contract TestEndToEndRelayer is IntegrationHelpers, IRateLimiterEvents, Wormhole
             [wormholeTransceiverChain2, wormholeTransceiverChain2Other],
             [chainId2, chainId2]
         );
+        nttManagerChain1.setOutboundPauseStatus(true);
         nttManagerChain1.setPeer(
             chainId2, toWormholeFormat(address(nttManagerChain2)), 7, type(uint64).max
         );
-
+        nttManagerChain1.setOutboundPauseStatus(false);
         DummyToken token1 = DummyToken(nttManagerChain1.token());
         uint8 decimals = token1.decimals();
 

--- a/evm/test/IntegrationStandalone.t.sol
+++ b/evm/test/IntegrationStandalone.t.sol
@@ -146,6 +146,11 @@ contract TestEndToEndBase is Test, IRateLimiterEvents {
         // Actually set it
         nttManagerChain1.setThreshold(1);
         nttManagerChain2.setThreshold(1);
+
+        nttManagerChain1.setInboundPauseStatus(false);
+        nttManagerChain1.setOutboundPauseStatus(false);
+        nttManagerChain2.setInboundPauseStatus(false);
+        nttManagerChain2.setOutboundPauseStatus(false); 
     }
 
     function test_chainToChainBase() public {
@@ -331,7 +336,15 @@ contract TestEndToEndBase is Test, IRateLimiterEvents {
         ); // Wrong chain receiving the signed VAA
         wormholeTransceiverChain1.receiveMessage(encodedVMs[0]);
 
+        
         vm.chainId(chainId2);
+
+        // Check if the inbound pauser works effectively
+        nttManagerChain2.setInboundPauseStatus(true);
+        vm.expectRevert(abi.encodeWithSelector(IManagerBase.InboundPaused.selector));
+        wormholeTransceiverChain2.receiveMessage(encodedVMs[0]);
+        nttManagerChain2.setInboundPauseStatus(false);
+ 
         {
             uint256 supplyBefore = token2.totalSupply();
             wormholeTransceiverChain2.receiveMessage(encodedVMs[0]);
@@ -377,6 +390,14 @@ contract TestEndToEndBase is Test, IRateLimiterEvents {
                 true,
                 encodeTransceiverInstruction(true)
             );
+
+            // Check that the outbound pause status checker works on queued transactions
+            vm.stopPrank();
+            nttManagerChain2.setOutboundPauseStatus(true);
+            vm.expectRevert(abi.encodeWithSelector(IManagerBase.OutboundPaused.selector));
+            nttManagerChain2.completeOutboundQueuedTransfer(0);
+            nttManagerChain2.setOutboundPauseStatus(false);
+            vm.startPrank(userC);
 
             // Test timing on the queues
             vm.expectRevert(
@@ -446,6 +467,14 @@ contract TestEndToEndBase is Test, IRateLimiterEvents {
                 Utils.fetchQueuedTransferDigestsFromLogs(vm.getRecordedLogs());
 
             vm.warp(vm.getBlockTimestamp() + 100000);
+
+            // Verify that the inbound paused modifier is functional for the inbound queue.
+            nttManagerChain1.setInboundPauseStatus(true);
+            vm.expectRevert(abi.encodeWithSelector(IManagerBase.InboundPaused.selector));
+            nttManagerChain1.completeInboundQueuedTransfer(queuedDigests[0]);
+            nttManagerChain1.setInboundPauseStatus(false);
+
+            // Complete the transfer and remove it from the queue.
             nttManagerChain1.completeInboundQueuedTransfer(queuedDigests[0]);
 
             // Double redeem
@@ -514,9 +543,17 @@ contract TestEndToEndBase is Test, IRateLimiterEvents {
         nttManagerChain2.setTransceiver(address(wormholeTransceiverChain2_2));
         nttManagerChain1.setTransceiver(address(wormholeTransceiverChain1_2));
 
+        // Ensure that a threshold change comes alongside an upgrade pauser
+        vm.expectRevert(abi.encodeWithSelector(IManagerBase.NotPausedForUpdate.selector));
+        nttManagerChain1.setThreshold(2);
+
         // Change the threshold from the setUp functions 1 to 2.
+        nttManagerChain1.setOutboundPauseStatus(true);
+        nttManagerChain2.setOutboundPauseStatus(true);
         nttManagerChain1.setThreshold(2);
         nttManagerChain2.setThreshold(2);
+        nttManagerChain1.setOutboundPauseStatus(false);
+        nttManagerChain2.setOutboundPauseStatus(false);
 
         // Setting up the transfer
         DummyToken token1 = DummyToken(nttManagerChain1.token());

--- a/evm/test/RateLimit.t.sol
+++ b/evm/test/RateLimit.t.sol
@@ -50,6 +50,10 @@ contract TestRateLimit is Test, IRateLimiterEvents {
 
         DummyTransceiver e = new DummyTransceiver(address(nttManager));
         nttManager.setTransceiver(address(e));
+
+        nttManager.setInboundPauseStatus(false);
+        nttManager.setOutboundPauseStatus(false);
+
     }
 
     function test_outboundRateLimit_setLimitSimple() public {

--- a/evm/test/Upgrades.t.sol
+++ b/evm/test/Upgrades.t.sol
@@ -139,6 +139,7 @@ contract TestUpgrades is Test, IRateLimiterEvents {
         nttManagerChain1.setThreshold(1);
         nttManagerChain2.setThreshold(1);
         vm.chainId(chainId1);
+
     }
 
     function test_basicUpgradeNttManager() public {
@@ -441,6 +442,11 @@ contract TestUpgrades is Test, IRateLimiterEvents {
     }
 
     function basicFunctionality() public {
+
+        nttManagerChain1.setInboundPauseStatus(false);
+        nttManagerChain1.setOutboundPauseStatus(false);
+        nttManagerChain2.setInboundPauseStatus(false);
+        nttManagerChain2.setOutboundPauseStatus(false);
         vm.chainId(chainId1);
 
         // Setting up the transfer
@@ -583,6 +589,10 @@ contract TestUpgrades is Test, IRateLimiterEvents {
         }
 
         vm.stopPrank();
+        nttManagerChain1.setInboundPauseStatus(true);
+        nttManagerChain1.setOutboundPauseStatus(true);
+        nttManagerChain2.setInboundPauseStatus(true);
+        nttManagerChain2.setOutboundPauseStatus(true);
     }
 
     function encodeTransceiverInstruction(bool relayer_off) public view returns (bytes memory) {

--- a/evm/test/libraries/TransceiverHelpers.sol
+++ b/evm/test/libraries/TransceiverHelpers.sol
@@ -19,11 +19,14 @@ library TransceiverHelpersLib {
         internal
         returns (DummyTransceiver, DummyTransceiver)
     {
+        nttManager.setOutboundPauseStatus(true);
         DummyTransceiver e1 = new DummyTransceiver(address(nttManager));
         DummyTransceiver e2 = new DummyTransceiver(address(nttManager));
         nttManager.setTransceiver(address(e1));
         nttManager.setTransceiver(address(e2));
         nttManager.setThreshold(2);
+        nttManager.setOutboundPauseStatus(false);
+
         return (e1, e2);
     }
 
@@ -98,9 +101,14 @@ library TransceiverHelpersLib {
     ) internal {
         DummyToken token = DummyToken(nttManager.token());
         token.mintDummy(address(recipientNttManager), amount.untrim(token.decimals()));
+
+        nttManager.setOutboundPauseStatus(true);
+        recipientNttManager.setOutboundPauseStatus(true);
         NttManagerHelpersLib.setConfigs(
             inboundLimit, nttManager, recipientNttManager, token.decimals()
         );
+        nttManager.setOutboundPauseStatus(false);
+        recipientNttManager.setOutboundPauseStatus(false);
     }
 
     function buildTransceiverMessageWithNttManagerPayload(


### PR DESCRIPTION
From the Spearbit audit, we noticed that some edits would brick in-flight calls. So, we created a mechanism, alongside proper administration, that should solve this problem. 

There is now a way to pause all inbound or all outbound txs. This allows for *outbound* txs to be paused during a potentially bricking update for in-flight Txs but allow incoming calls. After a certain amount of time that we're confident all Txs have made it, we can change the settings. 

Currently, the inboundPause and outboundPause are on all functions where pause is on. 

The functions that must be paused in order to update, it's more complicated. I identified that `setPeer`, `removeTransceiver` and `setThreshold` all have the capability to break in flights txs. So, these are the only ones that must be outbound paused in order to allow for updates. There is currently no strict time enforcement on this - it's the job of the manager to know this. 


Open questions
* What needs to be changed in the deployment and maintenance scripts? 
* Are there more functions that should be restricted? I thought that the changing of a transceiver peer on the Wormhole transceiver was another case where this could be useful. 
* Should this feature be done *globally* or *per chain*? Right now, it's setup per chain.

