### PR TITLE
sdk: update deprecated solana web3.js methods

### DIFF
--- a/solana/tests/anchor.test.ts
+++ b/solana/tests/anchor.test.ts
@@ -24,7 +24,12 @@ import {
 import { SolanaWormholeCore } from "@wormhole-foundation/sdk-solana-core";
 import * as fs from "fs";
 
-import { PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
+import {
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
 import { DummyTransferHook } from "../ts/idl/1_0_0/ts/dummy_transfer_hook.js";
 import { SolanaNtt } from "../ts/sdk/index.js";
 
@@ -159,8 +164,9 @@ describe("example-native-token-transfers", () => {
       transaction.feePayer = payer.publicKey;
       transaction.recentBlockhash = blockhash;
 
-      const txid = await connection.sendTransaction(transaction, [payer, mint]);
-      await connection.confirmTransaction(txid, "confirmed");
+      await sendAndConfirmTransaction(connection, transaction, [payer, mint], {
+        commitment: "confirmed",
+      });
 
       tokenAccount = await spl.createAssociatedTokenAccount(
         connection,
@@ -270,8 +276,9 @@ describe("example-native-token-transfers", () => {
       transaction.recentBlockhash = blockhash;
 
       transaction.sign(payer);
-      const txid = await connection.sendTransaction(transaction, [payer]);
-      await connection.confirmTransaction(txid, "confirmed");
+      await sendAndConfirmTransaction(connection, transaction, [payer], {
+        commitment: "confirmed",
+      });
     });
 
     test("Can send tokens", async () => {

--- a/solana/tests/anchor.test.ts
+++ b/solana/tests/anchor.test.ts
@@ -154,7 +154,7 @@ describe("example-native-token-transfers", () => {
         )
       );
 
-      const { blockhash } = await connection.getRecentBlockhash();
+      const { blockhash } = await connection.getLatestBlockhash();
 
       transaction.feePayer = payer.publicKey;
       transaction.recentBlockhash = blockhash;
@@ -266,7 +266,7 @@ describe("example-native-token-transfers", () => {
         initializeExtraAccountMetaListInstruction
       );
       transaction.feePayer = payer.publicKey;
-      const { blockhash } = await connection.getRecentBlockhash();
+      const { blockhash } = await connection.getLatestBlockhash();
       transaction.recentBlockhash = blockhash;
 
       transaction.sign(payer);

--- a/solana/ts/sdk/ntt.ts
+++ b/solana/ts/sdk/ntt.ts
@@ -29,7 +29,7 @@ import {
   WormholeNttTransceiver,
 } from "@wormhole-foundation/sdk-definitions-ntt";
 import {
-    AnySolanaAddress,
+  AnySolanaAddress,
   SolanaAddress,
   SolanaChains,
   SolanaPlatform,
@@ -46,16 +46,15 @@ import { NTT, NttQuoter, WEI_PER_GWEI } from "../lib/index.js";
 
 import { IdlVersion, NttBindings, getNttProgram } from "../lib/bindings.js";
 
-export class SolanaNttWormholeTransceiver<N extends Network, C extends SolanaChains>
-  implements NttTransceiver<N, C, WormholeNttTransceiver.VAA> {
-
-  constructor(
-    readonly manager: SolanaNtt<N, C>,
-    readonly address: PublicKey
-  ) {}
+export class SolanaNttWormholeTransceiver<
+  N extends Network,
+  C extends SolanaChains
+> implements NttTransceiver<N, C, WormholeNttTransceiver.VAA>
+{
+  constructor(readonly manager: SolanaNtt<N, C>, readonly address: PublicKey) {}
 
   async getPauser(): Promise<AccountAddress<C> | null> {
-    return null
+    return null;
   }
 
   async *setPauser(_newPauser: AccountAddress<C>, _payer: AccountAddress<C>) {
@@ -71,7 +70,10 @@ export class SolanaNttWormholeTransceiver<N extends Network, C extends SolanaCha
   }
 
   getAddress(): ChainAddress<C> {
-    return { chain: this.manager.chain, address: toUniversal(this.manager.chain, this.address.toBase58()) };
+    return {
+      chain: this.manager.chain,
+      address: toUniversal(this.manager.chain, this.address.toBase58()),
+    };
   }
 
   async *setPeer(peer: ChainAddress<C>, payer: AccountAddress<C>) {
@@ -94,7 +96,8 @@ export class SolanaNttWormholeTransceiver<N extends Network, C extends SolanaCha
 }
 
 export class SolanaNtt<N extends Network, C extends SolanaChains>
-  implements Ntt<N, C> {
+  implements Ntt<N, C>
+{
   core: SolanaWormholeCore<N, C>;
   pdas: NTT.Pdas;
 
@@ -149,7 +152,10 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
     if (ix !== 0) return null;
     if (this.whTransceiverAddress === undefined) return null;
 
-    return new SolanaNttWormholeTransceiver(this, new PublicKey(this.whTransceiverAddress));
+    return new SolanaNttWormholeTransceiver(
+      this,
+      new PublicKey(this.whTransceiverAddress)
+    );
   }
 
   async getMode(): Promise<Ntt.Mode> {
@@ -190,7 +196,7 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
 
   async getThreshold(): Promise<number> {
     const config = await this.getConfig();
-    return config.threshold
+    return config.threshold;
   }
 
   async getOwner(): Promise<AccountAddress<C>> {
@@ -199,7 +205,7 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
   }
 
   async getPauser(): Promise<AccountAddress<C> | null> {
-    return null
+    return null;
   }
 
   async *setOwner(newOwner: AnySolanaAddress, payer: AccountAddress<C>) {
@@ -280,12 +286,17 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
   }
 
   async getPeer<C extends Chain>(chain: C): Promise<Ntt.Peer<C> | null> {
-    const peer = await this.program.account.nttManagerPeer.fetchNullable(this.pdas.peerAccount(chain));
+    const peer = await this.program.account.nttManagerPeer.fetchNullable(
+      this.pdas.peerAccount(chain)
+    );
 
     if (!peer) return null;
 
     return {
-      address: { chain: chain, address: toUniversal(chain, new Uint8Array(peer.address)) },
+      address: {
+        chain: chain,
+        address: toUniversal(chain, new Uint8Array(peer.address)),
+      },
       tokenDecimals: peer.tokenDecimals,
       inboundLimit: await this.getInboundLimit(chain),
     };
@@ -308,7 +319,7 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
       );
     } catch (e) {
       // This might happen if e.g. the program is not deployed yet.
-      const version = "2.0.0"
+      const version = "2.0.0";
       return version;
     }
   }
@@ -504,17 +515,17 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
     const transferIx =
       config.mode.locking != null
         ? NTT.createTransferLockInstruction(
-          this.program,
-          config,
-          txArgs,
-          this.pdas
-        )
+            this.program,
+            config,
+            txArgs,
+            this.pdas
+          )
         : NTT.createTransferBurnInstruction(
-          this.program,
-          config,
-          txArgs,
-          this.pdas
-        );
+            this.program,
+            config,
+            txArgs,
+            this.pdas
+          );
 
     const releaseIx = NTT.createReleaseOutboundInstruction(
       this.program,
@@ -555,10 +566,12 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
       luts.push(await this.getAddressLookupTable());
     } catch {}
 
+    const { blockhash } = await this.connection.getLatestBlockhash();
+
     const messageV0 = new TransactionMessage({
       payerKey: payerAddress,
       instructions: tx.instructions,
-      recentBlockhash: (await this.connection.getRecentBlockhash()).blockhash,
+      recentBlockhash: blockhash,
     }).compileToV0Message(luts);
 
     const vtx = new VersionedTransaction(messageV0);
@@ -654,15 +667,15 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
     const releaseIx =
       config.mode.locking != null
         ? NTT.createReleaseInboundUnlockInstruction(
-          this.program,
-          config,
-          releaseArgs
-        )
+            this.program,
+            config,
+            releaseArgs
+          )
         : NTT.createReleaseInboundMintInstruction(
-          this.program,
-          config,
-          releaseArgs
-        );
+            this.program,
+            config,
+            releaseArgs
+          );
 
     const tx = new Transaction();
     tx.feePayer = senderAddress;
@@ -673,10 +686,12 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
       luts.push(await this.getAddressLookupTable());
     } catch {}
 
+    const { blockhash } = await this.connection.getLatestBlockhash();
+
     const messageV0 = new TransactionMessage({
       payerKey: senderAddress,
       instructions: tx.instructions,
-      recentBlockhash: (await this.connection.getRecentBlockhash()).blockhash,
+      recentBlockhash: blockhash,
     }).compileToV0Message(luts);
 
     const vtx = new VersionedTransaction(messageV0);
@@ -820,15 +835,15 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
     tx.add(
       await (config.mode.locking != null
         ? NTT.createReleaseInboundUnlockInstruction(
-          this.program,
-          config,
-          releaseArgs
-        )
+            this.program,
+            config,
+            releaseArgs
+          )
         : NTT.createReleaseInboundMintInstruction(
-          this.program,
-          config,
-          releaseArgs
-        ))
+            this.program,
+            config,
+            releaseArgs
+          ))
     );
 
     yield this.createUnsignedTx(
@@ -890,7 +905,7 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
           delete a[k];
         }
       }
-    }
+    };
 
     deleteMatching(remote, local);
 


### PR DESCRIPTION
`getRecentBlockhash` is deprecated and being removed in solana-core 2.0 https://github.com/anza-xyz/agave/wiki/Agave-v2.0-Transition-Guide