### PR TITLE
SDK: Remove the use of the metapackage

### DIFF
--- a/sdk/__tests__/accountant.ts
+++ b/sdk/__tests__/accountant.ts
@@ -1,4 +1,4 @@
-import { encoding } from "@wormhole-foundation/sdk";
+import { encoding } from "@wormhole-foundation/sdk-base";
 import {
   getWallet,
   getWormchainSigningClient,

--- a/sdk/__tests__/index.test.ts
+++ b/sdk/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { Chain } from "@wormhole-foundation/sdk";
+import { Chain } from "@wormhole-foundation/sdk-base";
 import { deploy, link, transferWithChecks, wh } from "./utils.js";
 import { submitAccountantVAA } from "./accountant.js";
 

--- a/sdk/__tests__/utils.ts
+++ b/sdk/__tests__/utils.ts
@@ -17,7 +17,7 @@ import {
   serialize,
   signSendWait as ssw,
   toChainId,
-} from "@wormhole-foundation/sdk";
+} from "@wormhole-foundation/sdk-connect";
 import evm from "@wormhole-foundation/sdk/platforms/evm";
 import solana from "@wormhole-foundation/sdk/platforms/solana";
 

--- a/sdk/definitions/src/index.ts
+++ b/sdk/definitions/src/index.ts
@@ -1,4 +1,4 @@
-import { registerPayloadTypes } from "@wormhole-foundation/sdk";
+import { registerPayloadTypes } from "@wormhole-foundation/sdk-definitions";
 import { nttNamedPayloads } from "./layouts/index.js";
 
 registerPayloadTypes("Ntt", nttNamedPayloads);

--- a/sdk/definitions/src/layouts/manager.ts
+++ b/sdk/definitions/src/layouts/manager.ts
@@ -1,4 +1,4 @@
-import { layoutItems } from "@wormhole-foundation/sdk";
+import { layoutItems } from "@wormhole-foundation/sdk-definitions";
 import {
   CustomizableBytes,
   Layout,

--- a/sdk/definitions/src/layouts/transceiver.ts
+++ b/sdk/definitions/src/layouts/transceiver.ts
@@ -1,4 +1,4 @@
-import { layoutItems } from "@wormhole-foundation/sdk";
+import { layoutItems } from "@wormhole-foundation/sdk-definitions";
 import {
   CustomizableBytes,
   Layout,

--- a/sdk/definitions/src/layouts/transfer.ts
+++ b/sdk/definitions/src/layouts/transfer.ts
@@ -1,4 +1,5 @@
-import { Layout, LayoutToType, layoutItems } from "@wormhole-foundation/sdk";
+import { Layout, LayoutToType } from "@wormhole-foundation/sdk-base";
+import { layoutItems } from "@wormhole-foundation/sdk-definitions";
 import { trimmedAmountItem } from "./amount.js";
 import { prefixItem } from "./prefix.js";
 

--- a/sdk/examples/src/consts.ts
+++ b/sdk/examples/src/consts.ts
@@ -1,4 +1,4 @@
-import { Chain } from "@wormhole-foundation/sdk";
+import { Chain } from "@wormhole-foundation/sdk-base";
 import { Ntt } from "@wormhole-foundation/sdk-definitions-ntt";
 import { NttRoute } from "@wormhole-foundation/sdk-route-ntt";
 export type NttContracts = {

--- a/solana/tests/anchor.test.ts
+++ b/solana/tests/anchor.test.ts
@@ -13,6 +13,7 @@ import {
   serialize,
   serializePayload,
   signSendWait as ssw,
+  AccountAddress,
 } from "@wormhole-foundation/sdk-connect";
 import * as testing from "@wormhole-foundation/sdk-definitions/testing";
 import {
@@ -24,7 +25,6 @@ import { SolanaWormholeCore } from "@wormhole-foundation/sdk-solana-core";
 import * as fs from "fs";
 
 import { PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
-import { AccountAddress } from "@wormhole-foundation/sdk-definitions";
 import { DummyTransferHook } from "../ts/idl/1_0_0/ts/dummy_transfer_hook.js";
 import { SolanaNtt } from "../ts/sdk/index.js";
 

--- a/solana/tests/anchor.test.ts
+++ b/solana/tests/anchor.test.ts
@@ -24,7 +24,7 @@ import { SolanaWormholeCore } from "@wormhole-foundation/sdk-solana-core";
 import * as fs from "fs";
 
 import { PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
-import { AccountAddress } from "@wormhole-foundation/sdk";
+import { AccountAddress } from "@wormhole-foundation/sdk-definitions";
 import { DummyTransferHook } from "../ts/idl/1_0_0/ts/dummy_transfer_hook.js";
 import { SolanaNtt } from "../ts/sdk/index.js";
 

--- a/solana/ts/lib/quoter.ts
+++ b/solana/ts/lib/quoter.ts
@@ -6,7 +6,7 @@ import {
   PublicKeyInitData,
   SystemProgram,
 } from "@solana/web3.js";
-import { amount, chainToPlatform } from "@wormhole-foundation/sdk";
+import { amount, chainToPlatform } from "@wormhole-foundation/sdk-base";
 import {
   Chain,
   deserializeLayout,


### PR DESCRIPTION
Since `@wormhole-foundation/sdk` is not actually listed in the dependencies (and we don't want it to be since it installs everything), replace imports to pull from the lower level package