### PR TITLE
Typescript SDK changes and bug fixes needed for Connect

### DIFF
--- a/evm/ts/package.json
+++ b/evm/ts/package.json
@@ -44,19 +44,19 @@
     "test": "jest --config ./jest.config.ts"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
-    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-    "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
-    "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.2",
     "ethers": "^6.5.1"
   },
   "peerDependencies": {
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-    "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
-    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
-    "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
-    "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.0"
+    "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.2"
   },
   "devDependencies": {
     "@typechain/ethers-v6": "^0.5.1",

--- a/evm/ts/package.json
+++ b/evm/ts/package.json
@@ -44,19 +44,19 @@
     "test": "jest --config ./jest.config.ts"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk-base": "^0.7",
-    "@wormhole-foundation/sdk-definitions": "^0.7",
+    "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-    "@wormhole-foundation/sdk-evm": "^0.7",
-    "@wormhole-foundation/sdk-evm-core": "^0.7",
+    "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.0",
     "ethers": "^6.5.1"
   },
   "peerDependencies": {
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-    "@wormhole-foundation/sdk-base": "^0.7",
-    "@wormhole-foundation/sdk-definitions": "^0.7",
-    "@wormhole-foundation/sdk-evm": "^0.7",
-    "@wormhole-foundation/sdk-evm-core": "^0.7"
+    "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.0"
   },
   "devDependencies": {
     "@typechain/ethers-v6": "^0.5.1",

--- a/evm/ts/package.json
+++ b/evm/ts/package.json
@@ -44,19 +44,19 @@
     "test": "jest --config ./jest.config.ts"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
-    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-base": "^0.8",
+    "@wormhole-foundation/sdk-definitions": "^0.8",
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-    "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
-    "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-evm": "^0.8",
+    "@wormhole-foundation/sdk-evm-core": "^0.8",
     "ethers": "^6.5.1"
   },
   "peerDependencies": {
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-    "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
-    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
-    "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
-    "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.2"
+    "@wormhole-foundation/sdk-base": "^0.8",
+    "@wormhole-foundation/sdk-definitions": "^0.8",
+    "@wormhole-foundation/sdk-evm": "^0.8",
+    "@wormhole-foundation/sdk-evm-core": "^0.8"
   },
   "devDependencies": {
     "@typechain/ethers-v6": "^0.5.1",

--- a/evm/ts/src/bindings.ts
+++ b/evm/ts/src/bindings.ts
@@ -1,14 +1,17 @@
 import { Provider } from "ethers";
 
 import { _0_1_0, _1_0_0, _1_1_0 } from "./ethers-contracts/index.js";
+import { Ntt } from "@wormhole-foundation/sdk-definitions-ntt";
 
-export const AbiVersions = {
-  "0.1.0": _0_1_0,
-  "1.0.0": _1_0_0,
-  "1.1.0": _1_1_0,
-  default: _1_1_0,
-} as const;
-export type AbiVersion = keyof typeof AbiVersions;
+// This is a descending list of all ABI versions the SDK is aware of.
+// We check for the first match in descending order, allowing for higher minor and patch versions
+// being used by the live contract (these are supposed to still be compatible with older ABIs).
+export const abiVersions = [
+  ["1.1.0", _1_1_0],
+  ["1.0.0", _1_0_0],
+  ["0.1.0", _0_1_0],
+] as const;
+export type AbiVersion = (typeof abiVersions)[number][0];
 
 export interface NttBindings {
   NttManager: NttManagerBindings;
@@ -36,8 +39,11 @@ export interface NttManagerBindings {
   connect(address: string, provider: Provider): NttManagerBindings.NttManager;
 }
 
-export function loadAbiVersion(version: string) {
-  if (!(version in AbiVersions))
-    throw new Error(`Unknown ABI version: ${version}`);
-  return AbiVersions[version as AbiVersion];
+export function loadAbiVersion(targetVersion: string) {
+  for (const [abiVersion, abi] of abiVersions) {
+    if (Ntt.abiVersionMatches(targetVersion, abiVersion)) {
+      return abi;
+    }
+  }
+  throw new Error(`Unknown ABI version: ${targetVersion}`);
 }

--- a/evm/ts/src/ntt.ts
+++ b/evm/ts/src/ntt.ts
@@ -98,7 +98,7 @@ export class EvmNtt<N extends Network, C extends EvmChains>
     readonly chain: C,
     readonly provider: Provider,
     readonly contracts: Contracts & { ntt?: Ntt.Contracts },
-    readonly version: string = "default"
+    readonly version: string = "1.0.0"
   ) {
     if (!contracts.ntt) throw new Error("No Ntt Contracts provided");
 
@@ -366,9 +366,10 @@ export class EvmNtt<N extends Network, C extends EvmChains>
     transceiverMessage: Ntt.Message,
     payer?: AccountAddress<C>
   ) {
-    const tx = await this.manager.completeInboundQueuedTransfer(
-      Ntt.messageDigest(fromChain, transceiverMessage)
-    );
+    const tx =
+      await this.manager.completeInboundQueuedTransfer.populateTransaction(
+        Ntt.messageDigest(fromChain, transceiverMessage)
+      );
     yield this.createUnsignedTx(tx, "Ntt.completeInboundQueuedTransfer");
   }
 

--- a/evm/ts/src/ntt.ts
+++ b/evm/ts/src/ntt.ts
@@ -9,8 +9,6 @@ import {
   ChainAddress,
   ChainsConfig,
   Contracts,
-  TokenAddress,
-  VAA,
   serialize,
   universalAddress,
 } from "@wormhole-foundation/sdk-definitions";
@@ -143,19 +141,30 @@ export class EvmNtt<N extends Network, C extends EvmChains>
     return enabled.filter((x) => x).length > 0;
   }
 
-  getIsExecuted(attestation: Ntt.Attestation): Promise<boolean> {
-    const { emitterChain: chain, payload } =
-      attestation as VAA<"Ntt:WormholeTransfer">;
-    return this.manager.isMessageExecuted(
-      Ntt.messageDigest(chain, payload["nttManagerPayload"])
+  async getIsExecuted(attestation: Ntt.Attestation): Promise<boolean> {
+    const payload =
+      attestation.payloadName === "WormholeTransfer"
+        ? attestation.payload
+        : attestation.payload.payload;
+    const isExecuted = await this.manager.isMessageExecuted(
+      Ntt.messageDigest(attestation.emitterChain, payload["nttManagerPayload"])
     );
+    if (!isExecuted) return false;
+    // Also check that the transfer is not queued for it to be considered complete
+    const queued = await this.getInboundQueuedTransfer(
+      attestation.emitterChain,
+      payload["nttManagerPayload"]
+    );
+    return queued === null;
   }
 
   getIsApproved(attestation: Ntt.Attestation): Promise<boolean> {
-    const { emitterChain: chain, payload } =
-      attestation as VAA<"Ntt:WormholeTransfer">;
+    const payload =
+      attestation.payloadName === "WormholeTransfer"
+        ? attestation.payload
+        : attestation.payload.payload;
     return this.manager.isMessageApproved(
-      Ntt.messageDigest(chain, payload["nttManagerPayload"])
+      Ntt.messageDigest(attestation.emitterChain, payload["nttManagerPayload"])
     );
   }
 
@@ -311,7 +320,13 @@ export class EvmNtt<N extends Network, C extends EvmChains>
 
     for (const idx in this.xcvrs) {
       const xcvr = this.xcvrs[idx]!;
-      yield* xcvr.receive(attestations[idx]);
+      const attestation = attestations[idx];
+      if (attestation?.payloadName !== "WormholeTransfer") {
+        // TODO: support standard relayer attestations
+        // which must be submitted to the delivery provider
+        throw new Error("Invalid attestation type for redeem");
+      }
+      yield* xcvr.receive(attestation);
     }
   }
 
@@ -349,7 +364,6 @@ export class EvmNtt<N extends Network, C extends EvmChains>
   async *completeInboundQueuedTransfer(
     fromChain: Chain,
     transceiverMessage: Ntt.Message,
-    token: TokenAddress<C>,
     payer?: AccountAddress<C>
   ) {
     const tx = await this.manager.completeInboundQueuedTransfer(

--- a/evm/ts/src/ntt.ts
+++ b/evm/ts/src/ntt.ts
@@ -151,11 +151,22 @@ export class EvmNtt<N extends Network, C extends EvmChains>
     );
     if (!isExecuted) return false;
     // Also check that the transfer is not queued for it to be considered complete
-    const queued = await this.getInboundQueuedTransfer(
-      attestation.emitterChain,
-      payload["nttManagerPayload"]
+    return !(await this.getIsTransferInboundQueued(attestation));
+  }
+
+  async getIsTransferInboundQueued(
+    attestation: Ntt.Attestation
+  ): Promise<boolean> {
+    const payload =
+      attestation.payloadName === "WormholeTransfer"
+        ? attestation.payload
+        : attestation.payload.payload;
+    return (
+      (await this.getInboundQueuedTransfer(
+        attestation.emitterChain,
+        payload["nttManagerPayload"]
+      )) !== null
     );
-    return queued === null;
   }
 
   getIsApproved(attestation: Ntt.Attestation): Promise<boolean> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@solana/web3.js": "1.91.7",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.2",
-        "@wormhole-foundation/sdk": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk": "0.8.0-beta.2",
         "@wormhole-foundation/wormchain-sdk": "^0.0.1",
         "ethers": "^6.5.1",
         "ts-jest": "^29.1.2",
@@ -79,11 +79,11 @@
       "version": "0.1.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-        "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.2",
         "ethers": "^6.5.1"
       },
       "devDependencies": {
@@ -95,11 +95,11 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-        "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.2"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -3660,17 +3660,17 @@
       "dev": true
     },
     "node_modules/@volar/language-core": {
-      "version": "2.4.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.0-alpha.15.tgz",
-      "integrity": "sha512-mt8z4Fm2WxfQYoQHPcKVjLQV6PgPqyKLbkCVY2cr5RSaamqCHjhKEpsFX66aL4D/7oYguuaUw9Bx03Vt0TpIIA==",
+      "version": "2.4.0-alpha.16",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.0-alpha.16.tgz",
+      "integrity": "sha512-oOTnIZlx0P/idFwVw+W0NbzKDtZAQMzXSdIFfTePCKcXlb4Ys12GaGkx8NF9dsvPYV3nbv3ZsSxnkZWBmNKd7A==",
       "dependencies": {
-        "@volar/source-map": "2.4.0-alpha.15"
+        "@volar/source-map": "2.4.0-alpha.16"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "2.4.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.0-alpha.15.tgz",
-      "integrity": "sha512-8Htngw5TmBY4L3ClDqBGyfLhsB8EmoEXUH1xydyEtEoK0O6NX5ur4Jw8jgvscTlwzizyl/wsN1vn0cQXVbbXYg=="
+      "version": "2.4.0-alpha.16",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.0-alpha.16.tgz",
+      "integrity": "sha512-sL9vNG7iR2hiKZor7UkD5Sufu3QCia4cbp2gX/nGRNSdaPbhOpdAoavwlBm0PrVkpiA19NZuavZoobD8krviFg=="
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.4.31",
@@ -3744,46 +3744,46 @@
       "integrity": "sha512-Yp3wtJk//8cO4NItOPpi3QkLExAr/aLBGZMmTtW9WpdwBCJpRM6zj9WgWktXAl8IDIozwNMByT45JP3tO3ACWA=="
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-0.8.0-beta.0.tgz",
-      "integrity": "sha512-xLCsUZ48W+qQRSEGqaMZCusrDoaJAiRYgyXAsKUAU/GJKRt2WwCUihUvc40XlEHDnrwzlhnvXNM6RMFT+A/fXg==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-0.8.0-beta.2.tgz",
+      "integrity": "sha512-GHgwJhXlQnw3/kiZvgVIqMU04P3s2Hh/FeDw1DPN2FebcNJ2SqVM9bfJ9ab3suRvLJgnUvrGt8QjIVxn6mTv/g==",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-algorand-core": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-aptos": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-aptos-core": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-evm-cctp": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-evm-portico": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-solana": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-solana-cctp": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-sui": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-sui-core": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-algorand": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-algorand-core": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-aptos": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-aptos-core": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-cosmwasm-core": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-evm-cctp": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-evm-portico": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-solana": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-solana-cctp": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-sui": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-sui-core": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "0.8.0-beta.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-0.8.0-beta.0.tgz",
-      "integrity": "sha512-kS4gXxrQEZJdkmA9j522f/EqTESOgYnV4lVysuKjprDmNjJ5jgJetnAarnPjr1AHJAiu/qbm5BLjuO64IcOxuQ==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-0.8.0-beta.2.tgz",
+      "integrity": "sha512-dR++vX8E79eSyDaWKRY3TUWDzqPg5cujFnaAuFX6e8yNtWIDS22//8F7c8DdRXSKXziH+bzufQUfH5JnVTLgqA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -3791,36 +3791,36 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-0.8.0-beta.0.tgz",
-      "integrity": "sha512-2W+FPm849XCyBBNi5MXx73shJBRYqVlOmkUwWTmq6ABPS0G34DWrwvkd6y9UseuNBZ5WVJ89fyMEMm497NQbMg==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-0.8.0-beta.2.tgz",
+      "integrity": "sha512-+V62PlCP5k9hi8adV3in/ARxG5rA1NMAWAPbj9QkimPifhXznNAP/ml4MM6KzGMFbCjM6GHsbDBQaew8GYXGGA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-algorand": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-0.8.0-beta.0.tgz",
-      "integrity": "sha512-xeI6PRMxiazCGxpZfCupycME/nbOXsxZBfJs30G9LUFlz6sh4JeXQBM0X5rdTNizh1lchfNl90ag095BnN28SA==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-0.8.0-beta.2.tgz",
+      "integrity": "sha512-dCxCfBTV1QcwZ9ibS3WLoEVIse6856axmTMloPhEjNZAwtMfWQo4lWfSd7OfxFeQmkb5IkEn49K8D+NYty3hIA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-algorand-core": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-algorand": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-algorand-core": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-0.8.0-beta.0.tgz",
-      "integrity": "sha512-AyeqR9aQ99TmLlOxHxZSkHcWdcVDIdXhWxTw3k7pEcsA5tqW3+dEw/d66OOgA7unYd2m3S8qrVAZftTalcWR4A==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-0.8.0-beta.2.tgz",
+      "integrity": "sha512-uEd+C5sb0pLP3Tfxb6/3cSTieuaftYe9xNSoLHhe0GvFry/0eqGqK56Ld8cUv1HRKB02j/saMLmriMbseoTeeQ==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
         "aptos": "1.21.0"
       },
       "engines": {
@@ -3828,44 +3828,44 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-0.8.0-beta.0.tgz",
-      "integrity": "sha512-z1jS1mbJRy/Mp3Eu4g8gd49DGg/g6SwP2fChhWHctgjtyo+pA+yMa6U+jIDEsJcTukiJlCuho13412liWu8NBw==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-0.8.0-beta.2.tgz",
+      "integrity": "sha512-I+1OU7nrFOdscNOM0TI3DhkJtRyEoqNPxlVAeRLck3YAD2hQjevYRG+wV7Ml56TKnw3khlhoRBn0zn2eRstcvA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-aptos": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-0.8.0-beta.0.tgz",
-      "integrity": "sha512-DBWWP6rL1J1iJpLcndTrHf8oEUmeOzNVoQd5ING+oWuoGHe2TaE472ISMXVViHSpoGWfRUOMtHLhLjD83sq0wQ==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-0.8.0-beta.2.tgz",
+      "integrity": "sha512-23+BqV8F4rwiq0Prti99rSutbLZb8YX5qBX2h+kEiN60+ZEyloEPAW0oX1bgoKI/pj9gxoEwBXAs0Q2qD56hMg==",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-aptos": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.8.0-beta.0.tgz",
-      "integrity": "sha512-TqfeJkqC+sYpA98Bi31my7gGxf+IfTi54bF3+dEYge2CF/XqYfO7NZs/f4RrLxO24DQEC2Lbwp+Vx/RA7fPA9g==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.8.0-beta.2.tgz",
+      "integrity": "sha512-zNjno8W5MqGvdtILmvjs71Qi2BUHnz0wLSLZBOUMlhpVO65CiBv/g7X9/nyHSY6X29kI5J4skBZ12RmJYfQKWg==",
       "dependencies": {
         "@scure/base": "^1.1.3"
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-0.8.0-beta.0.tgz",
-      "integrity": "sha512-Kok90Jz2WnvyqaylO8b6nYyhyv6w5QSOL/agX1VU8cDv1Dlv4i1QnzPntOpmAelQKfr34gefZwUUUHdQhMauhA==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-0.8.0-beta.2.tgz",
+      "integrity": "sha512-6nIB7l5SjHoeHbIeZoB1mAq8KPdMRRlWEx0wG/m2MIJ2PFZR9MyC+nKiNgZSes1Xe3NgvPr8gG7jR487c9teFw==",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -3873,15 +3873,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-0.8.0-beta.0.tgz",
-      "integrity": "sha512-n/pSDrK9Rq8O+tNLbpTWiXEbjGj0lBYvggy+ZwU5MpUCcMQQZ6Fy/SKdxVJoFDSX2P2gVo4tSiT2Mg7LshDNwg==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-0.8.0-beta.2.tgz",
+      "integrity": "sha512-vLKwaRO607njvBCJC3Aj3A5TjGjl6USniA2+pawp2YZaPjMkTXpAyxyjOTJE/FPkogTSzbhFOXGqx17zrgE1Wg==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -3889,31 +3889,31 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-0.8.0-beta.0.tgz",
-      "integrity": "sha512-+/DOTaVX8C4EHdQ8r9N9ouYnbTGks8PQS3mSYj//g+rqpNGFR9n2OiWpNE95ixUhhlAfYmI75hU0UGxNDp2uNA==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-0.8.0-beta.2.tgz",
+      "integrity": "sha512-Hk+CVP5TKIeDXMGfUaQk4O/6jsq76F0lPFS1znnLiDldt6uks5sWNpq2vSXH6wx3Mrb2EuKyhkbgwAIhy6Av3w==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-0.8.0-beta.0.tgz",
-      "integrity": "sha512-CfcMF1AEAJhSU7OBJR4adRhWs5PLvN1dSgV6s70lTgTDIlwTN0tC2PaT9kr/dWY5GTmUzbrYnj1IItPGWsuLIA==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-0.8.0-beta.2.tgz",
+      "integrity": "sha512-ZkOprx330UcwmsVqdcUf9KJYtQxvCl+/3d08XTIgocm5tpY6rkNB34nsN+lR4Xlyp0Je+n7Mzjio9gdxZyeByA==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-cosmwasm-core": "0.8.0-beta.2",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -3921,27 +3921,27 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-0.8.0-beta.0.tgz",
-      "integrity": "sha512-u3rj6mkYoMxmyucwmJIUxQjqAWMmOREfaAaAh/kUKr4/8xzVaE9QP3CUgLouwhdopXEE/XCmLKc81lHrVLpvdA==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-0.8.0-beta.2.tgz",
+      "integrity": "sha512-8Ov+yrcY4KeBsTXZHR7LjkAaIA62UTuap4E0ASGmsR426HRxDMORm+D1/5/LbrSnY2HCZNhakVePEp/P+jVPRA==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.8.0-beta.0.tgz",
-      "integrity": "sha512-atAxOs04OQWIaQR149p5qYeSAYvBPcLl+tEI45w0KkkFVBuZeOfgCgDx5KOkbzFEuVnUlH29QC7TJouCj9Ijfg==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.8.0-beta.2.tgz",
+      "integrity": "sha512-0pWlAKXvGJzwliLprJRg112yNyZUmZZWEP1l8lWPoAkAy6c4N5HJBQNDr9zkeCMpollMkvB8ponX9sKxFkvooQ==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.2"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions-ntt": {
@@ -3949,11 +3949,11 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-0.8.0-beta.0.tgz",
-      "integrity": "sha512-9AXJku4UKQEcHhi9Hq1Qm/ybCuWh4kksBlSrvzWUQ4WKYberpgAvAJOp7tpi9XXefwPaHeKWyibfjIpvNkJCTA==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-0.8.0-beta.2.tgz",
+      "integrity": "sha512-TUwy64n7F0E3GV5LucFVkbfEABDD03mmhtZBLG/HydqoQBw6FDmb26b3cC3QB5xoQLK50B2obvR657KCUlSzyA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -3961,12 +3961,12 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-0.8.0-beta.0.tgz",
-      "integrity": "sha512-9hUJTGA3XtC9LDfb6I/u3nqoVqx4a6eqmM6KpxvU33efYRo+Zl1q1XcrZPg5HkLe+xKSsyr5RIyd5vlowUgjvw==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-0.8.0-beta.2.tgz",
+      "integrity": "sha512-LjGkih/ebPGel0gz/RI0kWYz6gAYuZSpZ/uhsKDX2vnzbX0bYB7JDAmCbyCbQsnYmQu+kxn1Ks39Gs1ssoCvRQ==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -3974,12 +3974,12 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-0.8.0-beta.0.tgz",
-      "integrity": "sha512-ybUzwEhEq4JumRRm6HeJUzh/7aE0V15a3dAOJXm+7CsjB1jbO+lfITKQApUGzf8gmFmU7AGWxTgincIZeoYEUA==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-0.8.0-beta.2.tgz",
+      "integrity": "sha512-bscd8FCzR7cJDwV22xs2KcjnnGeCpHVgUgeTdM/X0YNQNhcoSx5Co6NwuFQPdQij3mdCE5gKIAW2yO3v5r3IWw==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -3991,14 +3991,14 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-0.8.0-beta.0.tgz",
-      "integrity": "sha512-4J/9k50A13K78sbYRHcyt8ED+ofXfNccLzsLDdHGWWKlLk23fT+t9QUuN0jqYAjuosUE8vmMDjs4WY1+fuxm2g==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-0.8.0-beta.2.tgz",
+      "integrity": "sha512-DcIq7f8eemKqMQjxxwtoSVjmSZxtC7LJqExta4hhKiARBjJ7E///1tTtK2Q8fJ7Sag+XmWejiVPXyE6XoQ7YgQ==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "0.8.0-beta.2",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4006,13 +4006,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-0.8.0-beta.0.tgz",
-      "integrity": "sha512-/p9QgCC3eQjvLzvBfot3oNBY/SkqbkxRlN9wfxKtP3GgJ84XVdktROc0xEKWx3HewB3cMY5HM8C7oYx/Q2Hixg==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-0.8.0-beta.2.tgz",
+      "integrity": "sha512-lllBZ+jXWzPd3gSew0G8kL0/cAOHaxQG9WouorE4PPo2UfBdqQLX4bNmFaey7XxtPMlnI4mXmzoO5SaaeAloNA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.2",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4028,45 +4028,45 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-0.8.0-beta.0.tgz",
-      "integrity": "sha512-7JKukYou8EkDGbBYnrpIZhHW3wSTnFTAZXZ9HauxK1QI22ICZJ1wT0GYcnF70uwLE9HLSfXgFktwarWhzDNQNw==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-0.8.0-beta.2.tgz",
+      "integrity": "sha512-CY3kWA2ZkTHIAZeXfsehZsuzTqIXkXFax+aY4nW0ggg4MEG0LCKKqXPHN56tMYFHUiE6OXbsncVbNh7PHUKb6A==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-0.8.0-beta.0.tgz",
-      "integrity": "sha512-PBYuqkgoQfOZ+31lglYK+iWpoeJ063I9zlY9CaG1EqeoMEi9mpnIg8kTo/vxVrXjR1Hu/J9tnKEWrqvEjhAtRw==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-0.8.0-beta.2.tgz",
+      "integrity": "sha512-m1OFjguFZiITg1p73BCNbpTXTujA4jqAfWKa9/Ak1hMmEQmOnaMD5/C7jPzp0+xyUSk4l68vdM3h806SIIyGfA==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-solana": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-solana": "0.8.0-beta.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-0.8.0-beta.0.tgz",
-      "integrity": "sha512-qRWbMLla6X6MZ1b73jSZOtWRqhyADigeYSGLMB2P9fz/0ishXQmH+t0kfxoIbT8wxa7EEUgrVoK+0HcJoj/xyw==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-0.8.0-beta.2.tgz",
+      "integrity": "sha512-EALjU7i5TT0bV8imrd6fhyrJPE4l9pOvUH2P/eZbm9gjeZnrKvauzuQHVCrCpxXBL8HEXtoT2FyUPursjZbY/g==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-solana": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-solana": "0.8.0-beta.2"
       },
       "engines": {
         "node": ">=16"
@@ -4077,55 +4077,55 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-0.8.0-beta.0.tgz",
-      "integrity": "sha512-fclEsrtrCKxv6P89FegTTIc8hqpUr2+lMPbchSebBqjjzG+oqf5umwnQ8KlZRcEIc+9H8WEoIRrXQt2sRgekSg==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-0.8.0-beta.2.tgz",
+      "integrity": "sha512-tPHC0oyUWA/kAcKu1SCTFboO4ArBtCJbXjD73X/Oi9oizpD0ytNrpaBIBth6KiKFEoO7n6wXdqAw4pJ0nQpYXg==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-solana": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-solana": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-0.8.0-beta.0.tgz",
-      "integrity": "sha512-mQ+cpDjQdPlGLv3yNtsqPO+K66CXZxYA6YSMv6Yh9brsNKAKk80/3cvPjLjs0e0NlnCDFtyflCsKG9qcTpLHCw==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-0.8.0-beta.2.tgz",
+      "integrity": "sha512-XeI9U7dB9xT+eGV4j1cajQetyxsxQccJ/gzwZFLHmYhx9OueFh3eZNgXTh39EVJgOh1VSg6vwta5vh4IEXFgzA==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-0.8.0-beta.0.tgz",
-      "integrity": "sha512-DRFyhHnn3bN30m3PRVQiUGkOCPZyBrd39TZ6NqRFcLLhH7vHyj60YOoI90Gzp5tH0hHN7Zvh13z8RYI6NUeR3Q==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-0.8.0-beta.2.tgz",
+      "integrity": "sha512-82hxSXc0ZIn3XjTmaHeRqE9Vz+HEuhu3LFCN851lRpyL8ax8Xpw2ITO59sr36+/suv8zsh5Z4GdRzgrQyTeS8w==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-sui": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-sui": "0.8.0-beta.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-0.8.0-beta.0.tgz",
-      "integrity": "sha512-MJuWWC93HDkXajjl40xfckw/tyVO7UWtsH6bpaLSI3Hi0PBzf3mlnTqqv3ZnIbXD9W0n+J3dFatTOR7wo2/MMQ==",
+      "version": "0.8.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-0.8.0-beta.2.tgz",
+      "integrity": "sha512-x+3auoKbx5cmJPV8rzjYN7iJYzmIpm/W1EqBdVW9x+lcBqqhVcKSsymUj01uwTsZNJDEUBEFX2ELkiFToBvvQA==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-sui": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-sui-core": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-sui": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-sui-core": "0.8.0-beta.2"
       },
       "engines": {
         "node": ">=16"
@@ -5948,12 +5948,12 @@
       }
     },
     "node_modules/axobject-query": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.0.0.tgz",
-      "integrity": "sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "peer": true,
-      "dependencies": {
-        "dequal": "^2.0.3"
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/babel-jest": {
@@ -12965,12 +12965,12 @@
       "name": "@wormhole-foundation/sdk-definitions-ntt",
       "version": "0.1.0-beta.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2"
       }
     },
     "sdk/evm": {
@@ -12999,7 +12999,7 @@
       "version": "0.1.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk": "0.8.0-beta.2",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-route-ntt": "0.1.0-beta.0",
@@ -13032,7 +13032,7 @@
       "version": "0.1.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0"
@@ -13046,6 +13046,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0"
@@ -13060,10 +13061,10 @@
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.4.0",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-solana": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-solana": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.2",
         "bn.js": "5.2.1"
       },
       "devDependencies": {
@@ -13077,11 +13078,11 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-        "@wormhole-foundation/sdk-solana": "0.8.0-beta.0",
-        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.0"
+        "@wormhole-foundation/sdk-solana": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.2"
       }
     },
     "solana/node_modules/@solana/codecs-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@solana/web3.js": "1.91.7",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.2",
-        "@wormhole-foundation/sdk": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk": "^0.8",
         "@wormhole-foundation/wormchain-sdk": "^0.0.1",
         "ethers": "^6.5.1",
         "ts-jest": "^29.1.2",
@@ -79,11 +79,11 @@
       "version": "0.1.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-base": "^0.8",
+        "@wormhole-foundation/sdk-definitions": "^0.8",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-        "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-evm": "^0.8",
+        "@wormhole-foundation/sdk-evm-core": "^0.8",
         "ethers": "^6.5.1"
       },
       "devDependencies": {
@@ -95,11 +95,11 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-base": "^0.8",
+        "@wormhole-foundation/sdk-definitions": "^0.8",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-        "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-evm": "^0.8",
+        "@wormhole-foundation/sdk-evm-core": "^0.8"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -3673,24 +3673,24 @@
       "integrity": "sha512-sL9vNG7iR2hiKZor7UkD5Sufu3QCia4cbp2gX/nGRNSdaPbhOpdAoavwlBm0PrVkpiA19NZuavZoobD8krviFg=="
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.31",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.31.tgz",
-      "integrity": "sha512-skOiodXWTV3DxfDhB4rOf3OGalpITLlgCeOwb+Y9GJpfQ8ErigdBUHomBzvG78JoVE8MJoQsb+qhZiHfKeNeEg==",
+      "version": "3.4.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.32.tgz",
+      "integrity": "sha512-8tCVWkkLe/QCWIsrIvExUGnhYCAOroUs5dzhSoKL5w4MJS8uIYiou+pOPSVIOALOQ80B0jBs+Ri+kd5+MBnCDw==",
       "dependencies": {
         "@babel/parser": "^7.24.7",
-        "@vue/shared": "3.4.31",
+        "@vue/shared": "3.4.32",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.31",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.31.tgz",
-      "integrity": "sha512-wK424WMXsG1IGMyDGyLqB+TbmEBFM78hIsOJ9QwUVLGrcSk0ak6zYty7Pj8ftm7nEtdU/DGQxAXp0/lM/2cEpQ==",
+      "version": "3.4.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.32.tgz",
+      "integrity": "sha512-PbSgt9KuYo4fyb90dynuPc0XFTfFPs3sCTbPLOLlo+PrUESW1gn/NjSsUvhR+mI2AmmEzexwYMxbHDldxSOr2A==",
       "dependencies": {
-        "@vue/compiler-core": "3.4.31",
-        "@vue/shared": "3.4.31"
+        "@vue/compiler-core": "3.4.32",
+        "@vue/shared": "3.4.32"
       }
     },
     "node_modules/@vue/language-core": {
@@ -3739,51 +3739,51 @@
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.4.31",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.31.tgz",
-      "integrity": "sha512-Yp3wtJk//8cO4NItOPpi3QkLExAr/aLBGZMmTtW9WpdwBCJpRM6zj9WgWktXAl8IDIozwNMByT45JP3tO3ACWA=="
+      "version": "3.4.32",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.32.tgz",
+      "integrity": "sha512-ep4mF1IVnX/pYaNwxwOpJHyBtOMKWoKZMbnUyd+z0udqIxLUh7YCCd/JfDna8aUrmnG9SFORyIq2HzEATRrQsg=="
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-0.8.0-beta.2.tgz",
-      "integrity": "sha512-GHgwJhXlQnw3/kiZvgVIqMU04P3s2Hh/FeDw1DPN2FebcNJ2SqVM9bfJ9ab3suRvLJgnUvrGt8QjIVxn6mTv/g==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-0.8.0.tgz",
+      "integrity": "sha512-3FjCtPUWzpT00wAWGe0OToZihg0eGcY0RX7X03XOGB5ZZW6u9isR9x1OyOBH+J6jBORy/uIyekM6Ot5oCHKTfA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-algorand-core": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-aptos": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-aptos-core": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-cosmwasm-core": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-evm-cctp": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-evm-portico": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-solana": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-solana-cctp": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-sui": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-sui-core": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-algorand": "0.8.0",
+        "@wormhole-foundation/sdk-algorand-core": "0.8.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "0.8.0",
+        "@wormhole-foundation/sdk-aptos": "0.8.0",
+        "@wormhole-foundation/sdk-aptos-core": "0.8.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "0.8.0",
+        "@wormhole-foundation/sdk-base": "0.8.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0",
+        "@wormhole-foundation/sdk-cosmwasm": "0.8.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "0.8.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "0.8.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "0.8.0",
+        "@wormhole-foundation/sdk-definitions": "0.8.0",
+        "@wormhole-foundation/sdk-evm": "0.8.0",
+        "@wormhole-foundation/sdk-evm-cctp": "0.8.0",
+        "@wormhole-foundation/sdk-evm-core": "0.8.0",
+        "@wormhole-foundation/sdk-evm-portico": "0.8.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "0.8.0",
+        "@wormhole-foundation/sdk-solana": "0.8.0",
+        "@wormhole-foundation/sdk-solana-cctp": "0.8.0",
+        "@wormhole-foundation/sdk-solana-core": "0.8.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "0.8.0",
+        "@wormhole-foundation/sdk-sui": "0.8.0",
+        "@wormhole-foundation/sdk-sui-core": "0.8.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "0.8.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-0.8.0-beta.2.tgz",
-      "integrity": "sha512-dR++vX8E79eSyDaWKRY3TUWDzqPg5cujFnaAuFX6e8yNtWIDS22//8F7c8DdRXSKXziH+bzufQUfH5JnVTLgqA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-0.8.0.tgz",
+      "integrity": "sha512-kGJw/0xlJ2a+DcXvirizSA2pQ2VH0SLAPCSTWToLjQIW7jT5Q+JLA1uU9fmgKJanS4aroBpIxFmH6Cs5iQZ++Q==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -3791,36 +3791,36 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-0.8.0-beta.2.tgz",
-      "integrity": "sha512-+V62PlCP5k9hi8adV3in/ARxG5rA1NMAWAPbj9QkimPifhXznNAP/ml4MM6KzGMFbCjM6GHsbDBQaew8GYXGGA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-0.8.0.tgz",
+      "integrity": "sha512-zcsd7ClJSkb8A9VbjAX6WmC31sOuIZzqrbCu5r/+ze+05qONYWR5CxR87XqkVDxQF3LVaeSRRXRytfY0wdUqsg==",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-algorand": "0.8.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-0.8.0-beta.2.tgz",
-      "integrity": "sha512-dCxCfBTV1QcwZ9ibS3WLoEVIse6856axmTMloPhEjNZAwtMfWQo4lWfSd7OfxFeQmkb5IkEn49K8D+NYty3hIA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-0.8.0.tgz",
+      "integrity": "sha512-bSUQN86uUEOjC9A9eWIEcdq/4tfr9HpLdHt4n02Q7FhWHA2jY7hK5OywfpXuxRIiJ51npC0FtyC4Fl3X0zG9sA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-algorand-core": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-algorand": "0.8.0",
+        "@wormhole-foundation/sdk-algorand-core": "0.8.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-0.8.0-beta.2.tgz",
-      "integrity": "sha512-uEd+C5sb0pLP3Tfxb6/3cSTieuaftYe9xNSoLHhe0GvFry/0eqGqK56Ld8cUv1HRKB02j/saMLmriMbseoTeeQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-0.8.0.tgz",
+      "integrity": "sha512-+XL5lguBv89BZUfta5X+CK90HTM6issHjT6Qa44AL9Lut64FxIetYUTeOISKPj2oJADTx2R/FTqxtVAgMS+jdQ==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0",
         "aptos": "1.21.0"
       },
       "engines": {
@@ -3828,44 +3828,44 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-0.8.0-beta.2.tgz",
-      "integrity": "sha512-I+1OU7nrFOdscNOM0TI3DhkJtRyEoqNPxlVAeRLck3YAD2hQjevYRG+wV7Ml56TKnw3khlhoRBn0zn2eRstcvA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-0.8.0.tgz",
+      "integrity": "sha512-7YF9I9kiA+hRxSEOFT79YAp/J7fTdGwGRBuDvh9MlzcMCEzRSz0KT1ox2SYg8pTCRELcROBT4oCvACP6hZNcXA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-aptos": "0.8.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-0.8.0-beta.2.tgz",
-      "integrity": "sha512-23+BqV8F4rwiq0Prti99rSutbLZb8YX5qBX2h+kEiN60+ZEyloEPAW0oX1bgoKI/pj9gxoEwBXAs0Q2qD56hMg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-0.8.0.tgz",
+      "integrity": "sha512-wO3fKeNEVmRMev1HlxklFh836ZY7HSy/SIJW8X5FfaxMdxGx63dBNPW2R69aOV6gIgfs6cv03bR583V/oL9tWw==",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-aptos": "0.8.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.8.0-beta.2.tgz",
-      "integrity": "sha512-zNjno8W5MqGvdtILmvjs71Qi2BUHnz0wLSLZBOUMlhpVO65CiBv/g7X9/nyHSY6X29kI5J4skBZ12RmJYfQKWg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.8.0.tgz",
+      "integrity": "sha512-c9Le/M4wHWk/f2UGR2Fnm7+VZDjCtGYaAs4G9HthqbrBKtQHpDV59teUiM5vgi8kvF+3sL7amzjivCxP8OtcRQ==",
       "dependencies": {
         "@scure/base": "^1.1.3"
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-0.8.0-beta.2.tgz",
-      "integrity": "sha512-6nIB7l5SjHoeHbIeZoB1mAq8KPdMRRlWEx0wG/m2MIJ2PFZR9MyC+nKiNgZSes1Xe3NgvPr8gG7jR487c9teFw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-0.8.0.tgz",
+      "integrity": "sha512-xxkYgVwNuUbu59hih3ogZmy4l1/M405dPi9U/YBHmtX0dUkj7UyQ03s90hVwcjn8SlNRg3iWNGNLicEkNoy+BQ==",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-base": "0.8.0",
+        "@wormhole-foundation/sdk-definitions": "0.8.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -3873,15 +3873,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-0.8.0-beta.2.tgz",
-      "integrity": "sha512-vLKwaRO607njvBCJC3Aj3A5TjGjl6USniA2+pawp2YZaPjMkTXpAyxyjOTJE/FPkogTSzbhFOXGqx17zrgE1Wg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-0.8.0.tgz",
+      "integrity": "sha512-2g5Q45D3J3JPDG0/Y8+Vb3cRnyqEMyT3aQWX08n6L44pHvqj4dsKaOWJyT0xO0MpNhjRxfcU2BTjSegxg92cUw==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -3889,31 +3889,31 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-0.8.0-beta.2.tgz",
-      "integrity": "sha512-Hk+CVP5TKIeDXMGfUaQk4O/6jsq76F0lPFS1znnLiDldt6uks5sWNpq2vSXH6wx3Mrb2EuKyhkbgwAIhy6Av3w==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-0.8.0.tgz",
+      "integrity": "sha512-+a+fthZeNlyKxDjShHa6EuKbbl+yc3q1sk1i62Rnia7ER7ApEVHicAv72pkCiMxa6A6Wrx86i2+cdXCBSYgo4g==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0",
+        "@wormhole-foundation/sdk-cosmwasm": "0.8.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-0.8.0-beta.2.tgz",
-      "integrity": "sha512-ZkOprx330UcwmsVqdcUf9KJYtQxvCl+/3d08XTIgocm5tpY6rkNB34nsN+lR4Xlyp0Je+n7Mzjio9gdxZyeByA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-0.8.0.tgz",
+      "integrity": "sha512-bUyakI+DDCAHUpPM4QBq/DODDWo/SWeskmouEJ3p2j2z6rLZXpfMVMtO1a1TquTyImO5iG2FHPzj8RniEq2CLQ==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-cosmwasm-core": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0",
+        "@wormhole-foundation/sdk-cosmwasm": "0.8.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "0.8.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -3921,27 +3921,27 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-0.8.0-beta.2.tgz",
-      "integrity": "sha512-8Ov+yrcY4KeBsTXZHR7LjkAaIA62UTuap4E0ASGmsR426HRxDMORm+D1/5/LbrSnY2HCZNhakVePEp/P+jVPRA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-0.8.0.tgz",
+      "integrity": "sha512-HuU28jbhXp4UPub/bldAtFhz3+YfSz6lnK0FslZ0LSU9C4jyrtnVVskXvyQFM8YySVXafOUd395pQxrX5CRi8w==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0",
+        "@wormhole-foundation/sdk-cosmwasm": "0.8.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.8.0-beta.2.tgz",
-      "integrity": "sha512-0pWlAKXvGJzwliLprJRg112yNyZUmZZWEP1l8lWPoAkAy6c4N5HJBQNDr9zkeCMpollMkvB8ponX9sKxFkvooQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.8.0.tgz",
+      "integrity": "sha512-9avbCMfaaWO2Ldtk5gMDBO6+0CLshWwI83tfW+6/cizHgPXhwLquNietY+bED1kHaLivbCVhkS6drBJKNqa+cQ==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-base": "0.8.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions-ntt": {
@@ -3949,11 +3949,11 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-0.8.0-beta.2.tgz",
-      "integrity": "sha512-TUwy64n7F0E3GV5LucFVkbfEABDD03mmhtZBLG/HydqoQBw6FDmb26b3cC3QB5xoQLK50B2obvR657KCUlSzyA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-0.8.0.tgz",
+      "integrity": "sha512-owmc9esfX26I+EIKXMSy0VXSIk6iy9K0jATTkqtdxHV9IgoOKuxfYWtoxmx5jvFDKNURGB2HPk8280ZuyObdwQ==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -3961,12 +3961,12 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-0.8.0-beta.2.tgz",
-      "integrity": "sha512-LjGkih/ebPGel0gz/RI0kWYz6gAYuZSpZ/uhsKDX2vnzbX0bYB7JDAmCbyCbQsnYmQu+kxn1Ks39Gs1ssoCvRQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-0.8.0.tgz",
+      "integrity": "sha512-uAGI+0Jq58xyhLwYKxhmNF4pkIt7jDILkhkdT8Z2AxBj8sGOwJzuA6aLc0YqS5Nw54wN/LfA/bHx7/nf82EgZA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0",
+        "@wormhole-foundation/sdk-evm": "0.8.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -3974,12 +3974,12 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-0.8.0-beta.2.tgz",
-      "integrity": "sha512-bscd8FCzR7cJDwV22xs2KcjnnGeCpHVgUgeTdM/X0YNQNhcoSx5Co6NwuFQPdQij3mdCE5gKIAW2yO3v5r3IWw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-0.8.0.tgz",
+      "integrity": "sha512-UeJTKrM/zMW0mg7H5t1lUtuc3bvR4k8V42PvIWOZJ/BlcgRlx80XXB8j4b37JfWGnDB5A3o+jQx97nx+IMsiXw==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0",
+        "@wormhole-foundation/sdk-evm": "0.8.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -3991,14 +3991,14 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-0.8.0-beta.2.tgz",
-      "integrity": "sha512-DcIq7f8eemKqMQjxxwtoSVjmSZxtC7LJqExta4hhKiARBjJ7E///1tTtK2Q8fJ7Sag+XmWejiVPXyE6XoQ7YgQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-0.8.0.tgz",
+      "integrity": "sha512-Z8lDRmmhD5pDIrvKnnOYMQn3+t5sjoDVE+DYIcmT/DIe1wCPtgVbo+cqAn5hAdUj39GAVE3+FpoCRoevDZEMpQ==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0",
+        "@wormhole-foundation/sdk-evm": "0.8.0",
+        "@wormhole-foundation/sdk-evm-core": "0.8.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "0.8.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4006,13 +4006,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-0.8.0-beta.2.tgz",
-      "integrity": "sha512-lllBZ+jXWzPd3gSew0G8kL0/cAOHaxQG9WouorE4PPo2UfBdqQLX4bNmFaey7XxtPMlnI4mXmzoO5SaaeAloNA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-0.8.0.tgz",
+      "integrity": "sha512-1HPX1nmM2diiohlAlu2lf7pN90MZlgTAs1yadZzf4EaNgwLigTMc8QGnwAc+sjH1xFUBNouop2rQhaCK4rW+eQ==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-evm": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0",
+        "@wormhole-foundation/sdk-evm": "0.8.0",
+        "@wormhole-foundation/sdk-evm-core": "0.8.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4028,45 +4028,45 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-0.8.0-beta.2.tgz",
-      "integrity": "sha512-CY3kWA2ZkTHIAZeXfsehZsuzTqIXkXFax+aY4nW0ggg4MEG0LCKKqXPHN56tMYFHUiE6OXbsncVbNh7PHUKb6A==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-0.8.0.tgz",
+      "integrity": "sha512-Z0hr3vEGR3SmsMWjjWVCubJ6K2pV12AICQ9Sao5VhbaGe9Vic3RQHfyVkV68WZQHsjg2Sy+w6ecSvKcXz7N7dw==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-0.8.0-beta.2.tgz",
-      "integrity": "sha512-m1OFjguFZiITg1p73BCNbpTXTujA4jqAfWKa9/Ak1hMmEQmOnaMD5/C7jPzp0+xyUSk4l68vdM3h806SIIyGfA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-0.8.0.tgz",
+      "integrity": "sha512-aLffWyg7FUuGOT9gp3idpgsfBQIjci3aB3i5HUjrq7G9749luJpDNyADRh4oefsI7RMZ9wkPTDkL/Mhv0etPig==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-solana": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0",
+        "@wormhole-foundation/sdk-solana": "0.8.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-0.8.0-beta.2.tgz",
-      "integrity": "sha512-EALjU7i5TT0bV8imrd6fhyrJPE4l9pOvUH2P/eZbm9gjeZnrKvauzuQHVCrCpxXBL8HEXtoT2FyUPursjZbY/g==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-0.8.0.tgz",
+      "integrity": "sha512-aHWSNnNysogA82eyCYtpyvuYIQsdU7OKd5So+e454Poe0jVj4wFG4hXVA9Cgww1801EnhvR/yk86OjxecxwhDA==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-solana": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0",
+        "@wormhole-foundation/sdk-solana": "0.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -4077,55 +4077,55 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-0.8.0-beta.2.tgz",
-      "integrity": "sha512-tPHC0oyUWA/kAcKu1SCTFboO4ArBtCJbXjD73X/Oi9oizpD0ytNrpaBIBth6KiKFEoO7n6wXdqAw4pJ0nQpYXg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-0.8.0.tgz",
+      "integrity": "sha512-ei0Pvi7kLUgYZYiH1NGPdNamoDfEitUsjaurd7yqb0eEUS4orwOJZxjehuVyh/zQfQDivVozO8kDSA20SQp1Lw==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-solana": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0",
+        "@wormhole-foundation/sdk-solana": "0.8.0",
+        "@wormhole-foundation/sdk-solana-core": "0.8.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-0.8.0-beta.2.tgz",
-      "integrity": "sha512-XeI9U7dB9xT+eGV4j1cajQetyxsxQccJ/gzwZFLHmYhx9OueFh3eZNgXTh39EVJgOh1VSg6vwta5vh4IEXFgzA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-0.8.0.tgz",
+      "integrity": "sha512-aHoVGA8OCJd7CsGvgRRGiq6YdphwBlSjYJ9M6UgGcwk1Jh3QaGQ40fS5ZeIW+XH13msyi7zinLev8N3ZddIaAg==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-0.8.0-beta.2.tgz",
-      "integrity": "sha512-82hxSXc0ZIn3XjTmaHeRqE9Vz+HEuhu3LFCN851lRpyL8ax8Xpw2ITO59sr36+/suv8zsh5Z4GdRzgrQyTeS8w==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-0.8.0.tgz",
+      "integrity": "sha512-UBM06CtbKFHcLiv+oBYfuxFF5sk+bkgK0oQhZ7qebskGE6WK14OR08Npn0p8N/61NNDm2KYeP2fC2SeXiokt9Q==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-sui": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0",
+        "@wormhole-foundation/sdk-sui": "0.8.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "0.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-0.8.0-beta.2.tgz",
-      "integrity": "sha512-x+3auoKbx5cmJPV8rzjYN7iJYzmIpm/W1EqBdVW9x+lcBqqhVcKSsymUj01uwTsZNJDEUBEFX2ELkiFToBvvQA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-0.8.0.tgz",
+      "integrity": "sha512-uzqUmrm7xJ2qkf98iTf+hg4EtGHa83UpTAusbZJ1AJHErW/kWb+wRfJluUL1TtSSymbX3jOi0CIJTwCUSzCrmQ==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-sui": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-sui-core": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0",
+        "@wormhole-foundation/sdk-sui": "0.8.0",
+        "@wormhole-foundation/sdk-sui-core": "0.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -12965,12 +12965,12 @@
       "name": "@wormhole-foundation/sdk-definitions-ntt",
       "version": "0.1.0-beta.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-base": "^0.8",
+        "@wormhole-foundation/sdk-definitions": "^0.8"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-base": "^0.8",
+        "@wormhole-foundation/sdk-definitions": "^0.8"
       }
     },
     "sdk/evm": {
@@ -12999,7 +12999,7 @@
       "version": "0.1.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk": "^0.8",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-route-ntt": "0.1.0-beta.0",
@@ -13032,7 +13032,7 @@
       "version": "0.1.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "^0.8",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0"
@@ -13046,7 +13046,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-connect": "^0.8",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0"
@@ -13061,10 +13061,10 @@
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.4.0",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-solana": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-base": "^0.8",
+        "@wormhole-foundation/sdk-definitions": "^0.8",
+        "@wormhole-foundation/sdk-solana": "^0.8",
+        "@wormhole-foundation/sdk-solana-core": "^0.8",
         "bn.js": "5.2.1"
       },
       "devDependencies": {
@@ -13078,11 +13078,11 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
+        "@wormhole-foundation/sdk-base": "^0.8",
+        "@wormhole-foundation/sdk-definitions": "^0.8",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-        "@wormhole-foundation/sdk-solana": "0.8.0-beta.2",
-        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.2"
+        "@wormhole-foundation/sdk-solana": "^0.8",
+        "@wormhole-foundation/sdk-solana-core": "^0.8"
       }
     },
     "solana/node_modules/@solana/codecs-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@solana/web3.js": "1.91.7",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.2",
-        "@wormhole-foundation/sdk": "^0.7",
+        "@wormhole-foundation/sdk": "0.8.0-beta.0",
         "@wormhole-foundation/wormchain-sdk": "^0.0.1",
         "ethers": "^6.5.1",
         "ts-jest": "^29.1.2",
@@ -79,11 +79,11 @@
       "version": "0.1.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "^0.7",
-        "@wormhole-foundation/sdk-definitions": "^0.7",
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-        "@wormhole-foundation/sdk-evm": "^0.7",
-        "@wormhole-foundation/sdk-evm-core": "^0.7",
+        "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.0",
         "ethers": "^6.5.1"
       },
       "devDependencies": {
@@ -95,11 +95,11 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^0.7",
-        "@wormhole-foundation/sdk-definitions": "^0.7",
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-        "@wormhole-foundation/sdk-evm": "^0.7",
-        "@wormhole-foundation/sdk-evm-core": "^0.7"
+        "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -2299,12 +2299,12 @@
       }
     },
     "node_modules/@gql.tada/cli-utils": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.5.0.tgz",
