### PR TITLE
evm: make TrimmedAmount fuzz tests more efficient (fixes #431)

### DIFF
--- a/evm/src/libraries/TrimmedAmount.sol
+++ b/evm/src/libraries/TrimmedAmount.sol
@@ -106,6 +106,14 @@ library TrimmedAmountLib {
         return uint8(TrimmedAmount.unwrap(a) & 0xFF);
     }
 
+    /// @dev Set the decimals of the TrimmedAmount.
+    ///      This function should only be used for testing purposes, as it
+    ///      should not be necessary to change the decimals of a TrimmedAmount
+    ///      under normal circumstances.
+    function setDecimals(TrimmedAmount a, uint8 decimals) internal pure returns (TrimmedAmount) {
+        return TrimmedAmount.wrap((TrimmedAmount.unwrap(a) & ~uint72(0xFF)) | decimals);
+    }
+
     function isNull(TrimmedAmount a) internal pure returns (bool) {
         return (getAmount(a) == 0 && getDecimals(a) == 0);
     }

--- a/evm/test/TrimmedAmount.t.sol
+++ b/evm/test/TrimmedAmount.t.sol
@@ -165,6 +165,11 @@ contract TrimmingTest is Test {
 
     // =============   FUZZ TESTS ================== //
 
+    function testFuzz_setDecimals(TrimmedAmount a, uint8 decimals) public {
+        TrimmedAmount b = a.setDecimals(decimals);
+        assertEq(b.getDecimals(), decimals);
+    }
+
     function test_packUnpack(uint64 amount, uint8 decimals) public {
         TrimmedAmount trimmed = packTrimmedAmount(amount, decimals);
         assertEq(trimmed.getAmount(), amount);
@@ -172,7 +177,7 @@ contract TrimmingTest is Test {
     }
 
     function testFuzz_AddOperatorOverload(TrimmedAmount a, TrimmedAmount b) public {
-        vm.assume(a.getDecimals() == b.getDecimals());
+        a = a.setDecimals(b.getDecimals());
 
         // check if the add operation reverts on an overflow.
         // if it overflows, discard the input
@@ -188,7 +193,7 @@ contract TrimmingTest is Test {
     }
 
     function testFuzz_SubOperatorOverload(TrimmedAmount a, TrimmedAmount b) public {
-        vm.assume(a.getDecimals() == b.getDecimals());
+        a = a.setDecimals(b.getDecimals());
         vm.assume(a.getAmount() >= b.getAmount());
 
         TrimmedAmount subAmt = a - b;
@@ -206,7 +211,7 @@ contract TrimmingTest is Test {
     }
 
     function testFuzz_GtOperatorOverload(TrimmedAmount a, TrimmedAmount b) public {
-        vm.assume(a.getDecimals() == b.getDecimals());
+        a = a.setDecimals(b.getDecimals());
         bool isGt = a > b;
         bool expectedIsGt = gt(a, b);
 
@@ -214,7 +219,7 @@ contract TrimmingTest is Test {
     }
 
     function testFuzz_LtOperatorOverload(TrimmedAmount a, TrimmedAmount b) public {
-        vm.assume(a.getDecimals() == b.getDecimals());
+        a = a.setDecimals(b.getDecimals());
         bool isLt = a > b;
         bool expectedIsLt = gt(a, b);
 
@@ -224,7 +229,7 @@ contract TrimmingTest is Test {
     // invariant: forall (TrimmedAmount a, TrimmedAmount b)
     //            a.saturatingAdd(b).amount <= type(uint64).max
     function testFuzz_saturatingAddDoesNotOverflow(TrimmedAmount a, TrimmedAmount b) public {
-        vm.assume(a.getDecimals() == b.getDecimals());
+        a = a.setDecimals(b.getDecimals());
 
         TrimmedAmount c = a.saturatingAdd(b);
 


### PR DESCRIPTION
The code that tests operations on trimmed amounts previously made a
`vm.assume` call to enforce that the decimals of both amounts are the
same.

Since the decimal is an 8 bit value, the probability that
two (uniformly) randomly generated decimals are the same is 1/256,
meaning that the vast majority of test cases were discarded.

Now, we instead set the decimals of the first number to the decimals of
the second number. This does not change* the characteristics of the test
cases, as the amounts are sampled independently from the decimals.

*NOTE: this is only true under the assumption that the TrimmedAmount
type (which is backed by a uint72) is actually sampled from a uniform
distribution. This might not be the case depending on the fuzzer
implementation, as some fuzzers prefer certain edge cases. Nevertheless,
for most intents and purposes, it should be close enough without
significantly weakening the test cases.