### PR TITLE
ci: fail evm over size limit

### DIFF
--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -46,6 +46,10 @@ jobs:
           make lint
         id: check
 
+      - name: Run size test
+        run: |
+          make size-test
+
   echidna:
     name: echidna
     runs-on: ubuntu-latest

--- a/evm/Makefile
+++ b/evm/Makefile
@@ -22,8 +22,7 @@ gen-bindings: prod-build
 #######################
 ## TESTS
 
-test: forge-test push0-test
-
+test: forge-test push0-test size-test
 
 forge-test:
 	forge test -vvv
@@ -32,6 +31,11 @@ forge-test:
 push0-test:
 	forge build --extra-output evm.bytecode.opcodes
 	@if grep -qr --include \*.json PUSH0 ./evm/out; then echo "Contract uses PUSH0 instruction" 1>&2; exit 1; else echo "PUSH0 Verification Succeeded"; fi
+
+# Verify the contract size is under the Spurious Dragon limit (24576 bytes)
+# Without the prod profile (using --via-ir), the contracts are too large ='(
+size-test:
+	FOUNDRY_PROFILE=prod forge build --sizes --skip test
 
 
 #######################


### PR DESCRIPTION
Contract changes should not be made which would put the contract size over the Spurious Dragon limit. This check enforces that expectation.

Example failure https://github.com/wormhole-foundation/example-native-token-transfers/actions/runs/10908191583/job/30273582513?pr=518

Example success https://github.com/wormhole-foundation/example-native-token-transfers/actions/runs/10908415055/job/30274332155?pr=518