### PR TITLE
evm: adding contract verification to forge deploy scripts

### DIFF
--- a/evm/env/.env.sample
+++ b/evm/env/.env.sample
@@ -1,5 +1,7 @@
 export RPC=""
 
+export ETHERSCAN_KEY=""
+
 ### Foundry profile, we always need to deploy with prod.
 export FOUNDRY_PROFILE=prod
 

--- a/evm/sh/deploy_wormhole_ntt.sh
+++ b/evm/sh/deploy_wormhole_ntt.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-while getopts ":n:c:u:k:" opt; do
+while getopts ":n:c:u:e:k:" opt; do
   case $opt in
     n) network="$OPTARG"
     ;;
     c) chain="$OPTARG"
     ;;
     u) rpc="$OPTARG"
+    ;;
+    e) etherscan_key="$OPTARG"
     ;;
     k) private_key="$OPTARG"
     ;;
@@ -54,9 +56,16 @@ then
     rpc=$RPC
 fi
 
+# Use the ETHERSCAN_KEY environment variable if etherscan_key isn't set.
+if [ -z ${etherscan_key+x} ];
+then
+    etherscan_key=$ETHERSCAN_KEY
+fi
+
 forge script $FORGE_SCRIPTS/DeployWormholeNtt.s.sol \
     --rpc-url $rpc \
     --broadcast \
     --private-key $private_key \
+    --verify --etherscan-api-key $etherscan_key \
     --slow \
     --skip test

--- a/evm/sh/upgrade_ntt_manager.sh
+++ b/evm/sh/upgrade_ntt_manager.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-while getopts ":n:c:u:k:" opt; do
+while getopts ":n:c:u:e:k:" opt; do
   case $opt in
     n) network="$OPTARG"
     ;;
     c) chain="$OPTARG"
     ;;
     u) rpc="$OPTARG"
+    ;;
+    e) etherscan_key="$OPTARG"
     ;;
     k) private_key="$OPTARG"
     ;;
@@ -54,9 +56,16 @@ then
     rpc=$RPC
 fi
 
+# Use the ETHERSCAN_KEY environment variable if etherscan_key isn't set.
+if [ -z ${etherscan_key+x} ];
+then
+    etherscan_key=$ETHERSCAN_KEY
+fi
+
 forge script $FORGE_SCRIPTS/UpgradeNttManager.s.sol \
     --rpc-url $rpc \
     --broadcast \
     --private-key $private_key \
+    --verify --etherscan-api-key $etherscan_key \
     --slow \
     --skip test

--- a/evm/sh/upgrade_wormhole_transceiver.sh
+++ b/evm/sh/upgrade_wormhole_transceiver.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-while getopts ":n:c:u:k:" opt; do
+while getopts ":n:c:u:e:k:" opt; do
   case $opt in
     n) network="$OPTARG"
     ;;
     c) chain="$OPTARG"
     ;;
     u) rpc="$OPTARG"
+    ;;
+    e) etherscan_key="$OPTARG"
     ;;
     k) private_key="$OPTARG"
     ;;
@@ -54,9 +56,16 @@ then
     rpc=$RPC
 fi
 
+# Use the ETHERSCAN_KEY environment variable if etherscan_key isn't set.
+if [ -z ${etherscan_key+x} ];
+then
+    etherscan_key=$ETHERSCAN_KEY
+fi
+
 forge script $FORGE_SCRIPTS/UpgradeWormholeTransceiver.s.sol \
     --rpc-url $rpc \
     --broadcast \
     --private-key $private_key \
+    --verify --etherscan-api-key $etherscan_key \
     --slow \
     --skip test


### PR DESCRIPTION
Found this useful when going through the NTT deployment for ethfi @nik-suri. Just adds contract verification to forge scripts that deploy new contracts.