### PR TITLE
solana: Add Rust test cases to handle tokens with transfer fee

### DIFF
--- a/solana/programs/example-native-token-transfers/tests/sdk/accounts.rs
+++ b/solana/programs/example-native-token-transfers/tests/sdk/accounts.rs
@@ -182,10 +182,18 @@ impl NTT {
     }
 
     pub fn custody(&self, mint: &Pubkey) -> Pubkey {
+        self.custody_with_token_program_id(mint, &spl_token::ID)
+    }
+
+    pub fn custody_with_token_program_id(
+        &self,
+        mint: &Pubkey,
+        token_program_id: &Pubkey,
+    ) -> Pubkey {
         anchor_spl::associated_token::get_associated_token_address_with_program_id(
             &self.token_authority(),
             mint,
-            &spl_token::ID,
+            token_program_id,
         )
     }
 

--- a/solana/programs/example-native-token-transfers/tests/sdk/instructions/initialize.rs
+++ b/solana/programs/example-native-token-transfers/tests/sdk/instructions/initialize.rs
@@ -13,6 +13,15 @@ pub struct Initialize {
 }
 
 pub fn initialize(ntt: &NTT, accounts: Initialize, args: InitializeArgs) -> Instruction {
+    initialize_with_token_program_id(ntt, accounts, args, &Token::id())
+}
+
+pub fn initialize_with_token_program_id(
+    ntt: &NTT,
+    accounts: Initialize,
+    args: InitializeArgs,
+    token_program_id: &Pubkey,
+) -> Instruction {
     let data = example_native_token_transfers::instruction::Initialize { args };
 
     let bpf_loader_upgradeable_program = BpfLoaderUpgradeable::id();
@@ -24,8 +33,8 @@ pub fn initialize(ntt: &NTT, accounts: Initialize, args: InitializeArgs) -> Inst
         mint: accounts.mint,
         rate_limit: ntt.outbox_rate_limit(),
         token_authority: ntt.token_authority(),
-        custody: ntt.custody(&accounts.mint),
-        token_program: Token::id(),
+        custody: ntt.custody_with_token_program_id(&accounts.mint, token_program_id),
+        token_program: *token_program_id,
         associated_token_program: AssociatedToken::id(),
         bpf_loader_upgradeable_program,
         system_program: System::id(),


### PR DESCRIPTION
This PR adds:
- Test cases for locking and burning modes to handle tokens with transfer fee
- `*_with_token_program_id` helper methods to choose token program for the tests