-      "integrity": "sha512-BqbrcpKmE2FyM3tQgK3vzTIn1ghCOf+lH9MThPow7NbtS9K2+bH4u/1fPAhZMR1Zg5GExKsDvij+zLP64Ge6Ig==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.5.1.tgz",
+      "integrity": "sha512-JVLpoXLa4msrE7MHnmW/7fYnIl8dncLom8T/Ghsxu+Kz5iMGnzK2joJN5cZt4ewCAqfCV3HZZ0VH189OalGd9g==",
       "dependencies": {
         "@0no-co/graphqlsp": "^1.12.9",
-        "@gql.tada/internal": "1.0.3",
+        "@gql.tada/internal": "1.0.4",
         "@vue/compiler-dom": "^3.4.23",
         "@vue/language-core": "^2.0.17",
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
@@ -2317,9 +2317,9 @@
       }
     },
     "node_modules/@gql.tada/internal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.0.3.tgz",
-      "integrity": "sha512-n52/OjAkoPsX4ZyEufFBnncjnv0UrbXKs4OUG66db8gxtV5437EkLjI4MTAI1M6dsaj+VLi0unpraPPPbFR59A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.0.4.tgz",
+      "integrity": "sha512-tq0rgoqjhdVqKWEsbrkiX7Qpp5gA4/Br9r9TVBeh3WpJIcuGh5U48UjB4IOxtXBePZdX8E0oc07GjOid/P60Wg==",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5"
       },
