### PR TITLE
solana: fix governance action byte and add serde test from guardian

### DIFF
--- a/evm/test/wormhole/Governance.t.sol
+++ b/evm/test/wormhole/Governance.t.sol
@@ -41,6 +41,34 @@ contract GovernanceTest is Test {
         myContract.transferOwnership(address(governance));
     }
 
+    function test_parseGuardian() public {
+        // these bytes were dumped from the guardian command with prototxt
+        // ```
+        //   current_set_index: 4
+        //   # generic evm call
+        //   messages: {
+        //     sequence: 4513077582118919631
+        //     nonce: 2809988562
+        //     evm_call: {
+        //       chain_id: 3
+        //       governance_contract: "0xD8E4C2DbDd2e2bd8F1336EA691dBFF6952B1a6eB"
+        //       target_contract: "0xF890982f9310df57d00f659cf4fd87e65adEd8d7"
+        //       abi_encoded_call: "BEEFFACE"
+        //     }
+        //   }
+        // ```
+        bytes memory foo =
+            hex"000000000000000047656e6572616c507572706f7365476f7665726e616e6365010003d8e4c2dbdd2e2bd8f1336ea691dbff6952b1a6ebf890982f9310df57d00f659cf4fd87e65aded8d70004beefface";
+        Governance.GeneralPurposeGovernanceMessage memory message =
+            governance.parseGeneralPurposeGovernanceMessage(foo);
+        assertEq(message.action, uint8(Governance.GovernanceAction.EVM_CALL));
+        assertEq(message.chain, uint16(3));
+        assertEq(message.governanceContract, address(0xD8E4C2DbDd2e2bd8F1336EA691dBFF6952B1a6eB));
+        assertEq(message.governedContract, address(0xF890982f9310df57d00f659cf4fd87e65adEd8d7));
+        console.logBytes(message.callData);
+        assertEq(message.callData, hex"beefface");
+    }
+
     function buildGovernanceVaa(
         uint8 action,
         uint16 chainId,

--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -6383,6 +6383,7 @@ name = "wormhole-governance"
 version = "1.0.0"
 dependencies = [
  "anchor-lang",
+ "hex",
  "solana-program",
  "wormhole-anchor-sdk",
  "wormhole-io",

--- a/solana/programs/wormhole-governance/Cargo.toml
+++ b/solana/programs/wormhole-governance/Cargo.toml
@@ -33,3 +33,6 @@ solana-program.workspace = true
 wormhole-anchor-sdk.workspace = true
 wormhole-io.workspace = true
 wormhole-sdk.workspace = true
+
+[dev-dependencies]
+hex.workspace = true


### PR DESCRIPTION
This PR fixes the width of the governance action (from the inferred usize to u8). Also, extracted the body serialiser code for governance packets, as that will be needed to generate actual governance proposals.