### PR TITLE
cli: query token decimals outside of forge script

### DIFF
--- a/evm/script/DeployWormholeNtt.s.sol
+++ b/evm/script/DeployWormholeNtt.s.sol
@@ -52,7 +52,9 @@ contract DeployWormholeNtt is Script, DeployWormholeNttBase {
             // This is a bit of a hack, but in the worst case (i.e. if the token contract is actually broken), the
             // NTT manager initialiser will fail anyway.
             vm.mockCall(
-                token, abi.encodeWithSelector(ERC20.decimals.selector, ()), abi.encode(decimals)
+                token,
+                abi.encodeWithSelector(ERC20.decimals.selector),
+                abi.encode(decimals)
             );
         }
 

--- a/evm/script/DeployWormholeNtt.s.sol
+++ b/evm/script/DeployWormholeNtt.s.sol
@@ -52,9 +52,7 @@ contract DeployWormholeNtt is Script, DeployWormholeNttBase {
             // This is a bit of a hack, but in the worst case (i.e. if the token contract is actually broken), the
             // NTT manager initialiser will fail anyway.
             vm.mockCall(
-                token,
-                abi.encodeWithSelector(ERC20.decimals.selector),
-                abi.encode(decimals)
+                token, abi.encodeWithSelector(ERC20.decimals.selector), abi.encode(decimals)
             );
         }
 

--- a/evm/script/DeployWormholeNtt.s.sol
+++ b/evm/script/DeployWormholeNtt.s.sol
@@ -47,6 +47,13 @@ contract DeployWormholeNtt is Script, DeployWormholeNttBase {
             console.log(
                 "Failed to query token decimals. Proceeding with provided decimals.", decimals
             );
+            // the NTT manager initialiser calls the token contract to get the
+            // decimals as well. We're just going to mock that call to return the provided decimals.
+            // This is a bit of a hack, but in the worst case (i.e. if the token contract is actually broken), the
+            // NTT manager initialiser will fail anyway.
+            vm.mockCall(
+                token, abi.encodeWithSelector(ERC20.decimals.selector, ()), abi.encode(decimals)
+            );
         }
 
         uint16 chainId = wh.chainId();


### PR DESCRIPTION
This works around and edge case when the token contract is compiled against a different EVM version than what the forge script is running in (london currently).