@@ -3744,46 +3744,46 @@
       "integrity": "sha512-Yp3wtJk//8cO4NItOPpi3QkLExAr/aLBGZMmTtW9WpdwBCJpRM6zj9WgWktXAl8IDIozwNMByT45JP3tO3ACWA=="
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-0.7.2.tgz",
-      "integrity": "sha512-vrkPa2eM7dLHL4M5V2MjjmZivH9gxSq44wXfiHrJntqSAPmCuRwM4vlO/zWpUy1ev0FUZUkp7qBtTr2cSx6nCA==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-0.8.0-beta.0.tgz",
+      "integrity": "sha512-xLCsUZ48W+qQRSEGqaMZCusrDoaJAiRYgyXAsKUAU/GJKRt2WwCUihUvc40XlEHDnrwzlhnvXNM6RMFT+A/fXg==",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.7.2",
-        "@wormhole-foundation/sdk-algorand-core": "0.7.2",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "0.7.2",
-        "@wormhole-foundation/sdk-aptos": "0.7.2",
-        "@wormhole-foundation/sdk-aptos-core": "0.7.2",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "0.7.2",
-        "@wormhole-foundation/sdk-base": "0.7.2",
-        "@wormhole-foundation/sdk-connect": "0.7.2",
-        "@wormhole-foundation/sdk-cosmwasm": "0.7.2",
-        "@wormhole-foundation/sdk-cosmwasm-core": "0.7.2",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "0.7.2",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "0.7.2",
-        "@wormhole-foundation/sdk-definitions": "0.7.2",
-        "@wormhole-foundation/sdk-evm": "0.7.2",
-        "@wormhole-foundation/sdk-evm-cctp": "0.7.2",
-        "@wormhole-foundation/sdk-evm-core": "0.7.2",
-        "@wormhole-foundation/sdk-evm-portico": "0.7.2",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "0.7.2",
-        "@wormhole-foundation/sdk-solana": "0.7.2",
-        "@wormhole-foundation/sdk-solana-cctp": "0.7.2",
-        "@wormhole-foundation/sdk-solana-core": "0.7.2",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "0.7.2",
-        "@wormhole-foundation/sdk-sui": "0.7.2",
-        "@wormhole-foundation/sdk-sui-core": "0.7.2",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "0.7.2"
+        "@wormhole-foundation/sdk-algorand": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-algorand-core": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-aptos": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-aptos-core": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-evm-cctp": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-evm-portico": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-solana": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-solana-cctp": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-sui": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-sui-core": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "0.8.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-0.7.2.tgz",
-      "integrity": "sha512-8gEpeVcR5p8c7LQLSIPB8dD3okzIv4noB/MpXpq4wKfHpYc9qJ/z/QfS3r7Ngot4i3ngJ7zzU+bMZRBNdgZz/A==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-0.8.0-beta.0.tgz",
+      "integrity": "sha512-kS4gXxrQEZJdkmA9j522f/EqTESOgYnV4lVysuKjprDmNjJ5jgJetnAarnPjr1AHJAiu/qbm5BLjuO64IcOxuQ==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.7.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -3791,36 +3791,36 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-0.7.2.tgz",
-      "integrity": "sha512-YtpN6ZKkvZXjqNLL9kKh2eaxugWwz6AXxZa2Gt60ExFeqIrOMrI4ZpDZ0Cu8UlTxXwvfopH4yY5lhw6DP9tsCw==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2W+FPm849XCyBBNi5MXx73shJBRYqVlOmkUwWTmq6ABPS0G34DWrwvkd6y9UseuNBZ5WVJ89fyMEMm497NQbMg==",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.7.2",
-        "@wormhole-foundation/sdk-connect": "0.7.2"
+        "@wormhole-foundation/sdk-algorand": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-0.7.2.tgz",
-      "integrity": "sha512-nJ4OcLD2+1ZQ1+8NX+Sdjz9eF/r0X8QmOdDsOzoCZM5HXviEQdqJasNxtJAEOzu9gR847x/LOFiymcOYbqWOYA==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-0.8.0-beta.0.tgz",
+      "integrity": "sha512-xeI6PRMxiazCGxpZfCupycME/nbOXsxZBfJs30G9LUFlz6sh4JeXQBM0X5rdTNizh1lchfNl90ag095BnN28SA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.7.2",
-        "@wormhole-foundation/sdk-algorand-core": "0.7.2",
-        "@wormhole-foundation/sdk-connect": "0.7.2"
+        "@wormhole-foundation/sdk-algorand": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-algorand-core": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-0.7.2.tgz",
-      "integrity": "sha512-wN53KwPIVWb6Jg07jD2+nOavHMkgu++mkxQ02DyRrr/oxxxei1IWWRNyBoEiX7FtduLn9HCAVfOUGOB8N7gQGg==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-0.8.0-beta.0.tgz",
+      "integrity": "sha512-AyeqR9aQ99TmLlOxHxZSkHcWdcVDIdXhWxTw3k7pEcsA5tqW3+dEw/d66OOgA7unYd2m3S8qrVAZftTalcWR4A==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.7.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
         "aptos": "1.21.0"
       },
       "engines": {
@@ -3828,44 +3828,44 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-0.7.2.tgz",
-      "integrity": "sha512-0XO4mBHfFcHFbuZ22RNiZtAS8VGWbK0Toy27Diule7mogI3o/KT/HcGY7bPrA8S2KDAc8JD6Qo8wLk+DUgKDTg==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-0.8.0-beta.0.tgz",
+      "integrity": "sha512-z1jS1mbJRy/Mp3Eu4g8gd49DGg/g6SwP2fChhWHctgjtyo+pA+yMa6U+jIDEsJcTukiJlCuho13412liWu8NBw==",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "0.7.2",
-        "@wormhole-foundation/sdk-connect": "0.7.2"
+        "@wormhole-foundation/sdk-aptos": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-0.7.2.tgz",
-      "integrity": "sha512-R4YCJq0d+gdSXeKOcJ1LJ4USoIZ3nY2jRLtO1jobkX/M+gA/LGY92hSjLJef8rahNRca+eepdG9FBaVzH+aR4g==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-0.8.0-beta.0.tgz",
+      "integrity": "sha512-DBWWP6rL1J1iJpLcndTrHf8oEUmeOzNVoQd5ING+oWuoGHe2TaE472ISMXVViHSpoGWfRUOMtHLhLjD83sq0wQ==",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "0.7.2",
-        "@wormhole-foundation/sdk-connect": "0.7.2"
+        "@wormhole-foundation/sdk-aptos": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.7.2.tgz",
-      "integrity": "sha512-umPhwvEUOJJPQYzyLYDSnuKbdOBd0KH/7ZQDsxtrlKpQcm0AL4LU9k3tM+juCSLPQ6VU0EnXgYQnYxmV1sGsMw==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.8.0-beta.0.tgz",
+      "integrity": "sha512-TqfeJkqC+sYpA98Bi31my7gGxf+IfTi54bF3+dEYge2CF/XqYfO7NZs/f4RrLxO24DQEC2Lbwp+Vx/RA7fPA9g==",
       "dependencies": {
         "@scure/base": "^1.1.3"
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-0.7.2.tgz",
-      "integrity": "sha512-QV6jkiZ2VycEUhraRmaD5QbjI1vT/bzZ/6mwwWVThA9o9jUnazMN1oBGhv5NHho1rCERhD1jA+KDXzoht6Mdcw==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-0.8.0-beta.0.tgz",
+      "integrity": "sha512-Kok90Jz2WnvyqaylO8b6nYyhyv6w5QSOL/agX1VU8cDv1Dlv4i1QnzPntOpmAelQKfr34gefZwUUUHdQhMauhA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "0.7.2",
-        "@wormhole-foundation/sdk-definitions": "0.7.2",
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -3873,15 +3873,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-0.7.2.tgz",
-      "integrity": "sha512-YljpH9L/7RHl/8eu7JCczLkP/DX8kLR5+01JYYhR7arBD5xZHmnLwgGaXCJQYYLY7QAKCDRcQvvDepAHaJ36Xg==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-0.8.0-beta.0.tgz",
+      "integrity": "sha512-n/pSDrK9Rq8O+tNLbpTWiXEbjGj0lBYvggy+ZwU5MpUCcMQQZ6Fy/SKdxVJoFDSX2P2gVo4tSiT2Mg7LshDNwg==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.7.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -3889,31 +3889,31 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-0.7.2.tgz",
-      "integrity": "sha512-+xUK0CECqahg8XHKxlscd3H8DhTxyqh3126Gz2vepR0qT5f4WzzTzZiu5fX0DkTwxt9YQFISj5H2mkzJWF9diw==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-0.8.0-beta.0.tgz",
+      "integrity": "sha512-+/DOTaVX8C4EHdQ8r9N9ouYnbTGks8PQS3mSYj//g+rqpNGFR9n2OiWpNE95ixUhhlAfYmI75hU0UGxNDp2uNA==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.7.2",
-        "@wormhole-foundation/sdk-cosmwasm": "0.7.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-0.7.2.tgz",
-      "integrity": "sha512-rDey2Uci8qGvpc18sCeGVRXEDxxqsj108YAAO3scGk/htFjpc7upT2x+B7QnVvlLprqb0386MfaYR1vQ2LEhPw==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-0.8.0-beta.0.tgz",
+      "integrity": "sha512-CfcMF1AEAJhSU7OBJR4adRhWs5PLvN1dSgV6s70lTgTDIlwTN0tC2PaT9kr/dWY5GTmUzbrYnj1IItPGWsuLIA==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.7.2",
-        "@wormhole-foundation/sdk-cosmwasm": "0.7.2",
-        "@wormhole-foundation/sdk-cosmwasm-core": "0.7.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "0.8.0-beta.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -3921,27 +3921,27 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-0.7.2.tgz",
-      "integrity": "sha512-sF0HXy/hR6GJSW6P7q0QXxcC4O4tg9IjBon2GnBK+erND4r4x3MMpTuAoXMtsbH3dwTZ44WFKsZm4jKIpdjMew==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-0.8.0-beta.0.tgz",
+      "integrity": "sha512-u3rj6mkYoMxmyucwmJIUxQjqAWMmOREfaAaAh/kUKr4/8xzVaE9QP3CUgLouwhdopXEE/XCmLKc81lHrVLpvdA==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.7.2",
-        "@wormhole-foundation/sdk-cosmwasm": "0.7.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm": "0.8.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.7.2.tgz",
-      "integrity": "sha512-oVvE/cSq5eMJPI+f7i3CfZZxrO+llAN0QMTmMzns3OFPU0a0PAy0Cu/lNTXjuqApkpMTQI4iaWks7KL3A5rbgQ==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.8.0-beta.0.tgz",
+      "integrity": "sha512-atAxOs04OQWIaQR149p5qYeSAYvBPcLl+tEI45w0KkkFVBuZeOfgCgDx5KOkbzFEuVnUlH29QC7TJouCj9Ijfg==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "0.7.2"
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions-ntt": {
@@ -3949,11 +3949,11 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-0.7.2.tgz",
-      "integrity": "sha512-CBOFRcM2K0hh9Q0VGuZD/5tmam6TN0zEtQZ6v7aLRKUF1xmRPdhggpwQzcK9PDRmfhadpR/2emRk2NQabaN3uQ==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-0.8.0-beta.0.tgz",
+      "integrity": "sha512-9AXJku4UKQEcHhi9Hq1Qm/ybCuWh4kksBlSrvzWUQ4WKYberpgAvAJOp7tpi9XXefwPaHeKWyibfjIpvNkJCTA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.7.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -3961,12 +3961,12 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-0.7.2.tgz",
-      "integrity": "sha512-+zwEsdxV+z0//76tobjrzh7GxA6/o1VmCrAiF69fyyMhWQsPcAryNesjfv3JrJMq3JKUBhRcv/zEUBoRYX4rpg==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-0.8.0-beta.0.tgz",
+      "integrity": "sha512-9hUJTGA3XtC9LDfb6I/u3nqoVqx4a6eqmM6KpxvU33efYRo+Zl1q1XcrZPg5HkLe+xKSsyr5RIyd5vlowUgjvw==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.7.2",
-        "@wormhole-foundation/sdk-evm": "0.7.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -3974,12 +3974,12 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-0.7.2.tgz",
-      "integrity": "sha512-N6Xs2lbLINWNnkBi3iKIzA7gVS1NojTJGEDQemv1kJwEboMTVNPQe9gl64VDfadAEAoXVz6c4f1WT9hGohdb6w==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-0.8.0-beta.0.tgz",
+      "integrity": "sha512-ybUzwEhEq4JumRRm6HeJUzh/7aE0V15a3dAOJXm+7CsjB1jbO+lfITKQApUGzf8gmFmU7AGWxTgincIZeoYEUA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.7.2",
-        "@wormhole-foundation/sdk-evm": "0.7.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -3991,14 +3991,14 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-0.7.2.tgz",
-      "integrity": "sha512-YCwRG5VyQom5cFzBAIeM2X0PrGCmOFdoIc4fnz56QO0OgKQvw8PwnLc6PEsg0EImpoYhitxPOVwG+nl4/xtjBg==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-0.8.0-beta.0.tgz",
+      "integrity": "sha512-4J/9k50A13K78sbYRHcyt8ED+ofXfNccLzsLDdHGWWKlLk23fT+t9QUuN0jqYAjuosUE8vmMDjs4WY1+fuxm2g==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.7.2",
-        "@wormhole-foundation/sdk-evm": "0.7.2",
-        "@wormhole-foundation/sdk-evm-core": "0.7.2",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "0.7.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "0.8.0-beta.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4006,13 +4006,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-0.7.2.tgz",
-      "integrity": "sha512-W1dKl2DCKiHp116csWAI902Bedn89ls/ztpPIKHmz46pKJEXVCc8RwxJzArZLyx+oOJUZSkVO4BmCdd9XHZ8JA==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-0.8.0-beta.0.tgz",
+      "integrity": "sha512-/p9QgCC3eQjvLzvBfot3oNBY/SkqbkxRlN9wfxKtP3GgJ84XVdktROc0xEKWx3HewB3cMY5HM8C7oYx/Q2Hixg==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.7.2",
-        "@wormhole-foundation/sdk-evm": "0.7.2",
-        "@wormhole-foundation/sdk-evm-core": "0.7.2",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-evm": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-evm-core": "0.8.0-beta.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4028,45 +4028,45 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-0.7.2.tgz",
-      "integrity": "sha512-KvC2gqFI7ph8cZCSP9oN4EKpSWqUOEVIltiWyB8aCpAMELq6KUp/ZC0LgUEMF+VKi5uRDTfXNlqoXuBfOjXZwQ==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-0.8.0-beta.0.tgz",
+      "integrity": "sha512-7JKukYou8EkDGbBYnrpIZhHW3wSTnFTAZXZ9HauxK1QI22ICZJ1wT0GYcnF70uwLE9HLSfXgFktwarWhzDNQNw==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.7.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-0.7.2.tgz",
-      "integrity": "sha512-h0SCH9Q61Pr6RDkl0a0iBBZ8bA77Mn9j4Lb+NH5ZbaatjK0mSPRvonWTx3gkXvBlyKMlI2lTYNb9ebZ5E8UIhQ==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-0.8.0-beta.0.tgz",
+      "integrity": "sha512-PBYuqkgoQfOZ+31lglYK+iWpoeJ063I9zlY9CaG1EqeoMEi9mpnIg8kTo/vxVrXjR1Hu/J9tnKEWrqvEjhAtRw==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.7.2",
-        "@wormhole-foundation/sdk-solana": "0.7.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-solana": "0.8.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-0.7.2.tgz",
-      "integrity": "sha512-NKAo9NlA26kLY1GCIZrBjyekZ+DdFIgDm4gndCPxHDQ2SGlGjvEg9XveBBR/oaDcJd0PkZsTcR04DHqCWmTyyQ==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-0.8.0-beta.0.tgz",
+      "integrity": "sha512-qRWbMLla6X6MZ1b73jSZOtWRqhyADigeYSGLMB2P9fz/0ishXQmH+t0kfxoIbT8wxa7EEUgrVoK+0HcJoj/xyw==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.7.2",
-        "@wormhole-foundation/sdk-solana": "0.7.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-solana": "0.8.0-beta.0"
       },
       "engines": {
         "node": ">=16"
@@ -4077,55 +4077,55 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-0.7.2.tgz",
-      "integrity": "sha512-6kXNGSnxFzm+RXh8Ia4x64YdZNx0dOQPzHroFMDwABS+hv/Kj5O6NCysLCfVZa+UrViBxEqQXObcqhtiImLrRw==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-0.8.0-beta.0.tgz",
+      "integrity": "sha512-fclEsrtrCKxv6P89FegTTIc8hqpUr2+lMPbchSebBqjjzG+oqf5umwnQ8KlZRcEIc+9H8WEoIRrXQt2sRgekSg==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-connect": "0.7.2",
-        "@wormhole-foundation/sdk-solana": "0.7.2",
-        "@wormhole-foundation/sdk-solana-core": "0.7.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-solana": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-0.7.2.tgz",
-      "integrity": "sha512-jkO9jVAFZV8C1TiQm/16nxbyIwntR1g7ejRUEhDj/LF2GNZJ3C7PKb6n6aNboDPUiYcTHtxZvCjVZreLmhBCPQ==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-0.8.0-beta.0.tgz",
+      "integrity": "sha512-mQ+cpDjQdPlGLv3yNtsqPO+K66CXZxYA6YSMv6Yh9brsNKAKk80/3cvPjLjs0e0NlnCDFtyflCsKG9qcTpLHCw==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.7.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-0.7.2.tgz",
-      "integrity": "sha512-ytelbrPbTjZYqNY5JrHCd7/ARnwI/yzbz98GXI1+DgLOeNJ/zP6CfkWm2uqqLWTTPsYpBMS9U02qzV/aA+ce7A==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-0.8.0-beta.0.tgz",
+      "integrity": "sha512-DRFyhHnn3bN30m3PRVQiUGkOCPZyBrd39TZ6NqRFcLLhH7vHyj60YOoI90Gzp5tH0hHN7Zvh13z8RYI6NUeR3Q==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.7.2",
-        "@wormhole-foundation/sdk-sui": "0.7.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-sui": "0.8.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-0.7.2.tgz",
-      "integrity": "sha512-Rvpro3XZu3OtmfYEh4iPF55jBfAiWxXyZYHC1as5K9ARe5mUTUh5c/R43f/jbokOz7X2uEgEnXMAsNrY76rkbQ==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-0.8.0-beta.0.tgz",
+      "integrity": "sha512-MJuWWC93HDkXajjl40xfckw/tyVO7UWtsH6bpaLSI3Hi0PBzf3mlnTqqv3ZnIbXD9W0n+J3dFatTOR7wo2/MMQ==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.7.2",
-        "@wormhole-foundation/sdk-sui": "0.7.2",
-        "@wormhole-foundation/sdk-sui-core": "0.7.2"
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-sui": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-sui-core": "0.8.0-beta.0"
       },
       "engines": {
         "node": ">=16"
@@ -7961,14 +7961,14 @@
       }
     },
     "node_modules/gql.tada": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.1.tgz",
