### PR TITLE
evm: forge fmt

### DIFF
--- a/evm/script/helpers/DeployWormholeNttBase.sol
+++ b/evm/script/helpers/DeployWormholeNttBase.sol
@@ -31,7 +31,9 @@ contract DeployWormholeNttBase is ParseNttConfig {
     // gas on testnet, pick up the phone and start dialing!
     uint256 constant MIN_WORMHOLE_GAS_LIMIT = 150000;
 
-    function deployNttManager(DeploymentParams memory params) internal returns (address) {
+    function deployNttManager(
+        DeploymentParams memory params
+    ) internal returns (address) {
         // Deploy the Manager Implementation.
         NttManager implementation = new NttManager(
             params.token,

--- a/evm/script/helpers/ParseNttConfig.sol
+++ b/evm/script/helpers/ParseNttConfig.sol
@@ -25,7 +25,9 @@ contract ParseNttConfig is Script {
 
     mapping(uint16 => bool) duplicateChainIds;
 
-    function toUniversalAddress(address evmAddr) internal pure returns (bytes32 converted) {
+    function toUniversalAddress(
+        address evmAddr
+    ) internal pure returns (bytes32 converted) {
         assembly ("memory-safe") {
             converted := and(0xffffffffffffffffffffffffffffffffffffffff, evmAddr)
         }

--- a/evm/src/NttManager/ManagerBase.sol
+++ b/evm/src/NttManager/ManagerBase.sol
@@ -260,7 +260,9 @@ abstract contract ManagerBase is
         return (enabledTransceivers, instructions, priceQuotes, totalPriceQuote);
     }
 
-    function _refundToSender(uint256 refundAmount) internal {
+    function _refundToSender(
+        uint256 refundAmount
+    ) internal {
         // refund the price quote back to sender
         (bool refundSuccessful,) = payable(msg.sender).call{value: refundAmount}("");
 
@@ -283,7 +285,9 @@ abstract contract ManagerBase is
     }
 
     /// @inheritdoc IManagerBase
-    function isMessageApproved(bytes32 digest) public view returns (bool) {
+    function isMessageApproved(
+        bytes32 digest
+    ) public view returns (bool) {
         uint8 threshold = getThreshold();
         return messageAttestations(digest) >= threshold && threshold > 0;
     }
@@ -294,7 +298,9 @@ abstract contract ManagerBase is
     }
 
     /// @inheritdoc IManagerBase
-    function isMessageExecuted(bytes32 digest) public view returns (bool) {
+    function isMessageExecuted(
+        bytes32 digest
+    ) public view returns (bool) {
         return _getMessageAttestationsStorage()[digest].executed;
     }
 
@@ -305,14 +311,18 @@ abstract contract ManagerBase is
     }
 
     /// @inheritdoc IManagerBase
-    function messageAttestations(bytes32 digest) public view returns (uint8 count) {
+    function messageAttestations(
+        bytes32 digest
+    ) public view returns (uint8 count) {
         return countSetBits(_getMessageAttestations(digest));
     }
 
     // =============== Admin ==============================================================
 
     /// @inheritdoc IManagerBase
-    function upgrade(address newImplementation) external onlyOwner {
+    function upgrade(
+        address newImplementation
+    ) external onlyOwner {
         _upgrade(newImplementation);
     }
 
@@ -326,7 +336,9 @@ abstract contract ManagerBase is
     }
 
     /// @notice Transfer ownership of the Manager contract and all Transceiver contracts to a new owner.
-    function transferOwnership(address newOwner) public override onlyOwner {
+    function transferOwnership(
+        address newOwner
+    ) public override onlyOwner {
         super.transferOwnership(newOwner);
         // loop through all the registered transceivers and set the new owner of each transceiver to the newOwner
         address[] storage _registeredTransceivers = _getRegisteredTransceiversStorage();
@@ -338,7 +350,9 @@ abstract contract ManagerBase is
     }
 
     /// @inheritdoc IManagerBase
-    function setTransceiver(address transceiver) external onlyOwner {
+    function setTransceiver(
+        address transceiver
+    ) external onlyOwner {
         _setTransceiver(transceiver);
 
         _Threshold storage _threshold = _getThresholdStorage();
@@ -365,7 +379,9 @@ abstract contract ManagerBase is
     }
 
     /// @inheritdoc IManagerBase
-    function removeTransceiver(address transceiver) external onlyOwner {
+    function removeTransceiver(
+        address transceiver
+    ) external onlyOwner {
         _removeTransceiver(transceiver);
 
         _Threshold storage _threshold = _getThresholdStorage();
@@ -381,7 +397,9 @@ abstract contract ManagerBase is
     }
 
     /// @inheritdoc IManagerBase
-    function setThreshold(uint8 threshold) external onlyOwner {
+    function setThreshold(
+        uint8 threshold
+    ) external onlyOwner {
         if (threshold == 0) {
             revert ZeroThreshold();
         }
@@ -410,7 +428,9 @@ abstract contract ManagerBase is
     }
 
     /// @dev Returns the bitmap of attestations from enabled transceivers for a given message.
-    function _getMessageAttestations(bytes32 digest) internal view returns (uint64) {
+    function _getMessageAttestations(
+        bytes32 digest
+    ) internal view returns (uint64) {
         uint64 enabledTransceiverBitmap = _getEnabledTransceiversBitmap();
         return
             _getMessageAttestationsStorage()[digest].attestedTransceivers & enabledTransceiverBitmap;
@@ -425,7 +445,9 @@ abstract contract ManagerBase is
 
     // @dev Mark a message as executed.
     // This function will retuns `true` if the message has already been executed.
-    function _replayProtect(bytes32 digest) internal returns (bool) {
+    function _replayProtect(
+        bytes32 digest
+    ) internal returns (bool) {
         // check if this message has already been executed
         if (isMessageExecuted(digest)) {
             return true;

--- a/evm/src/NttManager/NttManager.sol
+++ b/evm/src/NttManager/NttManager.sol
@@ -92,7 +92,9 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
     // =============== Public Getters ========================================================
 
     /// @inheritdoc INttManager
-    function getPeer(uint16 chainId_) external view returns (NttManagerPeer memory) {
+    function getPeer(
+        uint16 chainId_
+    ) external view returns (NttManagerPeer memory) {
         return _getPeersStorage()[chainId_];
     }
 
@@ -132,7 +134,9 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
     }
 
     /// @inheritdoc INttManager
-    function setOutboundLimit(uint256 limit) external onlyOwner {
+    function setOutboundLimit(
+        uint256 limit
+    ) external onlyOwner {
         uint8 toDecimals = tokenDecimals();
         _setOutboundLimit(limit.trim(toDecimals, toDecimals));
     }
@@ -241,7 +245,9 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
     }
 
     /// @inheritdoc INttManager
-    function completeInboundQueuedTransfer(bytes32 digest) external nonReentrant whenNotPaused {
+    function completeInboundQueuedTransfer(
+        bytes32 digest
+    ) external nonReentrant whenNotPaused {
         // find the message in the queue
         InboundQueuedTransfer memory queuedTransfer = getInboundQueuedTransfer(digest);
         if (queuedTransfer.txTimestamp == 0) {

--- a/evm/src/NttManager/TransceiverRegistry.sol
+++ b/evm/src/NttManager/TransceiverRegistry.sol
@@ -138,7 +138,9 @@ abstract contract TransceiverRegistry {
 
     // =============== Storage Getters/Setters ========================================
 
-    function _setTransceiver(address transceiver) internal returns (uint8 index) {
+    function _setTransceiver(
+        address transceiver
+    ) internal returns (uint8 index) {
         mapping(address => TransceiverInfo) storage transceiverInfos = _getTransceiverInfosStorage();
         _EnabledTransceiverBitmap storage _enabledTransceiverBitmap = _getTransceiverBitmapStorage();
         address[] storage _enabledTransceivers = _getEnabledTransceiversStorage();
@@ -181,7 +183,9 @@ abstract contract TransceiverRegistry {
         return transceiverInfos[transceiver].index;
     }
 
-    function _removeTransceiver(address transceiver) internal {
+    function _removeTransceiver(
+        address transceiver
+    ) internal {
         mapping(address => TransceiverInfo) storage transceiverInfos = _getTransceiverInfosStorage();
         _EnabledTransceiverBitmap storage _enabledTransceiverBitmap = _getTransceiverBitmapStorage();
         address[] storage _enabledTransceivers = _getEnabledTransceiversStorage();
@@ -276,7 +280,9 @@ abstract contract TransceiverRegistry {
     }
 
     // @dev Check that the transceiver is in a valid state.
-    function _checkTransceiverInvariants(address transceiver) private view {
+    function _checkTransceiverInvariants(
+        address transceiver
+    ) private view {
         mapping(address => TransceiverInfo) storage transceiverInfos = _getTransceiverInfosStorage();
         _EnabledTransceiverBitmap storage _enabledTransceiverBitmap = _getTransceiverBitmapStorage();
         _NumTransceivers storage _numTransceivers = _getNumTransceiversStorage();

--- a/evm/src/Transceiver/Transceiver.sol
+++ b/evm/src/Transceiver/Transceiver.sol
@@ -33,7 +33,9 @@ abstract contract Transceiver is
     address public immutable nttManagerToken;
     address immutable deployer;
 
-    constructor(address _nttManager) {
+    constructor(
+        address _nttManager
+    ) {
         nttManager = _nttManager;
         nttManagerToken = INttManager(nttManager).token();
         deployer = msg.sender;
@@ -63,11 +65,15 @@ abstract contract Transceiver is
 
     /// @dev transfer the ownership of the transceiver to a new address
     /// the nttManager should be able to update transceiver ownership.
-    function transferTransceiverOwnership(address newOwner) external onlyNttManager {
+    function transferTransceiverOwnership(
+        address newOwner
+    ) external onlyNttManager {
         _transferOwnership(newOwner);
     }
 
-    function upgrade(address newImplementation) external onlyOwner {
+    function upgrade(
+        address newImplementation
+    ) external onlyOwner {
         _upgrade(newImplementation);
     }
 

--- a/evm/src/Transceiver/WormholeTransceiver/WormholeTransceiver.sol
+++ b/evm/src/Transceiver/WormholeTransceiver/WormholeTransceiver.sol
@@ -60,7 +60,9 @@ contract WormholeTransceiver is
     }
 
     /// @inheritdoc IWormholeTransceiver
-    function receiveMessage(bytes memory encodedMessage) external {
+    function receiveMessage(
+        bytes memory encodedMessage
+    ) external {
         uint16 sourceChainId;
         bytes memory payload;
         (sourceChainId, payload) = _verifyMessage(encodedMessage);
@@ -240,7 +242,9 @@ contract WormholeTransceiver is
         emit SendTransceiverMessage(recipientChain, transceiverMessage);
     }
 
-    function _verifyMessage(bytes memory encodedMessage) internal returns (uint16, bytes memory) {
+    function _verifyMessage(
+        bytes memory encodedMessage
+    ) internal returns (uint16, bytes memory) {
         // verify VAA against Wormhole Core Bridge contract
         (IWormhole.VM memory vm, bool valid, string memory reason) =
             wormhole.parseAndVerifyVM(encodedMessage);
@@ -267,7 +271,9 @@ contract WormholeTransceiver is
         return (vm.emitterChainId, vm.payload);
     }
 
-    function _verifyBridgeVM(IWormhole.VM memory vm) internal view returns (bool) {
+    function _verifyBridgeVM(
+        IWormhole.VM memory vm
+    ) internal view returns (bool) {
         checkFork(wormholeTransceiver_evmChainId);
         return getWormholePeer(vm.emitterChainId) == vm.emitterAddress;
     }

--- a/evm/src/Transceiver/WormholeTransceiver/WormholeTransceiverState.sol
+++ b/evm/src/Transceiver/WormholeTransceiver/WormholeTransceiverState.sol
@@ -174,27 +174,37 @@ abstract contract WormholeTransceiverState is IWormholeTransceiverState, Transce
     // =============== Public Getters ======================================================
 
     /// @inheritdoc IWormholeTransceiverState
-    function isVAAConsumed(bytes32 hash) public view returns (bool) {
+    function isVAAConsumed(
+        bytes32 hash
+    ) public view returns (bool) {
         return _getWormholeConsumedVAAsStorage()[hash];
     }
 
     /// @inheritdoc IWormholeTransceiverState
-    function getWormholePeer(uint16 chainId) public view returns (bytes32) {
+    function getWormholePeer(
+        uint16 chainId
+    ) public view returns (bytes32) {
         return _getWormholePeersStorage()[chainId];
     }
 
     /// @inheritdoc IWormholeTransceiverState
-    function isWormholeRelayingEnabled(uint16 chainId) public view returns (bool) {
+    function isWormholeRelayingEnabled(
+        uint16 chainId
+    ) public view returns (bool) {
         return _getWormholeRelayingEnabledChainsStorage()[chainId].toBool();
     }
 
     /// @inheritdoc IWormholeTransceiverState
-    function isSpecialRelayingEnabled(uint16 chainId) public view returns (bool) {
+    function isSpecialRelayingEnabled(
+        uint16 chainId
+    ) public view returns (bool) {
         return _getSpecialRelayingEnabledChainsStorage()[chainId].toBool();
     }
 
     /// @inheritdoc IWormholeTransceiverState
-    function isWormholeEvmChain(uint16 chainId) public view returns (bool) {
+    function isWormholeEvmChain(
+        uint16 chainId
+    ) public view returns (bool) {
         return _getWormholeEvmChainIdsStorage()[chainId].toBool();
     }
 
@@ -266,15 +276,21 @@ abstract contract WormholeTransceiverState is IWormholeTransceiverState, Transce
 
     // ============= Internal ===============================================================
 
-    function _checkInvalidRelayingConfig(uint16 chainId) internal view returns (bool) {
+    function _checkInvalidRelayingConfig(
+        uint16 chainId
+    ) internal view returns (bool) {
         return isWormholeRelayingEnabled(chainId) && !isWormholeEvmChain(chainId);
     }
 
-    function _shouldRelayViaStandardRelaying(uint16 chainId) internal view returns (bool) {
+    function _shouldRelayViaStandardRelaying(
+        uint16 chainId
+    ) internal view returns (bool) {
         return isWormholeRelayingEnabled(chainId) && isWormholeEvmChain(chainId);
     }
 
-    function _setVAAConsumed(bytes32 hash) internal {
+    function _setVAAConsumed(
+        bytes32 hash
+    ) internal {
         _getWormholeConsumedVAAsStorage()[hash] = true;
     }
 

--- a/evm/src/interfaces/IManagerBase.sol
+++ b/evm/src/interfaces/IManagerBase.sol
@@ -122,28 +122,38 @@ interface IManagerBase {
     /// to be considered valid.
     /// @param threshold The new threshold (number of attestations).
     /// @dev This method can only be executed by the `owner`.
-    function setThreshold(uint8 threshold) external;
+    function setThreshold(
+        uint8 threshold
+    ) external;
 
     /// @notice Sets the transceiver for the given chain.
     /// @param transceiver The address of the transceiver.
     /// @dev This method can only be executed by the `owner`.
-    function setTransceiver(address transceiver) external;
+    function setTransceiver(
+        address transceiver
+    ) external;
 
     /// @notice Removes the transceiver for the given chain.
     /// @param transceiver The address of the transceiver.
     /// @dev This method can only be executed by the `owner`.
-    function removeTransceiver(address transceiver) external;
+    function removeTransceiver(
+        address transceiver
+    ) external;
 
     /// @notice Checks if a message has been approved. The message should have at least
     /// the minimum threshold of attestations from distinct endpoints.
     /// @param digest The digest of the message.
     /// @return - Boolean indicating if message has been approved.
-    function isMessageApproved(bytes32 digest) external view returns (bool);
+    function isMessageApproved(
+        bytes32 digest
+    ) external view returns (bool);
 
     /// @notice Checks if a message has been executed.
     /// @param digest The digest of the message.
     /// @return - Boolean indicating if message has been executed.
-    function isMessageExecuted(bytes32 digest) external view returns (bool);
+    function isMessageExecuted(
+        bytes32 digest
+    ) external view returns (bool);
 
     /// @notice Returns the next message sequence.
     function nextMessageSequence() external view returns (uint64);
@@ -152,7 +162,9 @@ interface IManagerBase {
     /// @dev This is upgraded via a proxy, and can only be executed
     /// by the `owner`.
     /// @param newImplementation The address of the new implementation.
-    function upgrade(address newImplementation) external;
+    function upgrade(
+        address newImplementation
+    ) external;
 
     /// @notice Pauses the manager.
     function pause() external;
@@ -177,7 +189,9 @@ interface IManagerBase {
     /// @notice Returns the number of attestations for a given message.
     /// @param digest The digest of the message.
     /// @return count The number of attestations received for the given message digest
-    function messageAttestations(bytes32 digest) external view returns (uint8 count);
+    function messageAttestations(
+        bytes32 digest
+    ) external view returns (uint8 count);
 
     /// @notice Returns of the address of the token managed by this contract.
     function token() external view returns (address);

--- a/evm/src/interfaces/INttManager.sol
+++ b/evm/src/interfaces/INttManager.sol
@@ -181,11 +181,15 @@ interface INttManager is IManagerBase {
     /// @notice Cancels an outbound transfer that's been queued.
     /// @dev This method is called by the client to cancel an outbound transfer that's been queued.
     /// @param queueSequence The sequence of the message in the queue.
-    function cancelOutboundQueuedTransfer(uint64 queueSequence) external;
+    function cancelOutboundQueuedTransfer(
+        uint64 queueSequence
+    ) external;
 
     /// @notice Complete an inbound queued transfer.
     /// @param digest The digest of the message to complete.
-    function completeInboundQueuedTransfer(bytes32 digest) external;
+    function completeInboundQueuedTransfer(
+        bytes32 digest
+    ) external;
 
     /// @notice Called by an Endpoint contract to deliver a verified attestation.
     /// @dev This function enforces attestation threshold and replay logic for messages. Once all
@@ -220,7 +224,9 @@ interface INttManager is IManagerBase {
 
     /// @notice Returns registered peer contract for a given chain.
     /// @param chainId_ Wormhole chain ID.
-    function getPeer(uint16 chainId_) external view returns (NttManagerPeer memory);
+    function getPeer(
+        uint16 chainId_
+    ) external view returns (NttManagerPeer memory);
 
     /// @notice Sets the corresponding peer.
     /// @dev The nttManager that executes the message sets the source nttManager as the peer.
@@ -240,7 +246,9 @@ interface INttManager is IManagerBase {
     /// @dev This method can only be executed by the `owner`.
     /// @param limit The new outbound limit. This is formatted in the normal
     ///              token representation. e.g. a limit of 100 for a token with 6 decimals = 100_000_000
-    function setOutboundLimit(uint256 limit) external;
+    function setOutboundLimit(
+        uint256 limit
+    ) external;
 
     /// @notice Sets the inbound transfer limit for a given chain.
     /// @dev This method can only be executed by the `owner`.

--- a/evm/src/interfaces/INttToken.sol
+++ b/evm/src/interfaces/INttToken.sol
@@ -27,10 +27,14 @@ interface INttToken {
     function mint(address account, uint256 amount) external;
 
     // NOTE: the `setMinter` method is not present in the standard ERC20 interface.
-    function setMinter(address newMinter) external;
+    function setMinter(
+        address newMinter
+    ) external;
 
     // NOTE: NttTokens in `burn` mode require the `burn` method to be present.
     //       This method is not present in the standard ERC20 interface, but is
     //       found in the `ERC20Burnable` interface.
-    function burn(uint256 amount) external;
+    function burn(
+        uint256 amount
+    ) external;
 }

--- a/evm/src/interfaces/IRateLimiter.sol
+++ b/evm/src/interfaces/IRateLimiter.sol
@@ -97,7 +97,9 @@ interface IRateLimiter {
     /// @notice Returns the currently remaining inbound capacity allowed from a given chain
     ///         before transfers are queued auutomatically
     /// @param chainId The Wormhole chain ID of the peer
-    function getCurrentInboundCapacity(uint16 chainId) external view returns (uint256);
+    function getCurrentInboundCapacity(
+        uint16 chainId
+    ) external view returns (uint256);
 
     /// @notice Returns the queued transfer details for a given message digest in the inbound queue
     /// @param digest The digest of the transfer in the inbound queue

--- a/evm/src/interfaces/ITransceiver.sol
+++ b/evm/src/interfaces/ITransceiver.sol
@@ -74,9 +74,13 @@ interface ITransceiver {
 
     /// @notice Upgrades the transceiver to a new implementation.
     /// @param newImplementation The address of the new implementation contract
-    function upgrade(address newImplementation) external;
+    function upgrade(
+        address newImplementation
+    ) external;
 
     /// @notice Transfers the ownership of the transceiver to a new address.
     /// @param newOwner The address of the new owner
-    function transferTransceiverOwnership(address newOwner) external;
+    function transferTransceiverOwnership(
+        address newOwner
+    ) external;
 }

--- a/evm/src/interfaces/IWormholeTransceiver.sol
+++ b/evm/src/interfaces/IWormholeTransceiver.sol
@@ -60,7 +60,9 @@ interface IWormholeTransceiver is IWormholeTransceiverState {
     ///         This function should verify the `encodedVm` and then deliver the attestation
     /// to the transceiver NttManager contract.
     /// @param encodedMessage The attested message.
-    function receiveMessage(bytes memory encodedMessage) external;
+    function receiveMessage(
+        bytes memory encodedMessage
+    ) external;
 
     /// @notice Parses the encoded instruction and returns the instruction struct.
     ///         This instruction is specific to the WormholeTransceiver contract.

--- a/evm/src/interfaces/IWormholeTransceiverState.sol
+++ b/evm/src/interfaces/IWormholeTransceiverState.sol
@@ -72,23 +72,33 @@ interface IWormholeTransceiverState {
     /// @dev that peers are registered under Wormhole chain ID values.
     /// @param chainId The Wormhole chain ID of the peer to get.
     /// @return peerContract The address of the peer contract on the given chain.
-    function getWormholePeer(uint16 chainId) external view returns (bytes32);
+    function getWormholePeer(
+        uint16 chainId
+    ) external view returns (bytes32);
 
     /// @notice Returns a boolean indicating whether the given VAA hash has been consumed.
     /// @param hash The VAA hash to check.
-    function isVAAConsumed(bytes32 hash) external view returns (bool);
+    function isVAAConsumed(
+        bytes32 hash
+    ) external view returns (bool);
 
     /// @notice Returns a boolean indicating whether Wormhole relaying is enabled for the given chain.
     /// @param chainId The Wormhole chain ID to check.
-    function isWormholeRelayingEnabled(uint16 chainId) external view returns (bool);
+    function isWormholeRelayingEnabled(
+        uint16 chainId
+    ) external view returns (bool);
 
     /// @notice Returns a boolean indicating whether special relaying is enabled for the given chain.
     /// @param chainId The Wormhole chain ID to check.
-    function isSpecialRelayingEnabled(uint16 chainId) external view returns (bool);
+    function isSpecialRelayingEnabled(
+        uint16 chainId
+    ) external view returns (bool);
 
     /// @notice Returns a boolean indicating whether the given chain is EVM compatible.
     /// @param chainId The Wormhole chain ID to check.
-    function isWormholeEvmChain(uint16 chainId) external view returns (bool);
+    function isWormholeEvmChain(
+        uint16 chainId
+    ) external view returns (bool);
 
     /// @notice Set the Wormhole peer contract for the given chain.
     /// @dev This function is only callable by the `owner`.

--- a/evm/src/libraries/BooleanFlag.sol
+++ b/evm/src/libraries/BooleanFlag.sol
@@ -15,18 +15,24 @@ library BooleanFlagLib {
     uint256 constant FALSE = 0;
     uint256 constant TRUE = 1;
 
-    function isSet(BooleanFlag value) internal pure returns (bool) {
+    function isSet(
+        BooleanFlag value
+    ) internal pure returns (bool) {
         return BooleanFlag.unwrap(value) == TRUE;
     }
 
-    function toBool(BooleanFlag value) internal pure returns (bool) {
+    function toBool(
+        BooleanFlag value
+    ) internal pure returns (bool) {
         if (BooleanFlag.unwrap(value) == 0) return false;
         if (BooleanFlag.unwrap(value) == 1) return true;
 
         revert InvalidBoolValue(value);
     }
 
-    function toWord(bool value) internal pure returns (BooleanFlag) {
+    function toWord(
+        bool value
+    ) internal pure returns (BooleanFlag) {
         if (value) {
             return BooleanFlag.wrap(TRUE);
         } else {

--- a/evm/src/libraries/Implementation.sol
+++ b/evm/src/libraries/Implementation.sol
@@ -77,7 +77,9 @@ abstract contract Implementation is Initializable, ERC1967Upgrade {
 
     function _checkImmutables() internal view virtual;
 
-    function _upgrade(address newImplementation) internal {
+    function _upgrade(
+        address newImplementation
+    ) internal {
         _checkDelegateCall();
         _upgradeTo(newImplementation);
 
@@ -98,7 +100,9 @@ abstract contract Implementation is Initializable, ERC1967Upgrade {
         return _getMigratesImmutablesStorage().value;
     }
 
-    function _setMigratesImmutables(bool value) internal {
+    function _setMigratesImmutables(
+        bool value
+    ) internal {
         _getMigratesImmutablesStorage().value = value;
     }
 }

--- a/evm/src/libraries/PausableOwnable.sol
+++ b/evm/src/libraries/PausableOwnable.sol
@@ -17,7 +17,9 @@ abstract contract PausableOwnable is PausableUpgradeable, OwnableUpgradeable {
     /*
      * @dev Modifier to allow only the Pauser to access some functionality
      */
-    function _checkOwnerOrPauser(address owner) internal view {
+    function _checkOwnerOrPauser(
+        address owner
+    ) internal view {
         if (pauser() != msg.sender && owner != msg.sender) {
             revert InvalidPauser(msg.sender);
         }
@@ -31,7 +33,9 @@ abstract contract PausableOwnable is PausableUpgradeable, OwnableUpgradeable {
     /**
      * @dev Transfers the ability to pause to a new account (`newPauser`).
      */
-    function transferPauserCapability(address newPauser) public virtual onlyOwnerOrPauser {
+    function transferPauserCapability(
+        address newPauser
+    ) public virtual onlyOwnerOrPauser {
         PauserStorage storage $ = _getPauserStorage();
         address oldPauser = $._pauser;
         $._pauser = newPauser;

--- a/evm/src/libraries/PausableUpgradeable.sol
+++ b/evm/src/libraries/PausableUpgradeable.sol
@@ -75,15 +75,21 @@ abstract contract PausableUpgradeable is Initializable {
         }
     }
 
-    function _setPauseStorage(uint256 pauseFlag) internal {
+    function _setPauseStorage(
+        uint256 pauseFlag
+    ) internal {
         _getPauseStorage()._pauseFlag = pauseFlag;
     }
 
-    function __Paused_init(address initialPauser) internal onlyInitializing {
+    function __Paused_init(
+        address initialPauser
+    ) internal onlyInitializing {
         __Paused_init_unchained(initialPauser);
     }
 
-    function __Paused_init_unchained(address initialPauser) internal onlyInitializing {
+    function __Paused_init_unchained(
+        address initialPauser
+    ) internal onlyInitializing {
         // set pause flag to false initially
         PauseStorage storage $ = _getPauseStorage();
         $._pauseFlag = NOT_PAUSED;

--- a/evm/src/libraries/RateLimiter.sol
+++ b/evm/src/libraries/RateLimiter.sol
@@ -93,7 +93,9 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
         rateLimitParams.lastTxTimestamp = uint64(block.timestamp);
     }
 
-    function _setOutboundLimit(TrimmedAmount limit) internal {
+    function _setOutboundLimit(
+        TrimmedAmount limit
+    ) internal {
         _setLimit(limit, _getOutboundLimitParamsStorage());
     }
 
@@ -117,11 +119,15 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
         _setLimit(limit, _getInboundLimitParamsStorage()[chainId_]);
     }
 
-    function getInboundLimitParams(uint16 chainId_) public view returns (RateLimitParams memory) {
+    function getInboundLimitParams(
+        uint16 chainId_
+    ) public view returns (RateLimitParams memory) {
         return _getInboundLimitParamsStorage()[chainId_];
     }
 
-    function getCurrentInboundCapacity(uint16 chainId_) public view returns (uint256) {
+    function getCurrentInboundCapacity(
+        uint16 chainId_
+    ) public view returns (uint256) {
         TrimmedAmount trimmedCapacity = _getCurrentCapacity(getInboundLimitParams(chainId_));
         uint8 decimals = tokenDecimals();
         return trimmedCapacity.untrim(decimals);
@@ -199,14 +205,18 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
         }
     }
 
-    function _consumeOutboundAmount(TrimmedAmount amount) internal {
+    function _consumeOutboundAmount(
+        TrimmedAmount amount
+    ) internal {
         if (rateLimitDuration == 0) return;
         _consumeRateLimitAmount(
             amount, _getCurrentCapacity(getOutboundLimitParams()), _getOutboundLimitParamsStorage()
         );
     }
 
-    function _backfillOutboundAmount(TrimmedAmount amount) internal {
+    function _backfillOutboundAmount(
+        TrimmedAmount amount
+    ) internal {
         if (rateLimitDuration == 0) return;
         _backfillRateLimitAmount(
             amount, _getCurrentCapacity(getOutboundLimitParams()), _getOutboundLimitParamsStorage()
@@ -251,7 +261,9 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
         rateLimitParams.currentCapacity = capacity.saturatingAdd(amount).min(rateLimitParams.limit);
     }
 
-    function _isOutboundAmountRateLimited(TrimmedAmount amount) internal view returns (bool) {
+    function _isOutboundAmountRateLimited(
+        TrimmedAmount amount
+    ) internal view returns (bool) {
         return rateLimitDuration != 0
             ? _isAmountRateLimited(_getCurrentCapacity(getOutboundLimitParams()), amount)
             : false;

--- a/evm/src/libraries/TransceiverHelpers.sol
+++ b/evm/src/libraries/TransceiverHelpers.sol
@@ -3,13 +3,17 @@ pragma solidity >=0.8.8 <0.9.0;
 
 error InvalidFork(uint256 evmChainId, uint256 blockChainId);
 
-function checkFork(uint256 evmChainId) view {
+function checkFork(
+    uint256 evmChainId
+) view {
     if (isFork(evmChainId)) {
         revert InvalidFork(evmChainId, block.chainid);
     }
 }
 
-function isFork(uint256 evmChainId) view returns (bool) {
+function isFork(
+    uint256 evmChainId
+) view returns (bool) {
     return evmChainId != block.chainid;
 }
 
@@ -18,7 +22,9 @@ function min(uint256 a, uint256 b) pure returns (uint256) {
 }
 
 // @dev Count the number of set bits in a uint64
-function countSetBits(uint64 x) pure returns (uint8 count) {
+function countSetBits(
+    uint64 x
+) pure returns (uint8 count) {
     while (x != 0) {
         x &= x - 1;
         count++;

--- a/evm/src/libraries/TrimmedAmount.sol
+++ b/evm/src/libraries/TrimmedAmount.sol
@@ -23,7 +23,9 @@ error NumberOfDecimalsNotEqual(uint8 decimals, uint8 decimalsOther);
 
 uint8 constant TRIMMED_DECIMALS = 8;
 
-function unwrap(TrimmedAmount a) pure returns (uint72) {
+function unwrap(
+    TrimmedAmount a
+) pure returns (uint72) {
     return TrimmedAmount.unwrap(a);
 }
 
@@ -93,7 +95,9 @@ library TrimmedAmountLib {
     /// @param amount The amount to be trimmed.
     error AmountTooLarge(uint256 amount);
 
-    function getAmount(TrimmedAmount a) internal pure returns (uint64) {
+    function getAmount(
+        TrimmedAmount a
+    ) internal pure returns (uint64) {
         // Extract the raw integer value from TrimmedAmount
         uint72 rawValue = TrimmedAmount.unwrap(a);
 
@@ -102,7 +106,9 @@ library TrimmedAmountLib {
         return result;
     }
 
-    function getDecimals(TrimmedAmount a) internal pure returns (uint8) {
+    function getDecimals(
+        TrimmedAmount a
+    ) internal pure returns (uint8) {
         return uint8(TrimmedAmount.unwrap(a) & 0xFF);
     }
 
@@ -114,7 +120,9 @@ library TrimmedAmountLib {
         return TrimmedAmount.wrap((TrimmedAmount.unwrap(a) & ~uint72(0xFF)) | decimals);
     }
 
-    function isNull(TrimmedAmount a) internal pure returns (bool) {
+    function isNull(
+        TrimmedAmount a
+    ) internal pure returns (bool) {
         return (getAmount(a) == 0 && getDecimals(a) == 0);
     }
 
@@ -160,7 +168,9 @@ library TrimmedAmountLib {
         );
     }
 
-    function max(uint8 decimals) internal pure returns (TrimmedAmount) {
+    function max(
+        uint8 decimals
+    ) internal pure returns (TrimmedAmount) {
         uint8 actualDecimals = minUint8(TRIMMED_DECIMALS, decimals);
         return packTrimmedAmount(type(uint64).max, actualDecimals);
     }

--- a/evm/src/libraries/external/Initializable.sol
+++ b/evm/src/libraries/external/Initializable.sol
@@ -153,7 +153,9 @@ abstract contract Initializable {
      *
      * Emits an {Initialized} event.
      */
-    modifier reinitializer(uint64 version) {
+    modifier reinitializer(
+        uint64 version
+    ) {
         // solhint-disable-next-line var-name-mixedcase
         InitializableStorage storage $ = _getInitializableStorage();
 

--- a/evm/src/libraries/external/OwnableUpgradeable.sol
+++ b/evm/src/libraries/external/OwnableUpgradeable.sol
@@ -53,11 +53,15 @@ abstract contract OwnableUpgradeable is Initializable, ContextUpgradeable, IOwna
     /**
      * @dev Initializes the contract setting the address provided by the deployer as the initial owner.
      */
-    function __Ownable_init(address initialOwner) internal onlyInitializing {
+    function __Ownable_init(
+        address initialOwner
+    ) internal onlyInitializing {
         __Ownable_init_unchained(initialOwner);
     }
 
-    function __Ownable_init_unchained(address initialOwner) internal onlyInitializing {
+    function __Ownable_init_unchained(
+        address initialOwner
+    ) internal onlyInitializing {
         if (initialOwner == address(0)) {
             revert OwnableInvalidOwner(address(0));
         }
@@ -93,7 +97,9 @@ abstract contract OwnableUpgradeable is Initializable, ContextUpgradeable, IOwna
      * @dev Transfers ownership of the contract to a new account (`newOwner`).
      * Can only be called by the current owner.
      */
-    function transferOwnership(address newOwner) public virtual onlyOwner {
+    function transferOwnership(
+        address newOwner
+    ) public virtual onlyOwner {
         if (newOwner == address(0)) {
             revert OwnableInvalidOwner(address(0));
         }
@@ -104,7 +110,9 @@ abstract contract OwnableUpgradeable is Initializable, ContextUpgradeable, IOwna
      * @dev Transfers ownership of the contract to a new account (`newOwner`).
      * Internal function without access restriction.
      */
-    function _transferOwnership(address newOwner) internal virtual {
+    function _transferOwnership(
+        address newOwner
+    ) internal virtual {
         OwnableStorage storage $ = _getOwnableStorage();
         address oldOwner = $._owner;
         $._owner = newOwner;

--- a/evm/src/mocks/DummyToken.sol
+++ b/evm/src/mocks/DummyToken.sol
@@ -26,7 +26,9 @@ contract DummyToken is ERC20, ERC1967Upgrade {
         revert("Locking nttManager should not call 'burn()'");
     }
 
-    function upgrade(address newImplementation) public {
+    function upgrade(
+        address newImplementation
+    ) public {
         _upgradeTo(newImplementation);
     }
 }
@@ -37,7 +39,9 @@ contract DummyTokenMintAndBurn is DummyToken {
         _mint(to, amount);
     }
 
-    function burn(uint256 amount) public {
+    function burn(
+        uint256 amount
+    ) public {
         // TODO - add access control here?
         _burn(msg.sender, amount);
     }
@@ -46,7 +50,9 @@ contract DummyTokenMintAndBurn is DummyToken {
 contract DummyTokenDifferentDecimals is DummyTokenMintAndBurn {
     uint8 private immutable _decimals;
 
-    constructor(uint8 newDecimals) {
+    constructor(
+        uint8 newDecimals
+    ) {
         _decimals = newDecimals;
     }
 
@@ -60,7 +66,9 @@ contract DummyTokenBroken is DummyToken {
         revert("broken decimals");
     }
 
-    function balanceOf(address) public pure override returns (uint256) {
+    function balanceOf(
+        address
+    ) public pure override returns (uint256) {
         revert("broken balanceOf");
     }
 }

--- a/evm/src/wormhole/Governance.sol
+++ b/evm/src/wormhole/Governance.sol
@@ -74,11 +74,15 @@ contract Governance {
         bytes callData;
     }
 
-    constructor(address _wormhole) {
+    constructor(
+        address _wormhole
+    ) {
         wormhole = IWormhole(_wormhole);
     }
 
-    function performGovernance(bytes calldata vaa) external {
+    function performGovernance(
+        bytes calldata vaa
+    ) external {
         IWormhole.VM memory verified = _verifyGovernanceVAA(vaa);
         GeneralPurposeGovernanceMessage memory message =
             parseGeneralPurposeGovernanceMessage(verified.payload);
@@ -103,7 +107,9 @@ contract Governance {
         }
     }
 
-    function _replayProtect(bytes32 digest) internal {
+    function _replayProtect(
+        bytes32 digest
+    ) internal {
         mapping(bytes32 => bool) storage $ = _getConsumedGovernanceActionsStorage();
         if ($[digest]) {
             revert GovernanceActionAlreadyConsumed(digest);

--- a/evm/test/IntegrationRelayer.t.sol
+++ b/evm/test/IntegrationRelayer.t.sol
@@ -564,7 +564,9 @@ contract TestEndToEndRelayer is IntegrationHelpers, IRateLimiterEvents, Wormhole
         assertGt(refundAddress.balance, 0);
     }
 
-    function copyBytes(bytes memory _bytes) private pure returns (bytes memory) {
+    function copyBytes(
+        bytes memory _bytes
+    ) private pure returns (bytes memory) {
         bytes memory copy = new bytes(_bytes.length);
         uint256 max = _bytes.length + 31;
         for (uint256 i = 32; i <= max; i += 32) {

--- a/evm/test/IntegrationStandalone.t.sol
+++ b/evm/test/IntegrationStandalone.t.sol
@@ -639,7 +639,9 @@ contract TestEndToEndBase is Test, IRateLimiterEvents {
         vm.stopPrank();
     }
 
-    function copyBytes(bytes memory _bytes) private pure returns (bytes memory) {
+    function copyBytes(
+        bytes memory _bytes
+    ) private pure returns (bytes memory) {
         bytes memory copy = new bytes(_bytes.length);
         uint256 max = _bytes.length + 31;
         for (uint256 i = 32; i <= max; i += 32) {
@@ -650,7 +652,9 @@ contract TestEndToEndBase is Test, IRateLimiterEvents {
         return copy;
     }
 
-    function encodeTransceiverInstruction(bool relayer_off) public view returns (bytes memory) {
+    function encodeTransceiverInstruction(
+        bool relayer_off
+    ) public view returns (bytes memory) {
         WormholeTransceiver.WormholeTransceiverInstruction memory instruction =
             IWormholeTransceiver.WormholeTransceiverInstruction(relayer_off);
         bytes memory encodedInstructionWormhole =
@@ -664,7 +668,9 @@ contract TestEndToEndBase is Test, IRateLimiterEvents {
     }
 
     // Encode an instruction for each of the relayers
-    function encodeTransceiverInstructions(bool relayer_off) public view returns (bytes memory) {
+    function encodeTransceiverInstructions(
+        bool relayer_off
+    ) public view returns (bytes memory) {
         WormholeTransceiver.WormholeTransceiverInstruction memory instruction =
             IWormholeTransceiver.WormholeTransceiverInstruction(relayer_off);
 

--- a/evm/test/NttManager.t.sol
+++ b/evm/test/NttManager.t.sol
@@ -75,7 +75,9 @@ contract TestNttManager is Test, IRateLimiterEvents {
     // === pure unit tests
 
     // naive implementation of countSetBits to test against
-    function simpleCount(uint64 n) public pure returns (uint8) {
+    function simpleCount(
+        uint64 n
+    ) public pure returns (uint8) {
         uint8 count;
 
         while (n > 0) {
@@ -86,7 +88,9 @@ contract TestNttManager is Test, IRateLimiterEvents {
         return count;
     }
 
-    function testFuzz_countSetBits(uint64 n) public {
+    function testFuzz_countSetBits(
+        uint64 n
+    ) public {
         assertEq(simpleCount(n), countSetBits(n));
     }
 

--- a/evm/test/Upgrades.t.sol
+++ b/evm/test/Upgrades.t.sol
@@ -585,7 +585,9 @@ contract TestUpgrades is Test, IRateLimiterEvents {
         vm.stopPrank();
     }
 
-    function encodeTransceiverInstruction(bool relayer_off) public view returns (bytes memory) {
+    function encodeTransceiverInstruction(
+        bool relayer_off
+    ) public view returns (bytes memory) {
         WormholeTransceiver.WormholeTransceiverInstruction memory instruction =
             IWormholeTransceiver.WormholeTransceiverInstruction(relayer_off);
         bytes memory encodedInstructionWormhole =

--- a/evm/test/interfaces/ITransceiverReceiver.sol
+++ b/evm/test/interfaces/ITransceiverReceiver.sol
@@ -2,5 +2,7 @@
 pragma solidity >=0.8.8 <0.9.0;
 
 interface ITransceiverReceiver {
-    function receiveMessage(bytes memory encodedMessage) external;
+    function receiveMessage(
+        bytes memory encodedMessage
+    ) external;
 }

--- a/evm/test/libraries/Implementation.t.sol
+++ b/evm/test/libraries/Implementation.t.sol
@@ -16,7 +16,9 @@ contract TestImplementation is Implementation {
 
     function _checkImmutables() internal view override {}
 
-    function upgrade(address newImplementation) external {
+    function upgrade(
+        address newImplementation
+    ) external {
         _upgrade(newImplementation);
     }
 
@@ -42,7 +44,9 @@ contract TestImplementation2 is Implementation {
 
     function _checkImmutables() internal view override {}
 
-    function upgrade(address newImplementation) external {
+    function upgrade(
+        address newImplementation
+    ) external {
         _upgrade(newImplementation);
     }
 

--- a/evm/test/libraries/IntegrationHelpers.sol
+++ b/evm/test/libraries/IntegrationHelpers.sol
@@ -45,7 +45,9 @@ contract IntegrationHelpers is Test {
         });
     }
 
-    function encodeTransceiverInstruction(bool relayer_off) public view returns (bytes memory) {
+    function encodeTransceiverInstruction(
+        bool relayer_off
+    ) public view returns (bytes memory) {
         TransceiverStructs.TransceiverInstruction memory TransceiverInstruction =
             buildTransceiverInstruction(relayer_off);
         TransceiverStructs.TransceiverInstruction[] memory TransceiverInstructions =

--- a/evm/test/libraries/Utils.sol
+++ b/evm/test/libraries/Utils.sol
@@ -12,7 +12,9 @@ library Utils {
     ///      This is useful for testing that a contract's constructor does not
     ///      write to storage (and is therefore suitable as a constructor for an
     ///      implementation behind an upgradable proxy.)
-    function assertSafeUpgradeableConstructor(VmSafe.AccountAccess[] memory accesses) public pure {
+    function assertSafeUpgradeableConstructor(
+        VmSafe.AccountAccess[] memory accesses
+    ) public pure {
         bytes32 INITIALIZABLE_STORAGE =
             0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00;
 

--- a/evm/test/mocks/DummyTransceiver.sol
+++ b/evm/test/mocks/DummyTransceiver.sol
@@ -10,7 +10,9 @@ contract DummyTransceiver is Transceiver, ITransceiverReceiver {
     uint16 constant SENDING_CHAIN_ID = 1;
     bytes4 constant TEST_TRANSCEIVER_PAYLOAD_PREFIX = 0x99455454;
 
-    constructor(address nttManager) Transceiver(nttManager) {}
+    constructor(
+        address nttManager
+    ) Transceiver(nttManager) {}
 
     function getTransceiverType() external pure override returns (string memory) {
         return "dummy";
@@ -35,7 +37,9 @@ contract DummyTransceiver is Transceiver, ITransceiverReceiver {
         // do nothing
     }
 
-    function receiveMessage(bytes memory encodedMessage) external {
+    function receiveMessage(
+        bytes memory encodedMessage
+    ) external {
         TransceiverStructs.TransceiverMessage memory parsedTransceiverMessage;
         TransceiverStructs.NttManagerMessage memory parsedNttManagerMessage;
         (parsedTransceiverMessage, parsedNttManagerMessage) = TransceiverStructs

--- a/evm/test/mocks/MockTransceivers.sol
+++ b/evm/test/mocks/MockTransceivers.sol
@@ -25,7 +25,9 @@ contract MockWormholeTransceiverContract is WormholeTransceiver {
 
     /// @dev Override the [`transferOwnership`] method from OwnableUpgradeable
     /// to ensure owner of this contract is in sync with the onwer of the NttManager contract.
-    function transferOwnership(address newOwner) public view override onlyOwner {
+    function transferOwnership(
+        address newOwner
+    ) public view override onlyOwner {
         revert CannotTransferTransceiverOwnership(owner(), newOwner);
     }
 }

--- a/evm/test/wormhole/Governance.t.sol
+++ b/evm/test/wormhole/Governance.t.sol
@@ -91,7 +91,9 @@ contract GovernanceTest is Test {
         return guardian.encodeAndSignMessage(vaa);
     }
 
-    function buildVaa(bytes memory payload) public view returns (IWormhole.VM memory) {
+    function buildVaa(
+        bytes memory payload
+    ) public view returns (IWormhole.VM memory) {
         return IWormhole.VM({
             version: 1,
             timestamp: uint32(block.timestamp),


### PR DESCRIPTION
This partially undoes #501, which itself updated formatting after an upstream foundry change. That upstream change has been reverted https://github.com/foundry-rs/foundry/pull/8762, so we do the same here.