### PR TITLE
solana: put governance program in governance payload

### DIFF
--- a/solana/programs/wormhole-governance/src/error.rs
+++ b/solana/programs/wormhole-governance/src/error.rs
@@ -6,4 +6,6 @@ pub enum GovernanceError {
     InvalidGovernanceChain,
     #[msg("InvalidGovernanceEmitter")]
     InvalidGovernanceEmitter,
+    #[msg("InvalidGovernanceProgram")]
+    InvalidGovernanceProgram,
 }


### PR DESCRIPTION
this matches the EVM implementation.

The primary motivation for having this field is that it allows transferring ownership to a different version of the governance program (since the program itself is not upgradeable), and ensuring that old message still cannot be replayed (since the governance program maintains its own replay protection)