-      "integrity": "sha512-SKiWid+21JP1rCqXsWJr+A+fPcEUY2kz4XcQ6marzbMaFyXaf8LSLdYQPaZAFfqQ6tP2ZabG6Al7RFYByAsZwg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.2.tgz",
+      "integrity": "sha512-LLt+2RcLY6i+Rq+LQQwx3uiEAPfA+pmEaAo/bJjUdaV1CVJBy3Wowds6GHeerW5kvekRM/XdbPTJw5OvnLq/DQ==",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5",
         "@0no-co/graphqlsp": "^1.12.9",
-        "@gql.tada/cli-utils": "1.5.0",
-        "@gql.tada/internal": "1.0.3"
+        "@gql.tada/cli-utils": "1.5.1",
+        "@gql.tada/internal": "1.0.4"
       },
       "bin": {
         "gql-tada": "bin/cli.js",
@@ -10268,9 +10268,9 @@
       "dev": true
     },
     "node_modules/libsodium-sumo": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.13.tgz",
-      "integrity": "sha512-zTGdLu4b9zSNLfovImpBCbdAA4xkpkZbMnSQjP8HShyOutnGjRHmSOKlsylh1okao6QhLiz7nG98EGn+04cZjQ=="
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.14.tgz",
+      "integrity": "sha512-2nDge6qlAjcwyslAhWfVumlkeSNK5+WCfKa2/VEq9prvlT5vP2FR0m0o5hmKaYqfsZ4TQVj5czQsimZvXDB1CQ=="
     },
     "node_modules/libsodium-wrappers": {
       "version": "0.7.13",
@@ -10282,11 +10282,11 @@
       }
     },
     "node_modules/libsodium-wrappers-sumo": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.13.tgz",
