### PR TITLE
add solana signer interface and implementation for local private key

### DIFF
--- a/solana/ts/scripts/env.ts
+++ b/solana/ts/scripts/env.ts
@@ -12,7 +12,7 @@ if (!process.env.ENV) {
 
 const env = process.env.ENV;
 
-interface SolanaSigner {
+export interface SolanaSigner {
   getAddress(): Promise<Buffer>;
   signMessage(message: Buffer): Promise<Buffer>;
   signTransaction(transaction: Buffer): Promise<Buffer>;


### PR DESCRIPTION
An integrator with no access to a ledger may not be able to deploy the Solana contracts

This makes the `getSigner` function allow _either_ the ledger derivation path _or_ an environment variable `SOLANA_PRIVATE_KEY` to be used to create a signer
