### PR TITLE
solana: Update fee token comment to include required burn changes

### DIFF
--- a/solana/programs/example-native-token-transfers/src/instructions/transfer.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/transfer.rs
@@ -225,7 +225,9 @@ pub fn transfer_burn<'info>(
     // would be lost.
     // To support fee tokens, we would first transfer the amount, _then_ assert
     // that the resulting amount has no dust (instead of removing dust before
-    // the transfer like we do now).
+    // the transfer like we do now). We would also need to burn the new amount
+    // _after_ paying fees so as to not burn more than what was transferred to
+    // the custody.
     if after != before {
         return Err(NTTError::BadAmountAfterBurn.into());
     }


### PR DESCRIPTION
To support fee tokens, apart from first transferring and then asserting that there is no dust, we would also need to calculate the new amount to be burnt. This can be calculated as the amount _after_ paying the fees. This PR updates the comment to reflect that.