-      "integrity": "sha512-lz4YdplzDRh6AhnLGF2Dj2IUj94xRN6Bh8T0HLNwzYGwPehQJX6c7iYVrFUPZ3QqxE0bqC+K0IIqqZJYWumwSQ==",
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.14.tgz",
+      "integrity": "sha512-0lm7ZwN5a95J2yUi8R1rgQeeaVDIWnvNzgVmXmZswis4mC+bQtbDrB+QpJlL4qklaKx3hVpJjoc6ubzJFiv64Q==",
       "dependencies": {
-        "libsodium-sumo": "^0.7.13"
+        "libsodium-sumo": "^0.7.14"
       }
     },
     "node_modules/lines-and-columns": {
@@ -12965,12 +12965,12 @@
       "name": "@wormhole-foundation/sdk-definitions-ntt",
       "version": "0.1.0-beta.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "^0.7",
-        "@wormhole-foundation/sdk-definitions": "^0.7"
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^0.7",
-        "@wormhole-foundation/sdk-definitions": "^0.7"
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0"
       }
     },
     "sdk/evm": {
@@ -12999,7 +12999,7 @@
       "version": "0.1.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk": "^0.7",
+        "@wormhole-foundation/sdk": "0.8.0-beta.0",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-route-ntt": "0.1.0-beta.0",
@@ -13032,7 +13032,7 @@
       "version": "0.1.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "^0.7",
+        "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0"
@@ -13046,7 +13046,6 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-connect": "^0.7",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
         "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0"
@@ -13061,10 +13060,10 @@
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.4.0",
         "@solana/web3.js": "1.91.7",
-        "@wormhole-foundation/sdk-base": "^0.7",
-        "@wormhole-foundation/sdk-definitions": "^0.7",
-        "@wormhole-foundation/sdk-solana": "^0.7",
-        "@wormhole-foundation/sdk-solana-core": "^0.7",
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-solana": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.0",
         "bn.js": "5.2.1"
       },
       "devDependencies": {
@@ -13078,11 +13077,11 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^0.7",
-        "@wormhole-foundation/sdk-definitions": "^0.7",
+        "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
         "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-        "@wormhole-foundation/sdk-solana": "^0.7",
-        "@wormhole-foundation/sdk-solana-core": "^0.7"
+        "@wormhole-foundation/sdk-solana": "0.8.0-beta.0",
+        "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.0"
       }
     },
     "solana/node_modules/@solana/codecs-core": {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "version": "tsx setSdkVersion.ts"
   },
   "devDependencies": {
-    "@wormhole-foundation/sdk": "^0.7",
     "@solana/spl-token": "0.3.9",
     "@solana/web3.js": "1.91.7",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.2",
+    "@wormhole-foundation/sdk": "0.8.0-beta.0",
     "@wormhole-foundation/wormchain-sdk": "^0.0.1",
     "ethers": "^6.5.1",
     "ts-jest": "^29.1.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "version": "tsx setSdkVersion.ts"
   },
   "devDependencies": {
-    "@wormhole-foundation/sdk": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk": "^0.8",
     "@solana/spl-token": "0.3.9",
     "@solana/web3.js": "1.91.7",
     "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "version": "tsx setSdkVersion.ts"
   },
   "devDependencies": {
+    "@wormhole-foundation/sdk": "0.8.0-beta.2",
     "@solana/spl-token": "0.3.9",
     "@solana/web3.js": "1.91.7",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.2",
-    "@wormhole-foundation/sdk": "0.8.0-beta.0",
     "@wormhole-foundation/wormchain-sdk": "^0.0.1",
     "ethers": "^6.5.1",
     "ts-jest": "^29.1.2",

--- a/sdk/definitions/package.json
+++ b/sdk/definitions/package.json
@@ -49,12 +49,12 @@
     "test": "jest --config ./jest.config.ts"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk-base": "^0.7",
-    "@wormhole-foundation/sdk-definitions": "^0.7"
+    "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "^0.7",
-    "@wormhole-foundation/sdk-definitions": "^0.7"
+    "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0"
   },
   "type": "module"
 }

