### PR TITLE
Fix sdk-solana-ntt entry point

### DIFF
--- a/solana/package.json
+++ b/solana/package.json
@@ -14,9 +14,9 @@
     "test": "tests"
   },
   "license": "Apache-2.0",
-  "main": "./dist/cjs/index.js",
-  "types": "./dist/cjs/index.d.ts",
-  "module": "./dist/esm/index.js",
+  "main": "./dist/cjs/ts/index.js",
+  "types": "./dist/cjs/ts/index.d.ts",
+  "module": "./dist/esm/ts/index.js",
   "description": "NTT SDK for Solana",
   "files": [
     "dist/esm",


### PR DESCRIPTION
Temporary fix as entrypoint needs to be set to dist/cjs|esm/ts/ directory.