### PR TITLE
examples: fetch vaa for last tx hash

### DIFF
--- a/sdk/examples/src/index.ts
+++ b/sdk/examples/src/index.ts
@@ -62,7 +62,7 @@ const recoverTxids: TransactionId[] = [
   console.log("Source txs", txids);
 
   const vaa = await wh.getVaa(
-    txids[0]!.txid,
+    txids[txids.length - 1]!.txid,
     "Ntt:WormholeTransfer",
     25 * 60 * 1000
   );


### PR DESCRIPTION
the first tx hash may be the spending approval if from an evm chain