--- a/sdk/definitions/package.json
+++ b/sdk/definitions/package.json
@@ -49,12 +49,12 @@
     "test": "jest --config ./jest.config.ts"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
-    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2"
+    "@wormhole-foundation/sdk-base": "^0.8",
+    "@wormhole-foundation/sdk-definitions": "^0.8"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
-    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2"
+    "@wormhole-foundation/sdk-base": "^0.8",
+    "@wormhole-foundation/sdk-definitions": "^0.8"
   },
   "type": "module"
 }

--- a/sdk/definitions/package.json
+++ b/sdk/definitions/package.json
@@ -49,12 +49,12 @@
     "test": "jest --config ./jest.config.ts"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
-    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0"
+    "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
-    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0"
+    "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2"
   },
   "type": "module"
 }

--- a/sdk/definitions/src/layouts/index.ts
+++ b/sdk/definitions/src/layouts/index.ts
@@ -1,6 +1,7 @@
 import {
   NamedPayloads,
   RegisterPayloadTypes,
+  deliveryInstructionLayout,
 } from "@wormhole-foundation/sdk-definitions";
 import { nttManagerMessageLayout } from "./manager.js";
 import { transceiverInfo, transceiverRegistration } from "./transceiver.js";
@@ -12,6 +13,14 @@ export const nttNamedPayloads = [
     "WormholeTransfer",
     wormholeTransceiverMessageLayout(
       nttManagerMessageLayout(nativeTokenTransferLayout)
+    ),
+  ],
+  [
+    "WormholeTransferStandardRelayer",
+    deliveryInstructionLayout(
+      wormholeTransceiverMessageLayout(
+        nttManagerMessageLayout(nativeTokenTransferLayout)
+      )
     ),
   ],
   ["TransceiverInfo", transceiverInfo],

