### PR TITLE
SDK: Fix the relay fee amount in Solana NTT

### DIFF
--- a/solana/ts/lib/ntt.ts
+++ b/solana/ts/lib/ntt.ts
@@ -184,8 +184,11 @@ export namespace NTT {
     const program = getNttProgram(connection, programId.toString(), "1.0.0");
 
     const ix = await program.methods.version().accountsStrict({}).instruction();
-    const { blockhash } =
-      await program.provider.connection.getLatestBlockhash();
+    // Since we don't need the very very very latest blockhash, using finalized
+    // ensures the blockhash will be found when we immediately simulate the tx
+    const { blockhash } = await program.provider.connection.getLatestBlockhash(
+      "finalized"
+    );
     const msg = new TransactionMessage({
       payerKey: sender,
       recentBlockhash: blockhash,

--- a/solana/ts/sdk/ntt.ts
+++ b/solana/ts/sdk/ntt.ts
@@ -5,6 +5,7 @@ import {
   AddressLookupTableAccount,
   Connection,
   Keypair,
+  LAMPORTS_PER_SOL,
   PublicKey,
   SystemProgram,
   Transaction,
@@ -391,7 +392,7 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
         payerAddress,
         outboxItem.publicKey,
         destination.chain,
-        Number(fee),
+        Number(fee) / LAMPORTS_PER_SOL,
         // Note: quoter expects gas dropoff to be in terms of gwei
         Number(options.gasDropoff ?? 0n) / WEI_PER_GWEI
       );


### PR DESCRIPTION
The fee returned from `quoteDeliveryPrice` is in lamports but the `createRequestRelayInstruction` expects it to be in Sol