--- a/sdk/definitions/src/ntt.ts
+++ b/sdk/definitions/src/ntt.ts
@@ -116,6 +116,31 @@ export namespace Ntt {
       )
     );
   }
+
+  // Checks for compatibility between the Contract version in use on chain,
+  // and the ABI version the SDK has. Major version must match, minor version on chain
+  // should be gte SDK's ABI version.
+  //
+  // For example, if the contract is using 1.1.0, we would use 1.0.0 but not 1.2.0.
+  export function abiVersionMatches(
+    targetVersion: string,
+    abiVersion: string
+  ): boolean {
+    const parseVersion = (version: string) => {
+      // allow optional tag on patch version
+      const versionRegex = /^(\d+)\.(\d+)\.(.*)$/;
+      const match = version.match(versionRegex);
+      if (!match) {
+        throw new Error(`Invalid version format: ${version}`);
+      }
+      const [, major, minor, patchAndTag] = match;
+      return { major: Number(major), minor: Number(minor), patchAndTag };
+    };
+    const { major: majorTarget, minor: minorTarget } =
+      parseVersion(targetVersion);
+    const { major: majorAbi, minor: minorAbi } = parseVersion(abiVersion);
+    return majorTarget === majorAbi && minorTarget >= minorAbi;
+  }
 }
 
 /**
@@ -193,6 +218,11 @@ export interface Ntt<N extends Network, C extends Chain> {
    * @param fromChain the chain to check the inbound capacity for
    */
   getCurrentInboundCapacity(fromChain: Chain): Promise<bigint>;
+
+  /**
+   * getRateLimitDuration returns the duration of the rate limit for queued transfers in seconds
+   */
+  getRateLimitDuration(): Promise<bigint>;
 
   /**
    * getIsApproved returns whether an attestation is approved

--- a/sdk/definitions/src/ntt.ts
+++ b/sdk/definitions/src/ntt.ts
@@ -12,8 +12,8 @@ import {
   EmptyPlatformMap,
   ProtocolPayload,
   ProtocolVAA,
-  TokenAddress,
   UnsignedTransaction,
+  VAA,
   keccak256,
 } from "@wormhole-foundation/sdk-definitions";
 
@@ -62,7 +62,9 @@ export namespace Ntt {
   // TODO: what are the set of attestation types for Ntt?
   // can we know this ahead of time or does it need to be
   // flexible enough for folks to add their own somehow?
-  export type Attestation = any;
+  export type Attestation =
+    | VAA<"Ntt:WormholeTransfer">
+    | VAA<"Ntt:WormholeTransferStandardRelayer">;
 
   /**
    * InboundQueuedTransfer is a queued transfer from another chain
@@ -220,15 +222,13 @@ export interface Ntt<N extends Network, C extends Chain> {
   ): Promise<Ntt.InboundQueuedTransfer<C> | null>;
   /**
    * completeInboundQueuedTransfer completes an inbound queued transfer
-   * @param transceiverMessage the transceiver message
-   * @param token the token to transfer
    * @param fromChain the chain the transfer is from
+   * @param transceiverMessage the transceiver message
    * @param payer the address to pay for the transfer
    */
   completeInboundQueuedTransfer(
     fromChain: Chain,
     transceiverMessage: Ntt.Message,
-    token: TokenAddress<C>,
     payer?: AccountAddress<C>
   ): AsyncGenerator<UnsignedTransaction<N, C>>;
 }
@@ -256,7 +256,10 @@ export interface NttTransceiver<
 }
 
 export namespace WormholeNttTransceiver {
-  const _payloads = ["WormholeTransfer"] as const;
+  const _payloads = [
+    "WormholeTransfer",
+    "WormholeTransferStandardRelayer",
+  ] as const;
   export type PayloadNames = (typeof _payloads)[number];
   export type VAA<PayloadName extends PayloadNames = PayloadNames> =
     ProtocolVAA<Ntt.ProtocolName, PayloadName>;

--- a/sdk/definitions/src/ntt.ts
+++ b/sdk/definitions/src/ntt.ts
@@ -242,6 +242,12 @@ export interface Ntt<N extends Network, C extends Chain> {
   getIsExecuted(attestation: Ntt.Attestation): Promise<boolean>;
 
   /**
+   * getIsTransferInboundQueued returns whether the transfer is inbound queued
+   * @param attestation the attestation to check
+   */
+  getIsTransferInboundQueued(attestation: Ntt.Attestation): Promise<boolean>;
+
+  /**
    * getInboundQueuedTransfer returns the details of an inbound queued transfer
    * @param transceiverMessage the transceiver message
    * @param fromChain the chain the transfer is from

--- a/sdk/examples/package.json
+++ b/sdk/examples/package.json
@@ -32,7 +32,7 @@
     "tsx": "^4.7.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk": "^0.8",
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
     "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
     "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0",

--- a/sdk/examples/package.json
+++ b/sdk/examples/package.json
@@ -32,7 +32,7 @@
     "tsx": "^4.7.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk": "0.8.0-beta.2",
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
     "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
     "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0",

--- a/sdk/examples/package.json
+++ b/sdk/examples/package.json
@@ -32,7 +32,7 @@
     "tsx": "^4.7.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "^0.7",
+    "@wormhole-foundation/sdk": "0.8.0-beta.0",
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
     "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
     "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0",

--- a/sdk/examples/src/consts.ts
+++ b/sdk/examples/src/consts.ts
@@ -67,7 +67,7 @@ export const TEST_NTT_SPL22_TOKENS: NttContracts = {
 // Reformat NTT contracts to fit TokenConfig for Route
 function reformat(contracts: NttContracts) {
   return Object.entries(TEST_NTT_TOKENS).map(([chain, contracts]) => {
-    const { token, manager, transceiver: xcvrs, quoter } = contracts;
+    const { token, manager, transceiver: xcvrs, quoter } = contracts!;
     const transceiver = Object.entries(xcvrs).map(([k, v]) => {
       return { type: k as NttRoute.TransceiverType, address: v };
     });

--- a/sdk/route/package.json
+++ b/sdk/route/package.json
@@ -45,16 +45,15 @@
     "ts-node": "^10.9.2"
   },
   "dependencies": {
+    "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-    "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0",
     "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
-    "@wormhole-foundation/sdk-connect": "^0.7"
+    "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-connect": "^0.7",
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-    "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0",
-    "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0"
+    "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
+    "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0"
   },
   "type": "module",
   "exports": {

--- a/sdk/route/package.json
+++ b/sdk/route/package.json
@@ -45,15 +45,16 @@
     "ts-node": "^10.9.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk-connect": "0.8.0-beta.0",
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
+    "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0",
     "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
-    "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0"
+    "@wormhole-foundation/sdk-connect": "0.8.0-beta.2"
   },
   "peerDependencies": {
+    "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
-    "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
-    "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0"
+    "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0",
+    "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0"
   },
   "type": "module",
   "exports": {

--- a/sdk/route/package.json
+++ b/sdk/route/package.json
@@ -48,10 +48,10 @@
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
     "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0",
     "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0",
-    "@wormhole-foundation/sdk-connect": "0.8.0-beta.2"
+    "@wormhole-foundation/sdk-connect": "^0.8"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-connect": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-connect": "^0.8",
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0",
     "@wormhole-foundation/sdk-solana-ntt": "0.1.0-beta.0",
     "@wormhole-foundation/sdk-evm-ntt": "0.1.0-beta.0"

--- a/sdk/route/src/types.ts
+++ b/sdk/route/src/types.ts
@@ -62,15 +62,29 @@ export namespace NttRoute {
     normalizedParams: NormalizedParams;
   }
 
-  export type AttestationReceipt = {
+  export type ManualAttestationReceipt = {
     id: WormholeMessageId;
     attestation: VAA<"Ntt:WormholeTransfer">;
   };
 
-  export type TransferReceipt<
+  export type AutomaticAttestationReceipt = {
+    id: WormholeMessageId;
+    attestation:
+      | VAA<"Ntt:WormholeTransfer">
+      | VAA<"Ntt:WormholeTransferStandardRelayer">;
+  };
+
+  export type ManualTransferReceipt<
     SC extends Chain = Chain,
     DC extends Chain = Chain
-  > = _TransferReceipt<AttestationReceipt, SC, DC> & {
+  > = _TransferReceipt<ManualAttestationReceipt, SC, DC> & {
+    params: ValidatedParams;
+  };
+
+  export type AutomaticTransferReceipt<
+    SC extends Chain = Chain,
+    DC extends Chain = Chain
+  > = _TransferReceipt<AutomaticAttestationReceipt, SC, DC> & {
     params: ValidatedParams;
   };
 

--- a/sdk/route/src/types.ts
+++ b/sdk/route/src/types.ts
@@ -167,4 +167,15 @@ export namespace NttRoute {
     }
     throw new Error("Cannot find Ntt contracts in config for: " + address);
   }
+
+  // returns true if the amount is greater than 95% of the capacity
+  // useful for warning about the possibility of a transfer being queued
+  export function isCapacityThresholdExceeded(
+    amount: bigint,
+    capacity: bigint
+  ): boolean {
+    const threshold = (capacity * 95n) / 100n;
+    console.log(amount, threshold, amount > threshold);
+    return amount > threshold;
+  }
 }

--- a/sdk/route/src/types.ts
+++ b/sdk/route/src/types.ts
@@ -175,7 +175,6 @@ export namespace NttRoute {
     capacity: bigint
   ): boolean {
     const threshold = (capacity * 95n) / 100n;
-    console.log(amount, threshold, amount > threshold);
     return amount > threshold;
   }
 }

--- a/solana/package.json
+++ b/solana/package.json
@@ -8,7 +8,6 @@
   "bugs": {
     "url": "https://github.com/wormhole-foundation/example-native-token-transfers"
   },
-    
   "homepage": "https://github.com/wormhole-foundation/example-native-token-transfers#readme",
   "directories": {
     "test": "tests"
@@ -55,16 +54,16 @@
     "@solana/spl-token": "0.4.0",
     "@solana/web3.js": "1.91.7",
     "bn.js": "5.2.1",
-    "@wormhole-foundation/sdk-base": "^0.7",
-    "@wormhole-foundation/sdk-definitions": "^0.7",
-    "@wormhole-foundation/sdk-solana": "^0.7",
-    "@wormhole-foundation/sdk-solana-core": "^0.7"
+    "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-solana": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.0"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "^0.7",
-    "@wormhole-foundation/sdk-definitions": "^0.7",
-    "@wormhole-foundation/sdk-solana": "^0.7",
-    "@wormhole-foundation/sdk-solana-core": "^0.7",
+    "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-solana": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.0",
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0"
   },
   "type": "module",

--- a/solana/package.json
+++ b/solana/package.json
@@ -54,16 +54,16 @@
     "@solana/spl-token": "0.4.0",
     "@solana/web3.js": "1.91.7",
     "bn.js": "5.2.1",
-    "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
-    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
-    "@wormhole-foundation/sdk-solana": "0.8.0-beta.2",
-    "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.2"
+    "@wormhole-foundation/sdk-base": "^0.8",
+    "@wormhole-foundation/sdk-definitions": "^0.8",
+    "@wormhole-foundation/sdk-solana": "^0.8",
+    "@wormhole-foundation/sdk-solana-core": "^0.8"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
-    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
-    "@wormhole-foundation/sdk-solana": "0.8.0-beta.2",
-    "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-base": "^0.8",
+    "@wormhole-foundation/sdk-definitions": "^0.8",
+    "@wormhole-foundation/sdk-solana": "^0.8",
+    "@wormhole-foundation/sdk-solana-core": "^0.8",
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0"
   },
   "type": "module",

--- a/solana/package.json
+++ b/solana/package.json
@@ -54,16 +54,16 @@
     "@solana/spl-token": "0.4.0",
     "@solana/web3.js": "1.91.7",
     "bn.js": "5.2.1",
-    "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
-    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
-    "@wormhole-foundation/sdk-solana": "0.8.0-beta.0",
-    "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.0"
+    "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-solana": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.2"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "0.8.0-beta.0",
-    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.0",
-    "@wormhole-foundation/sdk-solana": "0.8.0-beta.0",
-    "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.0",
+    "@wormhole-foundation/sdk-base": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-definitions": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-solana": "0.8.0-beta.2",
+    "@wormhole-foundation/sdk-solana-core": "0.8.0-beta.2",
     "@wormhole-foundation/sdk-definitions-ntt": "0.1.0-beta.0"
   },
   "type": "module",

--- a/solana/ts/lib/ntt.ts
+++ b/solana/ts/lib/ntt.ts
@@ -214,8 +214,12 @@ export namespace NTT {
     const data = encoding.b64.decode(txSimulation.value.returnData?.data[0]!);
     const parsed = deserializeLayout(programVersionLayout, data);
     const version = encoding.bytes.decode(parsed.version);
-    if (version in IdlVersions) return version as IdlVersion;
-    else throw new Error("Unknown IDL version: " + version);
+    for (const [idlVersion] of IdlVersions) {
+      if (Ntt.abiVersionMatches(version, idlVersion)) {
+        return idlVersion;
+      }
+    }
+    throw new Error(`Unknown IDL version: ${version}`);
   }
 
   export async function createInitializeInstruction(

--- a/solana/ts/sdk/ntt.ts
+++ b/solana/ts/sdk/ntt.ts
@@ -20,7 +20,6 @@ import {
   ChainsConfig,
   Contracts,
   NativeAddress,
-  TokenAddress,
   UnsignedTransaction,
 } from "@wormhole-foundation/sdk-definitions";
 import {
@@ -458,7 +457,10 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
 
     // TODO: not this, we should iterate over the set of enabled xcvrs?
     // if (attestations.length !== this.xcvrs.length) throw "No";
-    const wormholeNTT = attestations[0]! as WormholeNttTransceiver.VAA;
+    const wormholeNTT = attestations[0];
+    if (!wormholeNTT || wormholeNTT.payloadName !== "WormholeTransfer") {
+      throw new Error("Invalid attestation payload");
+    }
 
     // Create the vaa if necessary
     yield* this.createAta(payer);
@@ -544,15 +546,20 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
   }
 
   async getIsExecuted(attestation: Ntt.Attestation): Promise<boolean> {
-    if (!this.getIsApproved(attestation)) return false;
-
-    const { emitterChain } = attestation as WormholeNttTransceiver.VAA;
-    const inboundQueued = await this.getInboundQueuedTransfer(
-      emitterChain,
-      attestation
-    );
-
-    return inboundQueued === null;
+    if (attestation.payloadName !== "WormholeTransfer") return false;
+    const payload = attestation.payload["nttManagerPayload"];
+    let inboxItem;
+    try {
+      inboxItem = await this.program.account.inboxItem.fetch(
+        this.pdas.inboxItemAccount(attestation.emitterChain, payload)
+      );
+    } catch (e: any) {
+      if (e.message?.includes("Account does not exist")) {
+        return false;
+      }
+      throw e;
+    }
+    return !!inboxItem.releaseStatus.released;
   }
 
   async getIsApproved(attestation: Ntt.Attestation): Promise<boolean> {
@@ -562,18 +569,13 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
       Buffer.from(digest)
     );
 
-    try {
-      const info = this.connection.getAccountInfo(vaaAddress);
-      return info !== null;
-    } catch (_) {}
-
-    return false;
+    const info = await this.connection.getAccountInfo(vaaAddress);
+    return info !== null;
   }
 
   async *completeInboundQueuedTransfer(
     fromChain: Chain,
     transceiverMessage: Ntt.Message,
-    token: TokenAddress<C>,
     payer: AccountAddress<C>
   ) {
     const config = await this.getConfig();
@@ -617,23 +619,29 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
     chain: Chain,
     nttMessage: Ntt.Message
   ): Promise<Ntt.InboundQueuedTransfer<C> | null> {
-    const inboxItem = await this.program.account.inboxItem.fetch(
-      this.pdas.inboxItemAccount(chain, nttMessage)
-    );
-    if (!inboxItem) return null;
+    let inboxItem;
+    try {
+      inboxItem = await this.program.account.inboxItem.fetch(
+        this.pdas.inboxItemAccount(chain, nttMessage)
+      );
+    } catch (e: any) {
+      if (e.message?.includes("Account does not exist")) {
+        return null;
+      }
+      throw e;
+    }
 
-    const { recipientAddress, amount, releaseStatus } = inboxItem!;
-    const rateLimitExpiry = releaseStatus.releaseAfter
-      ? releaseStatus.releaseAfter[0].toNumber()
-      : 0;
-
-    const xfer: Ntt.InboundQueuedTransfer<C> = {
-      recipient: new SolanaAddress(recipientAddress) as NativeAddress<C>,
-      amount: BigInt(amount.toString()),
-      rateLimitExpiryTimestamp: rateLimitExpiry,
-    };
-
-    return xfer;
+    if (inboxItem.releaseStatus.releaseAfter) {
+      const { recipientAddress, amount, releaseStatus } = inboxItem;
+      const rateLimitExpiry = releaseStatus.releaseAfter[0].toNumber();
+      const xfer: Ntt.InboundQueuedTransfer<C> = {
+        recipient: new SolanaAddress(recipientAddress) as NativeAddress<C>,
+        amount: BigInt(amount.toString()),
+        rateLimitExpiryTimestamp: rateLimitExpiry,
+      };
+      return xfer;
+    }
+    return null;
   }
 
   async getAddressLookupTable(

--- a/solana/ts/sdk/ntt.ts
+++ b/solana/ts/sdk/ntt.ts
@@ -545,6 +545,11 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
     return BigInt(rl.rateLimit.capacityAtLastTx.toString());
   }
 
+  async getRateLimitDuration(): Promise<bigint> {
+    // The rate limit duration is hardcoded to 24 hours on Solana
+    return BigInt(24 * 60 * 60);
+  }
+
   async getIsExecuted(attestation: Ntt.Attestation): Promise<boolean> {
     if (attestation.payloadName !== "WormholeTransfer") return false;
     const payload = attestation.payload["nttManagerPayload"];


### PR DESCRIPTION
- Added a WormholeTransferStandardRelayer payload type needed to parse the VAA for an automatic transfer between EVM chains
- EVM: getIsExecuted should check if the transfer is inbound queued to determine if the transfer is completed
- Solana: getIsExecuted should check if the inboxItem is released
- Solana: getIsApproved should not swallow exception
- Solana: getInboundQueuedTransfer should return null if the transfer is not queued
- Bumped SDK dependencies needed for Connect