### PR TITLE
EVM: NttManagerNoRateLimiting implementation

### DIFF
--- a/evm/README.md
+++ b/evm/README.md
@@ -226,9 +226,11 @@ cp WormholeNttConfig.json.sample WormholeNttConfig.json
 
 Configure each network to your liking (including adding/removing networks). We will eventually add the addresses of the deployed contracts to this file. Navigate back to the `evm` directory.
 
-___
+---
+
 ⚠️ **WARNING:** Ensure that if the `NttManager` on the source chain is configured to be in `LOCKING` mode, the corresponding `NttManager`s on the target chains are configured to be in `BURNING` mode. If not, transfers will NOT go through and user funds may be lost! Proceed with caution!
-___
+
+---
 
 Currently the per-chain `inBoundLimit` is set to zero by default. This means all inbound transfers will be queued by the rate limiter. Set this value accordingly.
 
@@ -267,3 +269,9 @@ bash sh/configure_wormhole_ntt.sh -n NETWORK_TYPE -c CHAIN_NAME -k PRIVATE_KEY
 Tokens powered by NTT in **burn** mode require the `burn` method to be present. This method is not present in the standard ERC20 interface, but is found in the `ERC20Burnable` interface.
 
 The `mint` and `setMinter` methods found in the [`INttToken` Interface](src/interfaces/INttToken.sol) are not found in the standard `ERC20` interface.
+
+#### No-Rate-Limiting
+
+Although the rate limiting feature can be disabled during contract instantiation, it still occupies code space in the `NttManager` contract. If you wish to free up code space for custom development, you can instead instantiate the
+`NttManagerNoRateLimiting` contract. This contract is built without the bulk of the rate limiting code. Note that the current immutable checks do not allow modifying the rate-limiting parameters during migration. This means migrating
+from an instance of `NttManager` with rate-limiting enabled to `NttManagerNoRateLimiting` or vice versa is not officially supported.

--- a/evm/src/NttManager/NttManager.sol
+++ b/evm/src/NttManager/NttManager.sol
@@ -136,13 +136,13 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
     /// @inheritdoc INttManager
     function setOutboundLimit(
         uint256 limit
-    ) external virtual onlyOwner {
+    ) external onlyOwner {
         uint8 toDecimals = tokenDecimals();
         _setOutboundLimit(limit.trim(toDecimals, toDecimals));
     }
 
     /// @inheritdoc INttManager
-    function setInboundLimit(uint256 limit, uint16 chainId_) external virtual onlyOwner {
+    function setInboundLimit(uint256 limit, uint16 chainId_) external onlyOwner {
         uint8 toDecimals = tokenDecimals();
         _setInboundLimit(limit.trim(toDecimals, toDecimals), chainId_);
     }
@@ -150,7 +150,7 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
     /// ============== Invariants =============================================
 
     /// @dev When we add new immutables, this function should be updated
-    function _checkImmutables() internal view virtual override {
+    function _checkImmutables() internal view override {
         super._checkImmutables();
         assert(this.rateLimitDuration() == rateLimitDuration);
     }

--- a/evm/src/NttManager/NttManager.sol
+++ b/evm/src/NttManager/NttManager.sol
@@ -263,7 +263,7 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
         bytes32 digest
     ) external virtual nonReentrant whenNotPaused {
         // find the message in the queue
-        InboundQueuedTransfer memory queuedTransfer = getInboundQueuedTransfer(digest);
+        InboundQueuedTransfer memory queuedTransfer = RateLimiter.getInboundQueuedTransfer(digest);
         if (queuedTransfer.txTimestamp == 0) {
             revert InboundQueuedTransferNotFound(digest);
         }

--- a/evm/src/NttManager/NttManager.sol
+++ b/evm/src/NttManager/NttManager.sol
@@ -239,7 +239,7 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
         uint16 sourceChainId,
         TrimmedAmount nativeTransferAmount,
         address transferRecipient
-    ) internal virtual whenNotPaused returns (bool) {
+    ) internal virtual returns (bool) {
         // Check inbound rate limits
         bool isRateLimited = _isInboundAmountRateLimited(nativeTransferAmount, sourceChainId);
         if (isRateLimited) {

--- a/evm/src/NttManager/NttManager.sol
+++ b/evm/src/NttManager/NttManager.sol
@@ -223,7 +223,7 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
 
         address transferRecipient = fromWormholeFormat(nativeTokenTransfer.to);
 
-        bool enqueued = _enqueueOrConsumeIndboundRateLimit(
+        bool enqueued = _enqueueOrConsumeInboundRateLimit(
             digest, sourceChainId, nativeTransferAmount, transferRecipient
         );
 
@@ -234,7 +234,7 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
         _mintOrUnlockToRecipient(digest, transferRecipient, nativeTransferAmount, false);
     }
 
-    function _enqueueOrConsumeIndboundRateLimit(
+    function _enqueueOrConsumeInboundRateLimit(
         bytes32 digest,
         uint16 sourceChainId,
         TrimmedAmount nativeTransferAmount,

--- a/evm/src/NttManager/NttManagerNoRateLimiting.sol
+++ b/evm/src/NttManager/NttManagerNoRateLimiting.sol
@@ -10,11 +10,6 @@ contract NttManagerNoRateLimiting is NttManager {
         uint16 _chainId
     ) NttManager(_token, _mode, _chainId, 0, true) {}
 
-    /// @dev When we add new immutables, this function should be updated
-    function _checkImmutables() internal view override {
-        ManagerBase._checkImmutables();
-    }
-
     // ==================== Override RateLimiter functions =========================
 
     function _setOutboundLimit(
@@ -23,42 +18,13 @@ contract NttManagerNoRateLimiting is NttManager {
 
     function _setInboundLimit(TrimmedAmount limit, uint16 chainId_) internal override {}
 
-    function _isOutboundAmountRateLimited(
-        TrimmedAmount // amount
-    ) internal pure override returns (bool) {
-        return false;
-    }
-
-    function _enqueueOutboundTransfer(
-        uint64, // sequence
-        TrimmedAmount, // amount
-        uint16, // recipientChain
-        bytes32, // recipient
-        bytes32, // refundAddress
-        address, // senderAddress
-        bytes memory // transceiverInstructions
-    ) internal override {}
-
-    function _enqueueInboundTransfer(
-        bytes32, // digest
-        TrimmedAmount, // amount
-        address // recipient
-    ) internal override {}
-
-    function _consumeOutboundAmount(
-        TrimmedAmount // amount
-    ) internal override {}
-
-    function _backfillOutboundAmount(
-        TrimmedAmount // amount
-    ) internal override {}
-
-    function _consumeInboundAmount(
-        TrimmedAmount, // amount
-        uint16 // chainId_
-    ) internal override {}
-
     // ==================== Unimplemented External Interface =================================
+
+    function getInboundLimitParams(
+        uint16 chainId_
+    ) public view override returns (RateLimitParams memory rateLimitParams) {}
+
+    function getOutboundLimitParams() public pure override returns (RateLimitParams memory) {}
 
     /// @notice Not used, always returns max value of uint256.
     function getCurrentOutboundCapacity() public pure override returns (uint256) {
@@ -89,21 +55,21 @@ contract NttManagerNoRateLimiting is NttManager {
     /// @notice Not used, always reverts with NotImplemented.
     function completeInboundQueuedTransfer(
         bytes32 // digest
-    ) external pure override {
+    ) external view override whenNotPaused {
         revert NotImplemented();
     }
 
     /// @notice Not used, always reverts with NotImplemented.
     function completeOutboundQueuedTransfer(
         uint64 // messageSequence
-    ) external payable override returns (uint64) {
+    ) external payable override whenNotPaused returns (uint64) {
         revert NotImplemented();
     }
 
     /// @notice Not used, always reverts with NotImplemented.
     function cancelOutboundQueuedTransfer(
         uint64 // messageSequence
-    ) external pure override {
+    ) external view override whenNotPaused {
         revert NotImplemented();
     }
 

--- a/evm/src/NttManager/NttManagerNoRateLimiting.sol
+++ b/evm/src/NttManager/NttManagerNoRateLimiting.sol
@@ -1,27 +1,9 @@
 // SPDX-License-Identifier: Apache 2
 pragma solidity >=0.8.8 <0.9.0;
 
-import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
-import "openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20Burnable.sol";
-import "wormhole-solidity-sdk/Utils.sol";
-import "wormhole-solidity-sdk/libraries/BytesParsing.sol";
-
-import "../libraries/RateLimiter.sol";
-
-import "../interfaces/INttManager.sol";
-import "../interfaces/INttToken.sol";
-import "../interfaces/ITransceiver.sol";
-
-import {ManagerBase} from "./ManagerBase.sol";
 import "./NttManager.sol";
 
 contract NttManagerNoRateLimiting is NttManager {
-    using BytesParsing for bytes;
-    using SafeERC20 for IERC20;
-    using TrimmedAmountLib for uint256;
-    using TrimmedAmountLib for TrimmedAmount;
-
     constructor(
         address _token,
         Mode _mode,
@@ -36,181 +18,115 @@ contract NttManagerNoRateLimiting is NttManager {
     // ==================== Override RateLimiter functions =========================
 
     function _setOutboundLimit(
-        TrimmedAmount limit
+        TrimmedAmount // limit
     ) internal override {}
 
     function _setInboundLimit(TrimmedAmount limit, uint16 chainId_) internal override {}
 
     function _isOutboundAmountRateLimited(
-        TrimmedAmount amount
-    ) internal view override returns (bool) {
+        TrimmedAmount // amount
+    ) internal pure override returns (bool) {
         return false;
     }
 
+    function _enqueueOutboundTransfer(
+        uint64, // sequence
+        TrimmedAmount, // amount
+        uint16, // recipientChain
+        bytes32, // recipient
+        bytes32, // refundAddress
+        address, // senderAddress
+        bytes memory // transceiverInstructions
+    ) internal override {}
+
     function _enqueueInboundTransfer(
-        bytes32 digest,
-        TrimmedAmount amount,
-        address recipient
+        bytes32, // digest
+        TrimmedAmount, // amount
+        address // recipient
+    ) internal override {}
+
+    function _consumeOutboundAmount(
+        TrimmedAmount // amount
     ) internal override {}
 
     function _backfillOutboundAmount(
-        TrimmedAmount amount
+        TrimmedAmount // amount
     ) internal override {}
 
-    function _consumeInboundAmount(TrimmedAmount amount, uint16 chainId_) internal override {}
+    function _consumeInboundAmount(
+        TrimmedAmount, // amount
+        uint16 // chainId_
+    ) internal override {}
 
     // ==================== Unimplemented External Interface =================================
 
     /// @notice Not used, always returns max value of uint256.
-    function getCurrentOutboundCapacity() public view override returns (uint256) {
+    function getCurrentOutboundCapacity() public pure override returns (uint256) {
         return type(uint256).max;
     }
 
     /// @notice Not used, always reverts with NotImplemented.
     function getOutboundQueuedTransfer(
-        uint64 /*queueSequence*/
-    ) public view override returns (OutboundQueuedTransfer memory) {
+        uint64 // queueSequence
+    ) public pure override returns (OutboundQueuedTransfer memory) {
         revert NotImplemented();
     }
 
     /// @notice Not used, always returns max value of uint256.
     function getCurrentInboundCapacity(
-        uint16 /*chainId*/
-    ) public view override returns (uint256) {
+        uint16 // chainId
+    ) public pure override returns (uint256) {
         return type(uint256).max;
     }
 
     /// @notice Not used, always reverts with NotImplemented.
     function getInboundQueuedTransfer(
-        bytes32 /*digest*/
-    ) public view override returns (InboundQueuedTransfer memory) {
+        bytes32 // digest
+    ) public pure override returns (InboundQueuedTransfer memory) {
         revert NotImplemented();
     }
 
     /// @notice Not used, always reverts with NotImplemented.
     function completeInboundQueuedTransfer(
-        bytes32 /*digest*/
-    ) external override nonReentrant whenNotPaused {
+        bytes32 // digest
+    ) external pure override {
         revert NotImplemented();
     }
 
     /// @notice Not used, always reverts with NotImplemented.
     function completeOutboundQueuedTransfer(
-        uint64 /*messageSequence*/
-    ) external payable override nonReentrant whenNotPaused returns (uint64) {
+        uint64 // messageSequence
+    ) external payable override returns (uint64) {
         revert NotImplemented();
     }
 
     /// @notice Not used, always reverts with NotImplemented.
     function cancelOutboundQueuedTransfer(
-        uint64 /*messageSequence*/
-    ) external override nonReentrant whenNotPaused {
+        uint64 // messageSequence
+    ) external pure override {
         revert NotImplemented();
     }
 
     // ==================== Overridden Implementations =================================
-
-    function _transferEntryPoint(
-        uint256 amount,
-        uint16 recipientChain,
-        bytes32 recipient,
-        bytes32 refundAddress,
-        bool shouldQueue,
-        bytes memory transceiverInstructions
-    ) internal override returns (uint64) {
-        if (amount == 0) {
-            revert ZeroAmount();
-        }
-
-        if (recipient == bytes32(0)) {
-            revert InvalidRecipient();
-        }
-
-        if (refundAddress == bytes32(0)) {
-            revert InvalidRefundAddress();
-        }
-
-        {
-            // Lock/burn tokens before checking rate limits
-            // use transferFrom to pull tokens from the user and lock them
-            // query own token balance before transfer
-            uint256 balanceBefore = _getTokenBalanceOf(token, address(this));
-
-            // transfer tokens
-            IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
-
-            // query own token balance after transfer
-            uint256 balanceAfter = _getTokenBalanceOf(token, address(this));
-
-            // correct amount for potential transfer fees
-            amount = balanceAfter - balanceBefore;
-            if (mode == Mode.BURNING) {
-                {
-                    // NOTE: We don't account for burn fees in this code path.
-                    // We verify that the user's change in balance is equal to the amount that's burned.
-                    // Accounting for burn fees can be non-trivial, since there
-                    // is no standard way to account for the fee if the fee amount
-                    // is taken out of the burn amount.
-                    // For example, if there's a fee of 1 which is taken out of the
-                    // amount, then burning 20 tokens would result in a transfer of only 19 tokens.
-                    // However, the difference in the user's balance would only show 20.
-                    // Since there is no standard way to query for burn fee amounts with burnable tokens,
-                    // and NTT would be used on a per-token basis, implementing this functionality
-                    // is left to integrating projects who may need to account for burn fees on their tokens.
-                    ERC20Burnable(token).burn(amount);
-
-                    // tokens held by the contract after the operation should be the same as before
-                    uint256 balanceAfterBurn = _getTokenBalanceOf(token, address(this));
-                    if (balanceBefore != balanceAfterBurn) {
-                        revert BurnAmountDifferentThanBalanceDiff(balanceBefore, balanceAfterBurn);
-                    }
-                }
-            }
-        }
-
-        // trim amount after burning to ensure transfer amount matches (amount - fee)
-        TrimmedAmount trimmedAmount = _trimTransferAmount(amount, recipientChain);
-
-        // get the sequence for this transfer
-        uint64 sequence = _useMessageSequence();
-
-        return _transfer(
-            sequence,
-            trimmedAmount,
-            recipientChain,
-            recipient,
-            refundAddress,
-            msg.sender,
-            transceiverInstructions
-        );
+    function _transferEntryPointRateLimitChecks(
+        uint256, // amount
+        uint16, // recipientChain
+        bytes32, // recipient
+        bytes32, // refundAddress
+        bool, // shouldQueue
+        bytes memory, // transceiverInstructions
+        TrimmedAmount, // trimmedAmount
+        uint64 // sequence
+    ) internal pure override returns (bool) {
+        return false;
     }
 
-    /// @inheritdoc INttManager
-    function executeMsg(
-        uint16 sourceChainId,
-        bytes32 sourceNttManagerAddress,
-        TransceiverStructs.NttManagerMessage memory message
-    ) public override whenNotPaused {
-        (bytes32 digest, bool alreadyExecuted) =
-            _isMessageExecuted(sourceChainId, sourceNttManagerAddress, message);
-
-        if (alreadyExecuted) {
-            return;
-        }
-
-        TransceiverStructs.NativeTokenTransfer memory nativeTokenTransfer =
-            TransceiverStructs.parseNativeTokenTransfer(message.payload);
-
-        // verify that the destination chain is valid
-        if (nativeTokenTransfer.toChain != chainId) {
-            revert InvalidTargetChain(nativeTokenTransfer.toChain, chainId);
-        }
-        uint8 toDecimals = tokenDecimals();
-        TrimmedAmount nativeTransferAmount =
-            (nativeTokenTransfer.amount.untrim(toDecimals)).trim(toDecimals, toDecimals);
-
-        address transferRecipient = fromWormholeFormat(nativeTokenTransfer.to);
-
-        _mintOrUnlockToRecipient(digest, transferRecipient, nativeTransferAmount, false);
+    function _executeMsgRateLimitChecks(
+        bytes32, // digest
+        uint16, // sourceChainId
+        TrimmedAmount, // nativeTransferAmount
+        address // transferRecipient
+    ) internal view override whenNotPaused returns (bool) {
+        return false;
     }
 }

--- a/evm/src/NttManager/NttManagerNoRateLimiting.sol
+++ b/evm/src/NttManager/NttManagerNoRateLimiting.sol
@@ -3,6 +3,13 @@ pragma solidity >=0.8.8 <0.9.0;
 
 import "./NttManager.sol";
 
+/// @title NttManagerNoRateLimiting
+/// @author Wormhole Project Contributors.
+/// @notice The NttManagerNoRateLimiting contract is an implementation of
+///         NttManager that eliminates most of the rate limiting code to
+///         free up code space.
+///
+/// @dev    All of the developer notes from `NttManager` apply here.
 contract NttManagerNoRateLimiting is NttManager {
     constructor(
         address _token,
@@ -95,7 +102,7 @@ contract NttManagerNoRateLimiting is NttManager {
         return false;
     }
 
-    function _enqueueOrConsumeIndboundRateLimit(
+    function _enqueueOrConsumeInboundRateLimit(
         bytes32, // digest
         uint16, // sourceChainId
         TrimmedAmount, // nativeTransferAmount

--- a/evm/src/NttManager/NttManagerNoRateLimiting.sol
+++ b/evm/src/NttManager/NttManagerNoRateLimiting.sol
@@ -12,18 +12,7 @@ contract NttManagerNoRateLimiting is NttManager {
 
     // ==================== Override RateLimiter functions =========================
 
-    function _setOutboundLimit(
-        TrimmedAmount // limit
-    ) internal override {}
-
-    function _setInboundLimit(TrimmedAmount limit, uint16 chainId_) internal override {}
-
-    // ==================== Unimplemented External Interface =================================
-
-    function getInboundLimitParams(
-        uint16 chainId_
-    ) public view override returns (RateLimitParams memory rateLimitParams) {}
-
+    /// @notice Not used, always returns empty RateLimitParams.
     function getOutboundLimitParams() public pure override returns (RateLimitParams memory) {}
 
     /// @notice Not used, always returns max value of uint256.
@@ -38,9 +27,14 @@ contract NttManagerNoRateLimiting is NttManager {
         revert NotImplemented();
     }
 
+    /// @notice Not used, always returns empty RateLimitParams.
+    function getInboundLimitParams(
+        uint16 // chainId_
+    ) public pure override returns (RateLimitParams memory) {}
+
     /// @notice Not used, always returns max value of uint256.
     function getCurrentInboundCapacity(
-        uint16 // chainId
+        uint16 // chainId_
     ) public pure override returns (uint256) {
         return type(uint256).max;
     }
@@ -52,6 +46,33 @@ contract NttManagerNoRateLimiting is NttManager {
         revert NotImplemented();
     }
 
+    /// @notice Ignore RateLimiter setting.
+    function _setOutboundLimit(
+        TrimmedAmount // limit
+    ) internal override {}
+
+    /// @notice Ignore RateLimiter setting.
+    function _setInboundLimit(
+        TrimmedAmount, // limit
+        uint16 // chainId_
+    ) internal override {}
+
+    // ==================== Unimplemented INttManager External Interface =================================
+
+    /// @notice Not used, always reverts with NotImplemented.
+    function completeOutboundQueuedTransfer(
+        uint64 // queueSequence
+    ) external payable override whenNotPaused returns (uint64) {
+        revert NotImplemented();
+    }
+
+    /// @notice Not used, always reverts with NotImplemented.
+    function cancelOutboundQueuedTransfer(
+        uint64 // queueSequence
+    ) external view override whenNotPaused {
+        revert NotImplemented();
+    }
+
     /// @notice Not used, always reverts with NotImplemented.
     function completeInboundQueuedTransfer(
         bytes32 // digest
@@ -59,21 +80,8 @@ contract NttManagerNoRateLimiting is NttManager {
         revert NotImplemented();
     }
 
-    /// @notice Not used, always reverts with NotImplemented.
-    function completeOutboundQueuedTransfer(
-        uint64 // messageSequence
-    ) external payable override whenNotPaused returns (uint64) {
-        revert NotImplemented();
-    }
+    // ==================== Overridden NttManager Implementations =================================
 
-    /// @notice Not used, always reverts with NotImplemented.
-    function cancelOutboundQueuedTransfer(
-        uint64 // messageSequence
-    ) external view override whenNotPaused {
-        revert NotImplemented();
-    }
-
-    // ==================== Overridden Implementations =================================
     function _transferEntryPointRateLimitChecks(
         uint256, // amount
         uint16, // recipientChain

--- a/evm/src/NttManager/NttManagerNoRateLimiting.sol
+++ b/evm/src/NttManager/NttManagerNoRateLimiting.sol
@@ -82,7 +82,7 @@ contract NttManagerNoRateLimiting is NttManager {
 
     // ==================== Overridden NttManager Implementations =================================
 
-    function _transferEntryPointRateLimitChecks(
+    function _enqueueOrConsumeOutboundRateLimit(
         uint256, // amount
         uint16, // recipientChain
         bytes32, // recipient
@@ -95,7 +95,7 @@ contract NttManagerNoRateLimiting is NttManager {
         return false;
     }
 
-    function _executeMsgRateLimitChecks(
+    function _enqueueOrConsumeIndboundRateLimit(
         bytes32, // digest
         uint16, // sourceChainId
         TrimmedAmount, // nativeTransferAmount

--- a/evm/src/NttManager/NttManagerNoRateLimiting.sol
+++ b/evm/src/NttManager/NttManagerNoRateLimiting.sol
@@ -22,9 +22,9 @@ contract NttManagerNoRateLimiting is NttManager {
     /// @notice Not used, always returns empty RateLimitParams.
     function getOutboundLimitParams() public pure override returns (RateLimitParams memory) {}
 
-    /// @notice Not used, always returns max value of uint256.
+    /// @notice Not used, always returns zero.
     function getCurrentOutboundCapacity() public pure override returns (uint256) {
-        return type(uint256).max;
+        return 0;
     }
 
     /// @notice Not used, always reverts with NotImplemented.
@@ -39,11 +39,11 @@ contract NttManagerNoRateLimiting is NttManager {
         uint16 // chainId_
     ) public pure override returns (RateLimitParams memory) {}
 
-    /// @notice Not used, always returns max value of uint256.
+    /// @notice Not used, always returns zero.
     function getCurrentInboundCapacity(
         uint16 // chainId_
     ) public pure override returns (uint256) {
-        return type(uint256).max;
+        return 0;
     }
 
     /// @notice Not used, always reverts with NotImplemented.
@@ -107,7 +107,7 @@ contract NttManagerNoRateLimiting is NttManager {
         uint16, // sourceChainId
         TrimmedAmount, // nativeTransferAmount
         address // transferRecipient
-    ) internal view override whenNotPaused returns (bool) {
+    ) internal pure override returns (bool) {
         return false;
     }
 }

--- a/evm/src/NttManager/NttManagerNoRateLimiting.sol
+++ b/evm/src/NttManager/NttManagerNoRateLimiting.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity >=0.8.8 <0.9.0;
+
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import "wormhole-solidity-sdk/Utils.sol";
+import "wormhole-solidity-sdk/libraries/BytesParsing.sol";
+
+import "../libraries/RateLimiter.sol";
+
+import "../interfaces/INttManager.sol";
+import "../interfaces/INttToken.sol";
+import "../interfaces/ITransceiver.sol";
+
+import {ManagerBase} from "./ManagerBase.sol";
+import "./NttManager.sol";
+
+contract NttManagerNoRateLimiting is NttManager {
+    using BytesParsing for bytes;
+    using SafeERC20 for IERC20;
+    using TrimmedAmountLib for uint256;
+    using TrimmedAmountLib for TrimmedAmount;
+
+    constructor(
+        address _token,
+        Mode _mode,
+        uint16 _chainId
+    ) NttManager(_token, _mode, _chainId, 0, true) {}
+
+    /// @dev When we add new immutables, this function should be updated
+    function _checkImmutables() internal view override {
+        ManagerBase._checkImmutables();
+    }
+
+    // ==================== Override RateLimiter functions =========================
+
+    function _setOutboundLimit(
+        TrimmedAmount limit
+    ) internal override {}
+
+    function _setInboundLimit(TrimmedAmount limit, uint16 chainId_) internal override {}
+
+    function _isOutboundAmountRateLimited(
+        TrimmedAmount amount
+    ) internal view override returns (bool) {
+        return false;
+    }
+
+    function _enqueueInboundTransfer(
+        bytes32 digest,
+        TrimmedAmount amount,
+        address recipient
+    ) internal override {}
+
+    function _backfillOutboundAmount(
+        TrimmedAmount amount
+    ) internal override {}
+
+    function _consumeInboundAmount(TrimmedAmount amount, uint16 chainId_) internal override {}
+
+    // ==================== Unimplemented External Interface =================================
+
+    /// @notice Not used, always returns max value of uint256.
+    function getCurrentOutboundCapacity() public view override returns (uint256) {
+        return type(uint256).max;
+    }
+
+    /// @notice Not used, always reverts with NotImplemented.
+    function getOutboundQueuedTransfer(
+        uint64 /*queueSequence*/
+    ) public view override returns (OutboundQueuedTransfer memory) {
+        revert NotImplemented();
+    }
+
+    /// @notice Not used, always returns max value of uint256.
+    function getCurrentInboundCapacity(
+        uint16 /*chainId*/
+    ) public view override returns (uint256) {
+        return type(uint256).max;
+    }
+
+    /// @notice Not used, always reverts with NotImplemented.
+    function getInboundQueuedTransfer(
+        bytes32 /*digest*/
+    ) public view override returns (InboundQueuedTransfer memory) {
+        revert NotImplemented();
+    }
+
+    /// @notice Not used, always reverts with NotImplemented.
+    function completeInboundQueuedTransfer(
+        bytes32 /*digest*/
+    ) external override nonReentrant whenNotPaused {
+        revert NotImplemented();
+    }
+
+    /// @notice Not used, always reverts with NotImplemented.
+    function completeOutboundQueuedTransfer(
+        uint64 /*messageSequence*/
+    ) external payable override nonReentrant whenNotPaused returns (uint64) {
+        revert NotImplemented();
+    }
+
+    /// @notice Not used, always reverts with NotImplemented.
+    function cancelOutboundQueuedTransfer(
+        uint64 /*messageSequence*/
+    ) external override nonReentrant whenNotPaused {
+        revert NotImplemented();
+    }
+
+    // ==================== Overridden Implementations =================================
+
+    function _transferEntryPoint(
+        uint256 amount,
+        uint16 recipientChain,
+        bytes32 recipient,
+        bytes32 refundAddress,
+        bool shouldQueue,
+        bytes memory transceiverInstructions
+    ) internal override returns (uint64) {
+        if (amount == 0) {
+            revert ZeroAmount();
+        }
+
+        if (recipient == bytes32(0)) {
+            revert InvalidRecipient();
+        }
+
+        if (refundAddress == bytes32(0)) {
+            revert InvalidRefundAddress();
+        }
+
+        {
+            // Lock/burn tokens before checking rate limits
+            // use transferFrom to pull tokens from the user and lock them
+            // query own token balance before transfer
+            uint256 balanceBefore = _getTokenBalanceOf(token, address(this));
+
+            // transfer tokens
+            IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+
+            // query own token balance after transfer
+            uint256 balanceAfter = _getTokenBalanceOf(token, address(this));
+
+            // correct amount for potential transfer fees
+            amount = balanceAfter - balanceBefore;
+            if (mode == Mode.BURNING) {
+                {
+                    // NOTE: We don't account for burn fees in this code path.
+                    // We verify that the user's change in balance is equal to the amount that's burned.
+                    // Accounting for burn fees can be non-trivial, since there
+                    // is no standard way to account for the fee if the fee amount
+                    // is taken out of the burn amount.
+                    // For example, if there's a fee of 1 which is taken out of the
+                    // amount, then burning 20 tokens would result in a transfer of only 19 tokens.
+                    // However, the difference in the user's balance would only show 20.
+                    // Since there is no standard way to query for burn fee amounts with burnable tokens,
+                    // and NTT would be used on a per-token basis, implementing this functionality
+                    // is left to integrating projects who may need to account for burn fees on their tokens.
+                    ERC20Burnable(token).burn(amount);
+
+                    // tokens held by the contract after the operation should be the same as before
+                    uint256 balanceAfterBurn = _getTokenBalanceOf(token, address(this));
+                    if (balanceBefore != balanceAfterBurn) {
+                        revert BurnAmountDifferentThanBalanceDiff(balanceBefore, balanceAfterBurn);
+                    }
+                }
+            }
+        }
+
+        // trim amount after burning to ensure transfer amount matches (amount - fee)
+        TrimmedAmount trimmedAmount = _trimTransferAmount(amount, recipientChain);
+
+        // get the sequence for this transfer
+        uint64 sequence = _useMessageSequence();
+
+        return _transfer(
+            sequence,
+            trimmedAmount,
+            recipientChain,
+            recipient,
+            refundAddress,
+            msg.sender,
+            transceiverInstructions
+        );
+    }
+
+    /// @inheritdoc INttManager
+    function executeMsg(
+        uint16 sourceChainId,
+        bytes32 sourceNttManagerAddress,
+        TransceiverStructs.NttManagerMessage memory message
+    ) public override whenNotPaused {
+        (bytes32 digest, bool alreadyExecuted) =
+            _isMessageExecuted(sourceChainId, sourceNttManagerAddress, message);
+
+        if (alreadyExecuted) {
+            return;
+        }
+
+        TransceiverStructs.NativeTokenTransfer memory nativeTokenTransfer =
+            TransceiverStructs.parseNativeTokenTransfer(message.payload);
+
+        // verify that the destination chain is valid
+        if (nativeTokenTransfer.toChain != chainId) {
+            revert InvalidTargetChain(nativeTokenTransfer.toChain, chainId);
+        }
+        uint8 toDecimals = tokenDecimals();
+        TrimmedAmount nativeTransferAmount =
+            (nativeTokenTransfer.amount.untrim(toDecimals)).trim(toDecimals, toDecimals);
+
+        address transferRecipient = fromWormholeFormat(nativeTokenTransfer.to);
+
+        _mintOrUnlockToRecipient(digest, transferRecipient, nativeTransferAmount, false);
+    }
+}

--- a/evm/src/interfaces/INttManager.sol
+++ b/evm/src/interfaces/INttManager.sol
@@ -135,6 +135,9 @@ interface INttManager is IManagerBase {
     /// @dev Selector 0x20371f2a.
     error InvalidPeerSameChainId();
 
+    /// @notice Feature is not implemented.
+    error NotImplemented();
+
     /// @notice Transfer a given amount to a recipient on a given chain. This function is called
     ///         by the user to send the token cross-chain. This function will either lock or burn the
     ///         sender's tokens. Finally, this function will call into registered `Endpoint` contracts

--- a/evm/src/libraries/RateLimiter.sol
+++ b/evm/src/libraries/RateLimiter.sol
@@ -99,7 +99,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
         _setLimit(limit, _getOutboundLimitParamsStorage());
     }
 
-    function getOutboundLimitParams() public pure returns (RateLimitParams memory) {
+    function getOutboundLimitParams() public pure virtual returns (RateLimitParams memory) {
         return _getOutboundLimitParamsStorage();
     }
 
@@ -121,7 +121,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
 
     function getInboundLimitParams(
         uint16 chainId_
-    ) public view returns (RateLimitParams memory) {
+    ) public view virtual returns (RateLimitParams memory) {
         return _getInboundLimitParamsStorage()[chainId_];
     }
 
@@ -207,7 +207,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
 
     function _consumeOutboundAmount(
         TrimmedAmount amount
-    ) internal virtual {
+    ) internal {
         if (rateLimitDuration == 0) return;
         _consumeRateLimitAmount(
             amount, _getCurrentCapacity(getOutboundLimitParams()), _getOutboundLimitParamsStorage()
@@ -216,14 +216,14 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
 
     function _backfillOutboundAmount(
         TrimmedAmount amount
-    ) internal virtual {
+    ) internal {
         if (rateLimitDuration == 0) return;
         _backfillRateLimitAmount(
             amount, _getCurrentCapacity(getOutboundLimitParams()), _getOutboundLimitParamsStorage()
         );
     }
 
-    function _consumeInboundAmount(TrimmedAmount amount, uint16 chainId_) internal virtual {
+    function _consumeInboundAmount(TrimmedAmount amount, uint16 chainId_) internal {
         if (rateLimitDuration == 0) return;
         _consumeRateLimitAmount(
             amount,
@@ -263,7 +263,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
 
     function _isOutboundAmountRateLimited(
         TrimmedAmount amount
-    ) internal view virtual returns (bool) {
+    ) internal view returns (bool) {
         return rateLimitDuration != 0
             ? _isAmountRateLimited(_getCurrentCapacity(getOutboundLimitParams()), amount)
             : false;
@@ -293,7 +293,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
         bytes32 refundAddress,
         address senderAddress,
         bytes memory transceiverInstructions
-    ) internal virtual {
+    ) internal {
         _getOutboundQueueStorage()[sequence] = OutboundQueuedTransfer({
             amount: amount,
             recipientChain: recipientChain,
@@ -311,7 +311,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
         bytes32 digest,
         TrimmedAmount amount,
         address recipient
-    ) internal virtual {
+    ) internal {
         _getInboundQueueStorage()[digest] = InboundQueuedTransfer({
             amount: amount,
             recipient: recipient,

--- a/evm/src/libraries/RateLimiter.sol
+++ b/evm/src/libraries/RateLimiter.sol
@@ -207,7 +207,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
 
     function _consumeOutboundAmount(
         TrimmedAmount amount
-    ) internal {
+    ) internal virtual {
         if (rateLimitDuration == 0) return;
         _consumeRateLimitAmount(
             amount, _getCurrentCapacity(getOutboundLimitParams()), _getOutboundLimitParamsStorage()
@@ -293,7 +293,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
         bytes32 refundAddress,
         address senderAddress,
         bytes memory transceiverInstructions
-    ) internal {
+    ) internal virtual {
         _getOutboundQueueStorage()[sequence] = OutboundQueuedTransfer({
             amount: amount,
             recipientChain: recipientChain,

--- a/evm/src/libraries/RateLimiter.sol
+++ b/evm/src/libraries/RateLimiter.sol
@@ -95,7 +95,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
 
     function _setOutboundLimit(
         TrimmedAmount limit
-    ) internal {
+    ) internal virtual {
         _setLimit(limit, _getOutboundLimitParamsStorage());
     }
 
@@ -103,7 +103,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
         return _getOutboundLimitParamsStorage();
     }
 
-    function getCurrentOutboundCapacity() public view returns (uint256) {
+    function getCurrentOutboundCapacity() public view virtual returns (uint256) {
         TrimmedAmount trimmedCapacity = _getCurrentCapacity(getOutboundLimitParams());
         uint8 decimals = tokenDecimals();
         return trimmedCapacity.untrim(decimals);
@@ -111,11 +111,11 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
 
     function getOutboundQueuedTransfer(
         uint64 queueSequence
-    ) public view returns (OutboundQueuedTransfer memory) {
+    ) public view virtual returns (OutboundQueuedTransfer memory) {
         return _getOutboundQueueStorage()[queueSequence];
     }
 
-    function _setInboundLimit(TrimmedAmount limit, uint16 chainId_) internal {
+    function _setInboundLimit(TrimmedAmount limit, uint16 chainId_) internal virtual {
         _setLimit(limit, _getInboundLimitParamsStorage()[chainId_]);
     }
 
@@ -127,7 +127,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
 
     function getCurrentInboundCapacity(
         uint16 chainId_
-    ) public view returns (uint256) {
+    ) public view virtual returns (uint256) {
         TrimmedAmount trimmedCapacity = _getCurrentCapacity(getInboundLimitParams(chainId_));
         uint8 decimals = tokenDecimals();
         return trimmedCapacity.untrim(decimals);
@@ -135,7 +135,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
 
     function getInboundQueuedTransfer(
         bytes32 digest
-    ) public view returns (InboundQueuedTransfer memory) {
+    ) public view virtual returns (InboundQueuedTransfer memory) {
         return _getInboundQueueStorage()[digest];
     }
 
@@ -216,14 +216,14 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
 
     function _backfillOutboundAmount(
         TrimmedAmount amount
-    ) internal {
+    ) internal virtual {
         if (rateLimitDuration == 0) return;
         _backfillRateLimitAmount(
             amount, _getCurrentCapacity(getOutboundLimitParams()), _getOutboundLimitParamsStorage()
         );
     }
 
-    function _consumeInboundAmount(TrimmedAmount amount, uint16 chainId_) internal {
+    function _consumeInboundAmount(TrimmedAmount amount, uint16 chainId_) internal virtual {
         if (rateLimitDuration == 0) return;
         _consumeRateLimitAmount(
             amount,
@@ -263,7 +263,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
 
     function _isOutboundAmountRateLimited(
         TrimmedAmount amount
-    ) internal view returns (bool) {
+    ) internal view virtual returns (bool) {
         return rateLimitDuration != 0
             ? _isAmountRateLimited(_getCurrentCapacity(getOutboundLimitParams()), amount)
             : false;
@@ -311,7 +311,7 @@ abstract contract RateLimiter is IRateLimiter, IRateLimiterEvents {
         bytes32 digest,
         TrimmedAmount amount,
         address recipient
-    ) internal {
+    ) internal virtual {
         _getInboundQueueStorage()[digest] = InboundQueuedTransfer({
             amount: amount,
             recipient: recipient,

--- a/evm/test/IntegrationWithoutRateLimiting.t.sol
+++ b/evm/test/IntegrationWithoutRateLimiting.t.sol
@@ -285,12 +285,12 @@ contract TestEndToEndNoRateLimiting is Test {
         nttManagerChain1.setInboundLimit(0, chainId2);
 
         require(
-            nttManagerChain1.getCurrentOutboundCapacity() == type(uint256).max,
+            nttManagerChain1.getCurrentOutboundCapacity() == 0,
             "getCurrentOutboundCapacity returned unexpected value"
         );
 
         require(
-            nttManagerChain1.getCurrentInboundCapacity(chainId2) == type(uint256).max,
+            nttManagerChain1.getCurrentInboundCapacity(chainId2) == 0,
             "getCurrentInboundCapacity returned unexpected value"
         );
 

--- a/evm/test/IntegrationWithoutRateLimiting.t.sol
+++ b/evm/test/IntegrationWithoutRateLimiting.t.sol
@@ -64,7 +64,7 @@ contract TestEndToEndNoRateLimiting is Test {
         vm.chainId(chainId1);
         DummyToken t1 = new DummyToken();
         NttManagerNoRateLimiting implementation = new MockNttManagerNoRateLimitingContract(
-            address(t1), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+            address(t1), IManagerBase.Mode.LOCKING, chainId1
         );
 
         nttManagerChain1 = MockNttManagerNoRateLimitingContract(
@@ -102,7 +102,7 @@ contract TestEndToEndNoRateLimiting is Test {
         vm.chainId(chainId2);
         DummyToken t2 = new DummyTokenMintAndBurn();
         NttManagerNoRateLimiting implementationChain2 = new MockNttManagerNoRateLimitingContract(
-            address(t2), IManagerBase.Mode.BURNING, chainId2, 1 days, false
+            address(t2), IManagerBase.Mode.BURNING, chainId2
         );
 
         nttManagerChain2 = MockNttManagerNoRateLimitingContract(

--- a/evm/test/IntegrationWithoutRateLimiting.t.sol
+++ b/evm/test/IntegrationWithoutRateLimiting.t.sol
@@ -1,0 +1,710 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity >=0.8.8 <0.9.0;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+
+import "../src/NttManager/NttManagerNoRateLimiting.sol";
+import "../src/Transceiver/Transceiver.sol";
+import "../src/interfaces/INttManager.sol";
+import "../src/interfaces/IRateLimiter.sol";
+import "../src/interfaces/ITransceiver.sol";
+import "../src/interfaces/IManagerBase.sol";
+import "../src/interfaces/IRateLimiterEvents.sol";
+import {Utils} from "./libraries/Utils.sol";
+import {DummyToken, DummyTokenMintAndBurn} from "./NttManager.t.sol";
+import "../src/interfaces/IWormholeTransceiver.sol";
+import {WormholeTransceiver} from "../src/Transceiver/WormholeTransceiver/WormholeTransceiver.sol";
+import "../src/libraries/TransceiverStructs.sol";
+import "./mocks/MockNttManager.sol";
+import "./mocks/MockTransceivers.sol";
+
+import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "wormhole-solidity-sdk/interfaces/IWormhole.sol";
+import "wormhole-solidity-sdk/testing/helpers/WormholeSimulator.sol";
+import "wormhole-solidity-sdk/Utils.sol";
+//import "wormhole-solidity-sdk/testing/WormholeRelayerTest.sol";
+
+contract TestEndToEndNoRateLimiting is Test {
+    NttManagerNoRateLimiting nttManagerChain1;
+    NttManagerNoRateLimiting nttManagerChain2;
+
+    using TrimmedAmountLib for uint256;
+    using TrimmedAmountLib for TrimmedAmount;
+
+    uint16 constant chainId1 = 7;
+    uint16 constant chainId2 = 100;
+    uint8 constant FAST_CONSISTENCY_LEVEL = 200;
+    uint256 constant GAS_LIMIT = 500000;
+
+    uint16 constant SENDING_CHAIN_ID = 1;
+    uint256 constant DEVNET_GUARDIAN_PK =
+        0xcfb12303a19cde580bb4dd771639b0d26bc68353645571a8cff516ab2ee113a0;
+    WormholeSimulator guardian;
+    uint256 initialBlockTimestamp;
+
+    WormholeTransceiver wormholeTransceiverChain1;
+    WormholeTransceiver wormholeTransceiverChain2;
+    address userA = address(0x123);
+    address userB = address(0x456);
+    address userC = address(0x789);
+    address userD = address(0xABC);
+
+    address relayer = address(0x28D8F1Be96f97C1387e94A53e00eCcFb4E75175a);
+    IWormhole wormhole = IWormhole(0x4a8bc80Ed5a4067f1CCf107057b8270E0cC11A78);
+
+    function setUp() public {
+        string memory url = "https://ethereum-sepolia-rpc.publicnode.com";
+        vm.createSelectFork(url);
+        initialBlockTimestamp = vm.getBlockTimestamp();
+
+        guardian = new WormholeSimulator(address(wormhole), DEVNET_GUARDIAN_PK);
+
+        vm.chainId(chainId1);
+        DummyToken t1 = new DummyToken();
+        NttManagerNoRateLimiting implementation = new MockNttManagerNoRateLimitingContract(
+            address(t1), IManagerBase.Mode.LOCKING, chainId1, 1 days, false
+        );
+
+        nttManagerChain1 = MockNttManagerNoRateLimitingContract(
+            address(new ERC1967Proxy(address(implementation), ""))
+        );
+        nttManagerChain1.initialize();
+
+        WormholeTransceiver wormholeTransceiverChain1Implementation = new MockWormholeTransceiverContract(
+            address(nttManagerChain1),
+            address(wormhole),
+            address(relayer),
+            address(0x0),
+            FAST_CONSISTENCY_LEVEL,
+            GAS_LIMIT
+        );
+        wormholeTransceiverChain1 = MockWormholeTransceiverContract(
+            address(new ERC1967Proxy(address(wormholeTransceiverChain1Implementation), ""))
+        );
+
+        // Only the deployer should be able to initialize
+        vm.prank(userA);
+        vm.expectRevert(
+            abi.encodeWithSelector(ITransceiver.UnexpectedDeployer.selector, address(this), userA)
+        );
+        wormholeTransceiverChain1.initialize();
+
+        // Actually initialize properly now
+        wormholeTransceiverChain1.initialize();
+
+        nttManagerChain1.setTransceiver(address(wormholeTransceiverChain1));
+        // nttManagerChain1.setOutboundLimit(type(uint64).max);
+        // nttManagerChain1.setInboundLimit(type(uint64).max, chainId2);
+
+        // Chain 2 setup
+        vm.chainId(chainId2);
+        DummyToken t2 = new DummyTokenMintAndBurn();
+        NttManagerNoRateLimiting implementationChain2 = new MockNttManagerNoRateLimitingContract(
+            address(t2), IManagerBase.Mode.BURNING, chainId2, 1 days, false
+        );
+
+        nttManagerChain2 = MockNttManagerNoRateLimitingContract(
+            address(new ERC1967Proxy(address(implementationChain2), ""))
+        );
+        nttManagerChain2.initialize();
+
+        WormholeTransceiver wormholeTransceiverChain2Implementation = new MockWormholeTransceiverContract(
+            address(nttManagerChain2),
+            address(wormhole),
+            address(relayer),
+            address(0x0),
+            FAST_CONSISTENCY_LEVEL,
+            GAS_LIMIT
+        );
+        wormholeTransceiverChain2 = MockWormholeTransceiverContract(
+            address(new ERC1967Proxy(address(wormholeTransceiverChain2Implementation), ""))
+        );
+        wormholeTransceiverChain2.initialize();
+
+        nttManagerChain2.setTransceiver(address(wormholeTransceiverChain2));
+        // nttManagerChain2.setOutboundLimit(type(uint64).max);
+        // nttManagerChain2.setInboundLimit(type(uint64).max, chainId1);
+
+        // Register peer contracts for the nttManager and transceiver. Transceivers and nttManager each have the concept of peers here.
+        nttManagerChain1.setPeer(
+            chainId2, bytes32(uint256(uint160(address(nttManagerChain2)))), 9, type(uint64).max
+        );
+        nttManagerChain2.setPeer(
+            chainId1, bytes32(uint256(uint160(address(nttManagerChain1)))), 7, type(uint64).max
+        );
+
+        // Set peers for the transceivers
+        wormholeTransceiverChain1.setWormholePeer(
+            chainId2, bytes32(uint256(uint160(address(wormholeTransceiverChain2))))
+        );
+        wormholeTransceiverChain2.setWormholePeer(
+            chainId1, bytes32(uint256(uint160(address(wormholeTransceiverChain1))))
+        );
+
+        require(nttManagerChain1.getThreshold() != 0, "Threshold is zero with active transceivers");
+
+        // Actually set it
+        nttManagerChain1.setThreshold(1);
+        nttManagerChain2.setThreshold(1);
+
+        INttManager.NttManagerPeer memory peer = nttManagerChain1.getPeer(chainId2);
+        require(9 == peer.tokenDecimals, "Peer has the wrong number of token decimals");
+    }
+
+    function test_chainToChainBase() public {
+        vm.chainId(chainId1);
+
+        // Setting up the transfer
+        DummyToken token1 = DummyToken(nttManagerChain1.token());
+        DummyToken token2 = DummyTokenMintAndBurn(nttManagerChain2.token());
+
+        uint8 decimals = token1.decimals();
+        uint256 sendingAmount = 5 * 10 ** decimals;
+        token1.mintDummy(address(userA), 5 * 10 ** decimals);
+        vm.startPrank(userA);
+        token1.approve(address(nttManagerChain1), sendingAmount);
+
+        vm.recordLogs();
+
+        // Send token through standard means (not relayer)
+        {
+            uint256 nttManagerBalanceBefore = token1.balanceOf(address(nttManagerChain1));
+            uint256 userBalanceBefore = token1.balanceOf(address(userA));
+            nttManagerChain1.transfer(sendingAmount, chainId2, bytes32(uint256(uint160(userB))));
+
+            // Balance check on funds going in and out working as expected
+            uint256 nttManagerBalanceAfter = token1.balanceOf(address(nttManagerChain1));
+            uint256 userBalanceAfter = token1.balanceOf(address(userB));
+            require(
+                nttManagerBalanceBefore + sendingAmount == nttManagerBalanceAfter,
+                "Should be locking the tokens"
+            );
+            require(
+                userBalanceBefore - sendingAmount == userBalanceAfter,
+                "User should have sent tokens"
+            );
+        }
+
+        vm.stopPrank();
+
+        // Get and sign the log to go down the other pipe. Thank you to whoever wrote this code in the past!
+        Vm.Log[] memory entries = guardian.fetchWormholeMessageFromLog(vm.getRecordedLogs());
+        bytes[] memory encodedVMs = new bytes[](entries.length);
+        for (uint256 i = 0; i < encodedVMs.length; i++) {
+            encodedVMs[i] = guardian.fetchSignedMessageFromLogs(entries[i], chainId1);
+        }
+
+        // Chain2 verification and checks
+        vm.chainId(chainId2);
+
+        // Wrong chain receiving the signed VAA
+        vm.expectRevert(abi.encodeWithSelector(InvalidFork.selector, chainId1, chainId2));
+        wormholeTransceiverChain1.receiveMessage(encodedVMs[0]);
+        {
+            uint256 supplyBefore = token2.totalSupply();
+            wormholeTransceiverChain2.receiveMessage(encodedVMs[0]);
+            uint256 supplyAfter = token2.totalSupply();
+
+            require(sendingAmount + supplyBefore == supplyAfter, "Supplies dont match");
+            require(token2.balanceOf(userB) == sendingAmount, "User didn't receive tokens");
+            require(
+                token2.balanceOf(address(nttManagerChain2)) == 0,
+                "NttManagerNoRateLimiting has unintended funds"
+            );
+        }
+
+        // Can't resubmit the same message twice
+        (IWormhole.VM memory wormholeVM,,) = wormhole.parseAndVerifyVM(encodedVMs[0]);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IWormholeTransceiver.TransferAlreadyCompleted.selector, wormholeVM.hash
+            )
+        );
+        wormholeTransceiverChain2.receiveMessage(encodedVMs[0]);
+
+        // Go back the other way from a THIRD user
+        vm.prank(userB);
+        token2.transfer(userC, sendingAmount);
+
+        vm.startPrank(userC);
+        token2.approve(address(nttManagerChain2), sendingAmount);
+        vm.recordLogs();
+
+        // Supply checks on the transfer
+        {
+            uint256 supplyBefore = token2.totalSupply();
+            nttManagerChain2.transfer(
+                sendingAmount,
+                chainId1,
+                toWormholeFormat(userD),
+                toWormholeFormat(userC),
+                false,
+                encodeTransceiverInstruction(true)
+            );
+
+            uint256 supplyAfter = token2.totalSupply();
+
+            require(sendingAmount - supplyBefore == supplyAfter, "Supplies don't match");
+            require(token2.balanceOf(userB) == 0, "OG user receive tokens");
+            require(token2.balanceOf(userC) == 0, "Sending user didn't receive tokens");
+            require(
+                token2.balanceOf(address(nttManagerChain2)) == 0,
+                "NttManagerNoRateLimiting didn't receive unintended funds"
+            );
+        }
+
+        // Get and sign the log to go down the other pipe. Thank you to whoever wrote this code in the past!
+        entries = guardian.fetchWormholeMessageFromLog(vm.getRecordedLogs());
+        encodedVMs = new bytes[](entries.length);
+        for (uint256 i = 0; i < encodedVMs.length; i++) {
+            encodedVMs[i] = guardian.fetchSignedMessageFromLogs(entries[i], chainId2);
+        }
+
+        // Chain1 verification and checks with the receiving of the message
+        vm.chainId(chainId1);
+
+        {
+            uint256 supplyBefore = token1.totalSupply();
+            wormholeTransceiverChain1.receiveMessage(encodedVMs[0]);
+
+            uint256 supplyAfter = token1.totalSupply();
+
+            require(supplyBefore == supplyAfter, "Supplies don't match between operations");
+            require(token1.balanceOf(userB) == 0, "OG user receive tokens");
+            require(token1.balanceOf(userC) == 0, "Sending user didn't receive tokens");
+            require(token1.balanceOf(userD) == sendingAmount, "User received funds");
+        }
+    }
+
+    // This test triggers some basic reverts to increase our code coverage.
+    function test_someReverts() public {
+        // These shouldn't revert.
+        nttManagerChain1.setOutboundLimit(0);
+        nttManagerChain1.setInboundLimit(0, chainId2);
+
+        require(
+            nttManagerChain1.getCurrentOutboundCapacity() == type(uint256).max,
+            "getCurrentOutboundCapacity returned unexpected value"
+        );
+
+        require(
+            nttManagerChain1.getCurrentInboundCapacity(chainId2) == type(uint256).max,
+            "getCurrentInboundCapacity returned unexpected value"
+        );
+
+        // Everything else should.
+        vm.expectRevert(abi.encodeWithSelector(INttManager.InvalidPeerChainIdZero.selector));
+        nttManagerChain1.setPeer(
+            0, bytes32(uint256(uint160(address(nttManagerChain2)))), 9, type(uint64).max
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(INttManager.InvalidPeerZeroAddress.selector));
+        nttManagerChain1.setPeer(chainId2, bytes32(0), 9, type(uint64).max);
+
+        vm.expectRevert(abi.encodeWithSelector(INttManager.InvalidPeerDecimals.selector));
+        nttManagerChain1.setPeer(
+            chainId2, bytes32(uint256(uint160(address(nttManagerChain2)))), 0, type(uint64).max
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(INttManager.InvalidPeerSameChainId.selector));
+        nttManagerChain1.setPeer(
+            chainId1, bytes32(uint256(uint160(address(nttManagerChain2)))), 9, type(uint64).max
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(INttManager.NotImplemented.selector));
+        nttManagerChain1.getOutboundQueuedTransfer(0);
+
+        vm.expectRevert(abi.encodeWithSelector(INttManager.NotImplemented.selector));
+        nttManagerChain1.getInboundQueuedTransfer(bytes32(0));
+
+        vm.expectRevert(abi.encodeWithSelector(INttManager.NotImplemented.selector));
+        nttManagerChain1.completeInboundQueuedTransfer(bytes32(0));
+
+        vm.expectRevert(abi.encodeWithSelector(INttManager.NotImplemented.selector));
+        nttManagerChain1.completeOutboundQueuedTransfer(0);
+
+        vm.expectRevert(abi.encodeWithSelector(INttManager.NotImplemented.selector));
+        nttManagerChain1.cancelOutboundQueuedTransfer(0);
+    }
+
+    function test_lotsOfReverts() public {
+        vm.chainId(chainId1);
+
+        // Setting up the transfer
+        DummyToken token1 = DummyToken(nttManagerChain1.token());
+        DummyToken token2 = DummyTokenMintAndBurn(nttManagerChain2.token());
+
+        uint8 decimals = token1.decimals();
+        uint256 sendingAmount = 5 * 10 ** decimals;
+        token1.mintDummy(address(userA), 5 * 10 ** decimals);
+        vm.startPrank(userA);
+        token1.approve(address(nttManagerChain1), sendingAmount);
+
+        vm.recordLogs();
+
+        // Send token through standard means (not relayer)
+        {
+            uint256 nttManagerBalanceBefore = token1.balanceOf(address(nttManagerChain1));
+            uint256 userBalanceBefore = token1.balanceOf(address(userA));
+            nttManagerChain1.transfer(
+                sendingAmount,
+                chainId2,
+                toWormholeFormat(userB),
+                toWormholeFormat(userA),
+                true,
+                encodeTransceiverInstruction(true)
+            );
+
+            // Balance check on funds going in and out working as expected
+            uint256 nttManagerBalanceAfter = token1.balanceOf(address(nttManagerChain1));
+            uint256 userBalanceAfter = token1.balanceOf(address(userB));
+            require(
+                nttManagerBalanceBefore + sendingAmount == nttManagerBalanceAfter,
+                "Should be locking the tokens"
+            );
+            require(
+                userBalanceBefore - sendingAmount == userBalanceAfter,
+                "User should have sent tokens"
+            );
+        }
+
+        vm.stopPrank();
+
+        // Get and sign the log to go down the other pipe. Thank you to whoever wrote this code in the past!
+        Vm.Log[] memory entries = guardian.fetchWormholeMessageFromLog(vm.getRecordedLogs());
+        bytes[] memory encodedVMs = new bytes[](entries.length);
+        for (uint256 i = 0; i < encodedVMs.length; i++) {
+            encodedVMs[i] = guardian.fetchSignedMessageFromLogs(entries[i], chainId1);
+        }
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IWormholeTransceiver.InvalidWormholePeer.selector,
+                chainId1,
+                wormholeTransceiverChain1
+            )
+        ); // Wrong chain receiving the signed VAA
+        wormholeTransceiverChain1.receiveMessage(encodedVMs[0]);
+
+        vm.chainId(chainId2);
+        {
+            uint256 supplyBefore = token2.totalSupply();
+            wormholeTransceiverChain2.receiveMessage(encodedVMs[0]);
+            uint256 supplyAfter = token2.totalSupply();
+
+            require(sendingAmount + supplyBefore == supplyAfter, "Supplies dont match");
+            require(token2.balanceOf(userB) == sendingAmount, "User didn't receive tokens");
+            require(
+                token2.balanceOf(address(nttManagerChain2)) == 0,
+                "NttManagerNoRateLimiting has unintended funds"
+            );
+        }
+
+        // Can't resubmit the same message twice
+        (IWormhole.VM memory wormholeVM,,) = wormhole.parseAndVerifyVM(encodedVMs[0]);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IWormholeTransceiver.TransferAlreadyCompleted.selector, wormholeVM.hash
+            )
+        );
+        wormholeTransceiverChain2.receiveMessage(encodedVMs[0]);
+
+        // Go back the other way from a THIRD user
+        vm.prank(userB);
+        token2.transfer(userC, sendingAmount);
+
+        vm.startPrank(userC);
+        token2.approve(address(nttManagerChain2), sendingAmount);
+        vm.recordLogs();
+
+        // Supply checks on the transfer
+        {
+            uint256 supplyBefore = token2.totalSupply();
+
+            vm.stopPrank();
+            // nttManagerChain2.setOutboundLimit(0);
+
+            vm.startPrank(userC);
+            nttManagerChain2.transfer(
+                sendingAmount,
+                chainId1,
+                toWormholeFormat(userD),
+                toWormholeFormat(userC),
+                true,
+                encodeTransceiverInstruction(true)
+            );
+
+            uint256 supplyAfter = token2.totalSupply();
+
+            require(sendingAmount - supplyBefore == supplyAfter, "Supplies don't match");
+            require(token2.balanceOf(userB) == 0, "OG user receive tokens");
+            require(token2.balanceOf(userC) == 0, "Sending user didn't receive tokens");
+            require(
+                token2.balanceOf(address(nttManagerChain2)) == 0,
+                "NttManagerNoRateLimiting didn't receive unintended funds"
+            );
+        }
+
+        // Get and sign the log to go down the other pipe. Thank you to whoever wrote this code in the past!
+        entries = guardian.fetchWormholeMessageFromLog(vm.getRecordedLogs());
+        encodedVMs = new bytes[](entries.length);
+        for (uint256 i = 0; i < encodedVMs.length; i++) {
+            encodedVMs[i] = guardian.fetchSignedMessageFromLogs(entries[i], chainId2);
+        }
+
+        // Chain1 verification and checks with the receiving of the message
+        vm.chainId(chainId1);
+        vm.stopPrank(); // Back to the owner of everything for this one.
+        vm.recordLogs();
+
+        {
+            uint256 supplyBefore = token1.totalSupply();
+
+            // nttManagerChain1.setInboundLimit(0, chainId2);
+            wormholeTransceiverChain1.receiveMessage(encodedVMs[0]);
+
+            bytes32[] memory queuedDigests =
+                Utils.fetchQueuedTransferDigestsFromLogs(vm.getRecordedLogs());
+
+            require(0 == queuedDigests.length, "Should not queue inbound messages");
+
+            uint256 supplyAfter = token1.totalSupply();
+
+            require(supplyBefore == supplyAfter, "Supplies don't match between operations");
+            require(token1.balanceOf(userB) == 0, "OG user receive tokens");
+            require(token1.balanceOf(userC) == 0, "Sending user didn't receive tokens");
+            require(token1.balanceOf(userD) == sendingAmount, "User received funds");
+        }
+    }
+
+    function test_multiTransceiver() public {
+        vm.chainId(chainId1);
+
+        WormholeTransceiver wormholeTransceiverChain1_1 = wormholeTransceiverChain1;
+
+        // Dual transceiver setup
+        WormholeTransceiver wormholeTransceiverChain1_2 = new MockWormholeTransceiverContract(
+            address(nttManagerChain1),
+            address(wormhole),
+            address(relayer),
+            address(0x0),
+            FAST_CONSISTENCY_LEVEL,
+            GAS_LIMIT
+        );
+
+        wormholeTransceiverChain1_2 = MockWormholeTransceiverContract(
+            address(new ERC1967Proxy(address(wormholeTransceiverChain1_2), ""))
+        );
+        wormholeTransceiverChain1_2.initialize();
+
+        vm.chainId(chainId2);
+        WormholeTransceiver wormholeTransceiverChain2_1 = wormholeTransceiverChain2;
+
+        // Dual transceiver setup
+        WormholeTransceiver wormholeTransceiverChain2_2 = new MockWormholeTransceiverContract(
+            address(nttManagerChain2),
+            address(wormhole),
+            address(relayer),
+            address(0x0),
+            FAST_CONSISTENCY_LEVEL,
+            GAS_LIMIT
+        );
+
+        wormholeTransceiverChain2_2 = MockWormholeTransceiverContract(
+            address(new ERC1967Proxy(address(wormholeTransceiverChain2_2), ""))
+        );
+        wormholeTransceiverChain2_2.initialize();
+
+        // Setup the new entrypoint hook ups to allow the transfers to occur
+        wormholeTransceiverChain1_2.setWormholePeer(
+            chainId2, bytes32(uint256(uint160((address(wormholeTransceiverChain2_2)))))
+        );
+        wormholeTransceiverChain2_2.setWormholePeer(
+            chainId1, bytes32(uint256(uint160((address(wormholeTransceiverChain1_2)))))
+        );
+        nttManagerChain2.setTransceiver(address(wormholeTransceiverChain2_2));
+        nttManagerChain1.setTransceiver(address(wormholeTransceiverChain1_2));
+
+        // Change the threshold from the setUp functions 1 to 2.
+        nttManagerChain1.setThreshold(2);
+        nttManagerChain2.setThreshold(2);
+
+        // Setting up the transfer
+        DummyToken token1 = DummyToken(nttManagerChain1.token());
+        DummyToken token2 = DummyTokenMintAndBurn(nttManagerChain2.token());
+
+        vm.startPrank(userA);
+        uint8 decimals = token1.decimals();
+        uint256 sendingAmount = 5 * 10 ** decimals;
+        token1.mintDummy(address(userA), sendingAmount);
+        vm.startPrank(userA);
+        token1.approve(address(nttManagerChain1), sendingAmount);
+
+        vm.chainId(chainId1);
+        vm.recordLogs();
+
+        // Send token through standard means (not relayer)
+        {
+            nttManagerChain1.transfer(
+                sendingAmount,
+                chainId2,
+                toWormholeFormat(userB),
+                toWormholeFormat(userA),
+                false,
+                encodeTransceiverInstructions(true)
+            );
+        }
+
+        // Get and sign the event emissions to go to the other chain.
+        Vm.Log[] memory entries = guardian.fetchWormholeMessageFromLog(vm.getRecordedLogs());
+        bytes[] memory encodedVMs = new bytes[](entries.length);
+        for (uint256 i = 0; i < encodedVMs.length; i++) {
+            encodedVMs[i] = guardian.fetchSignedMessageFromLogs(entries[i], chainId1);
+        }
+
+        vm.chainId(chainId2);
+
+        // Send in the messages for the two transceivers to complete the transfer from chain1 to chain2
+        {
+            // vm.stopPrank();
+            uint256 supplyBefore = token2.totalSupply();
+            wormholeTransceiverChain2_1.receiveMessage(encodedVMs[0]);
+
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    IWormholeTransceiver.InvalidWormholePeer.selector,
+                    chainId1,
+                    wormholeTransceiverChain1_1
+                )
+            );
+            wormholeTransceiverChain2_2.receiveMessage(encodedVMs[0]);
+
+            // Threshold check
+            require(supplyBefore == token2.totalSupply(), "Supplies have been updated too early");
+            require(token2.balanceOf(userB) == 0, "User received tokens to early");
+
+            // Finish the transfer out once the second VAA arrives
+            wormholeTransceiverChain2_2.receiveMessage(encodedVMs[1]);
+            uint256 supplyAfter = token2.totalSupply();
+
+            require(sendingAmount + supplyBefore == supplyAfter, "Supplies dont match");
+            require(token2.balanceOf(userB) == sendingAmount, "User didn't receive tokens");
+            require(
+                token2.balanceOf(address(nttManagerChain2)) == 0,
+                "NttManagerNoRateLimiting has unintended funds"
+            );
+        }
+
+        // Back the other way for the burn!
+        vm.startPrank(userB);
+        token2.approve(address(nttManagerChain2), sendingAmount);
+
+        vm.recordLogs();
+
+        // Send token through standard means (not relayer)
+        {
+            uint256 userBalanceBefore = token1.balanceOf(address(userB));
+            nttManagerChain2.transfer(
+                sendingAmount,
+                chainId1,
+                toWormholeFormat(userA),
+                toWormholeFormat(userB),
+                false,
+                encodeTransceiverInstructions(true)
+            );
+            uint256 nttManagerBalanceAfter = token1.balanceOf(address(nttManagerChain2));
+            uint256 userBalanceAfter = token1.balanceOf(address(userB));
+
+            require(userBalanceBefore - userBalanceAfter == 0, "No funds left for user");
+            require(
+                nttManagerBalanceAfter == 0,
+                "NttManagerNoRateLimiting should burn all tranferred tokens"
+            );
+        }
+
+        // Get the VAA proof for the transfers to use
+        entries = guardian.fetchWormholeMessageFromLog(vm.getRecordedLogs());
+        encodedVMs = new bytes[](entries.length);
+        for (uint256 i = 0; i < encodedVMs.length; i++) {
+            encodedVMs[i] = guardian.fetchSignedMessageFromLogs(entries[i], chainId2);
+        }
+
+        vm.chainId(chainId1);
+        {
+            uint256 supplyBefore = token1.totalSupply();
+            wormholeTransceiverChain1_1.receiveMessage(encodedVMs[0]);
+
+            require(supplyBefore == token1.totalSupply(), "Supplies have been updated too early");
+            require(token2.balanceOf(userA) == 0, "User received tokens to early");
+
+            // Finish the transfer out once the second VAA arrives
+            wormholeTransceiverChain1_2.receiveMessage(encodedVMs[1]);
+            uint256 supplyAfter = token1.totalSupply();
+
+            require(
+                supplyBefore == supplyAfter,
+                "Supplies don't match between operations. Should not increase."
+            );
+            require(token1.balanceOf(userB) == 0, "Sending user receive tokens");
+            require(
+                token1.balanceOf(userA) == sendingAmount, "Receiving user didn't receive tokens"
+            );
+        }
+
+        vm.stopPrank();
+    }
+
+    function copyBytes(
+        bytes memory _bytes
+    ) private pure returns (bytes memory) {
+        bytes memory copy = new bytes(_bytes.length);
+        uint256 max = _bytes.length + 31;
+        for (uint256 i = 32; i <= max; i += 32) {
+            assembly {
+                mstore(add(copy, i), mload(add(_bytes, i)))
+            }
+        }
+        return copy;
+    }
+
+    function encodeTransceiverInstruction(
+        bool relayer_off
+    ) public view returns (bytes memory) {
+        WormholeTransceiver.WormholeTransceiverInstruction memory instruction =
+            IWormholeTransceiver.WormholeTransceiverInstruction(relayer_off);
+        bytes memory encodedInstructionWormhole =
+            wormholeTransceiverChain1.encodeWormholeTransceiverInstruction(instruction);
+        TransceiverStructs.TransceiverInstruction memory TransceiverInstruction = TransceiverStructs
+            .TransceiverInstruction({index: 0, payload: encodedInstructionWormhole});
+        TransceiverStructs.TransceiverInstruction[] memory TransceiverInstructions =
+            new TransceiverStructs.TransceiverInstruction[](1);
+        TransceiverInstructions[0] = TransceiverInstruction;
+        return TransceiverStructs.encodeTransceiverInstructions(TransceiverInstructions);
+    }
+
+    // Encode an instruction for each of the relayers
+    function encodeTransceiverInstructions(
+        bool relayer_off
+    ) public view returns (bytes memory) {
+        WormholeTransceiver.WormholeTransceiverInstruction memory instruction =
+            IWormholeTransceiver.WormholeTransceiverInstruction(relayer_off);
+
+        bytes memory encodedInstructionWormhole =
+            wormholeTransceiverChain1.encodeWormholeTransceiverInstruction(instruction);
+
+        TransceiverStructs.TransceiverInstruction memory TransceiverInstruction1 =
+        TransceiverStructs.TransceiverInstruction({index: 0, payload: encodedInstructionWormhole});
+        TransceiverStructs.TransceiverInstruction memory TransceiverInstruction2 =
+        TransceiverStructs.TransceiverInstruction({index: 1, payload: encodedInstructionWormhole});
+
+        TransceiverStructs.TransceiverInstruction[] memory TransceiverInstructions =
+            new TransceiverStructs.TransceiverInstruction[](2);
+
+        TransceiverInstructions[0] = TransceiverInstruction1;
+        TransceiverInstructions[1] = TransceiverInstruction2;
+
+        return TransceiverStructs.encodeTransceiverInstructions(TransceiverInstructions);
+    }
+}

--- a/evm/test/NttManagerNoRateLimiting.t.sol
+++ b/evm/test/NttManagerNoRateLimiting.t.sol
@@ -1,0 +1,1133 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity >=0.8.8 <0.9.0;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+
+import "../src/NttManager/NttManagerNoRateLimiting.sol";
+import "../src/interfaces/INttManager.sol";
+import "../src/interfaces/IRateLimiter.sol";
+import "../src/interfaces/IManagerBase.sol";
+import "../src/interfaces/IRateLimiterEvents.sol";
+import "../src/NttManager/TransceiverRegistry.sol";
+import "../src/libraries/PausableUpgradeable.sol";
+import "../src/libraries/TransceiverHelpers.sol";
+import {Utils} from "./libraries/Utils.sol";
+
+import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "wormhole-solidity-sdk/interfaces/IWormhole.sol";
+import "wormhole-solidity-sdk/testing/helpers/WormholeSimulator.sol";
+import "wormhole-solidity-sdk/Utils.sol";
+import "./libraries/TransceiverHelpers.sol";
+import "./libraries/NttManagerHelpers.sol";
+import "./interfaces/ITransceiverReceiver.sol";
+import "./mocks/DummyTransceiver.sol";
+import "../src/mocks/DummyToken.sol";
+import "./mocks/MockNttManager.sol";
+
+// TODO: set this up so the common functionality tests can be run against both
+contract TestNttManagerNoRateLimiting is Test, IRateLimiterEvents {
+    MockNttManagerNoRateLimitingContract nttManager;
+    MockNttManagerNoRateLimitingContract nttManagerOther;
+    MockNttManagerNoRateLimitingContract nttManagerZeroRateLimiter;
+
+    using TrimmedAmountLib for uint256;
+    using TrimmedAmountLib for TrimmedAmount;
+
+    // 0x99'E''T''T'
+    uint16 constant chainId = 7;
+    uint16 constant chainId2 = 8;
+    uint256 constant DEVNET_GUARDIAN_PK =
+        0xcfb12303a19cde580bb4dd771639b0d26bc68353645571a8cff516ab2ee113a0;
+    WormholeSimulator guardian;
+    uint256 initialBlockTimestamp;
+    DummyTransceiver dummyTransceiver;
+
+    function setUp() public {
+        string memory url = "https://ethereum-sepolia-rpc.publicnode.com";
+        IWormhole wormhole = IWormhole(0x4a8bc80Ed5a4067f1CCf107057b8270E0cC11A78);
+        vm.createSelectFork(url);
+        initialBlockTimestamp = vm.getBlockTimestamp();
+
+        guardian = new WormholeSimulator(address(wormhole), DEVNET_GUARDIAN_PK);
+
+        DummyToken t = new DummyToken();
+        NttManagerNoRateLimiting implementation =
+            new MockNttManagerNoRateLimitingContract(address(t), IManagerBase.Mode.LOCKING, chainId);
+
+        NttManagerNoRateLimiting otherImplementation =
+            new MockNttManagerNoRateLimitingContract(address(t), IManagerBase.Mode.LOCKING, chainId);
+
+        nttManager = MockNttManagerNoRateLimitingContract(
+            address(new ERC1967Proxy(address(implementation), ""))
+        );
+        nttManager.initialize();
+
+        nttManagerOther = MockNttManagerNoRateLimitingContract(
+            address(new ERC1967Proxy(address(otherImplementation), ""))
+        );
+        nttManagerOther.initialize();
+
+        dummyTransceiver = new DummyTransceiver(address(nttManager));
+        nttManager.setTransceiver(address(dummyTransceiver));
+    }
+
+    // === pure unit tests
+
+    // naive implementation of countSetBits to test against
+    function simpleCount(
+        uint64 n
+    ) public pure returns (uint8) {
+        uint8 count;
+
+        while (n > 0) {
+            count += uint8(n & 1);
+            n >>= 1;
+        }
+
+        return count;
+    }
+
+    function testFuzz_countSetBits(
+        uint64 n
+    ) public {
+        assertEq(simpleCount(n), countSetBits(n));
+    }
+
+    // === ownership
+
+    function test_owner() public {
+        // TODO: implement separate governance contract
+        assertEq(nttManager.owner(), address(this));
+    }
+
+    function test_transferOwnership() public {
+        address newOwner = address(0x123);
+        nttManager.transferOwnership(newOwner);
+        assertEq(nttManager.owner(), newOwner);
+    }
+
+    function test_onlyOwnerCanTransferOwnership() public {
+        address notOwner = address(0x123);
+        vm.startPrank(notOwner);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, notOwner)
+        );
+        nttManager.transferOwnership(address(0x456));
+    }
+
+    function test_pauseUnpause() public {
+        assertEq(nttManager.isPaused(), false);
+        nttManager.pause();
+        assertEq(nttManager.isPaused(), true);
+
+        // When the NttManagerNoRateLimiting is paused, initiating transfers, completing queued transfers on both source and destination chains,
+        // executing transfers and attesting to transfers should all revert
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUpgradeable.RequireContractIsNotPaused.selector)
+        );
+        nttManager.transfer(0, 0, bytes32(0));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUpgradeable.RequireContractIsNotPaused.selector)
+        );
+        nttManager.completeOutboundQueuedTransfer(0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUpgradeable.RequireContractIsNotPaused.selector)
+        );
+        nttManager.completeInboundQueuedTransfer(bytes32(0));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUpgradeable.RequireContractIsNotPaused.selector)
+        );
+        TransceiverStructs.NttManagerMessage memory message;
+        nttManager.executeMsg(0, bytes32(0), message);
+
+        bytes memory transceiverMessage;
+        (, transceiverMessage) = TransceiverHelpersLib.buildTransceiverMessageWithNttManagerPayload(
+            0,
+            bytes32(0),
+            toWormholeFormat(address(nttManagerOther)),
+            toWormholeFormat(address(nttManager)),
+            abi.encode("payload")
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(PausableUpgradeable.RequireContractIsNotPaused.selector)
+        );
+        dummyTransceiver.receiveMessage(transceiverMessage);
+
+        nttManager.unpause();
+        assertEq(nttManager.isPaused(), false);
+    }
+
+    function test_pausePauserUnpauseOnlyOwner() public {
+        // transfer pauser to another address
+        address pauser = address(0x123);
+        nttManager.transferPauserCapability(pauser);
+
+        // execute from pauser context
+        vm.startPrank(pauser);
+        assertEq(nttManager.isPaused(), false);
+        nttManager.pause();
+        assertEq(nttManager.isPaused(), true);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, pauser)
+        );
+        nttManager.unpause();
+
+        // execute from owner context
+        // ensures that owner can still unpause
+        vm.startPrank(address(this));
+        nttManager.unpause();
+        assertEq(nttManager.isPaused(), false);
+    }
+
+    // === deployment with invalid token
+    function test_brokenToken() public {
+        DummyToken t = new DummyTokenBroken();
+        NttManagerNoRateLimiting implementation =
+            new MockNttManagerNoRateLimitingContract(address(t), IManagerBase.Mode.LOCKING, chainId);
+
+        NttManagerNoRateLimiting newNttManagerNoRateLimiting = MockNttManagerNoRateLimitingContract(
+            address(new ERC1967Proxy(address(implementation), ""))
+        );
+        vm.expectRevert(abi.encodeWithSelector(INttManager.StaticcallFailed.selector));
+        newNttManagerNoRateLimiting.initialize();
+
+        vm.expectRevert(abi.encodeWithSelector(INttManager.StaticcallFailed.selector));
+        newNttManagerNoRateLimiting.transfer(1, 1, bytes32("1"));
+    }
+
+    // === transceiver registration
+
+    function test_registerTransceiver() public {
+        DummyTransceiver e = new DummyTransceiver(address(nttManager));
+        nttManager.setTransceiver(address(e));
+    }
+
+    function test_onlyOwnerCanModifyTransceivers() public {
+        DummyTransceiver e = new DummyTransceiver(address(nttManager));
+        nttManager.setTransceiver(address(e));
+
+        address notOwner = address(0x123);
+        vm.startPrank(notOwner);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, notOwner)
+        );
+        nttManager.setTransceiver(address(e));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, notOwner)
+        );
+        nttManager.removeTransceiver(address(e));
+    }
+
+    function test_cantEnableTransceiverTwice() public {
+        DummyTransceiver e = new DummyTransceiver(address(nttManager));
+        nttManager.setTransceiver(address(e));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TransceiverRegistry.TransceiverAlreadyEnabled.selector, address(e)
+            )
+        );
+        nttManager.setTransceiver(address(e));
+    }
+
+    function test_disableReenableTransceiver() public {
+        DummyTransceiver e = new DummyTransceiver(address(nttManager));
+        nttManager.setTransceiver(address(e));
+        nttManager.removeTransceiver(address(e));
+        nttManager.setTransceiver(address(e));
+    }
+
+    function test_disableAllTransceiversFails() public {
+        vm.expectRevert(abi.encodeWithSelector(IManagerBase.ZeroThreshold.selector));
+        nttManager.removeTransceiver(address(dummyTransceiver));
+    }
+
+    function test_multipleTransceivers() public {
+        DummyTransceiver e1 = new DummyTransceiver(address(nttManager));
+        DummyTransceiver e2 = new DummyTransceiver(address(nttManager));
+
+        nttManager.setTransceiver(address(e1));
+        nttManager.setTransceiver(address(e2));
+    }
+
+    function test_transceiverIncompatibleNttManagerNoRateLimiting() public {
+        // Transceiver instantiation reverts if the nttManager doesn't have the proper token method
+        vm.expectRevert(bytes(""));
+        new DummyTransceiver(address(0xBEEF));
+    }
+
+    function test_transceiverWrongNttManagerNoRateLimiting() public {
+        // TODO: this is accepted currently. should we include a check to ensure
+        // only transceivers whose nttManager is us can be registered? (this would be
+        // a convenience check, not a security one)
+        DummyToken t = new DummyToken();
+        NttManagerNoRateLimiting altNttManagerNoRateLimiting =
+            new MockNttManagerNoRateLimitingContract(address(t), IManagerBase.Mode.LOCKING, chainId);
+        DummyTransceiver e = new DummyTransceiver(address(altNttManagerNoRateLimiting));
+        nttManager.setTransceiver(address(e));
+    }
+
+    function test_noEnabledTransceivers() public {
+        DummyToken token = new DummyToken();
+        NttManagerNoRateLimiting implementation = new MockNttManagerNoRateLimitingContract(
+            address(token), IManagerBase.Mode.LOCKING, chainId
+        );
+
+        MockNttManagerNoRateLimitingContract newNttManagerNoRateLimiting =
+        MockNttManagerNoRateLimitingContract(address(new ERC1967Proxy(address(implementation), "")));
+        newNttManagerNoRateLimiting.initialize();
+
+        address user_A = address(0x123);
+        address user_B = address(0x456);
+
+        uint8 decimals = token.decimals();
+
+        newNttManagerNoRateLimiting.setPeer(
+            chainId2, toWormholeFormat(address(0x1)), 9, type(uint64).max
+        );
+        newNttManagerNoRateLimiting.setOutboundLimit(
+            packTrimmedAmount(type(uint64).max, 8).untrim(decimals)
+        );
+
+        token.mintDummy(address(user_A), 5 * 10 ** decimals);
+
+        vm.startPrank(user_A);
+
+        token.approve(address(newNttManagerNoRateLimiting), 3 * 10 ** decimals);
+
+        vm.expectRevert(abi.encodeWithSelector(IManagerBase.NoEnabledTransceivers.selector));
+        newNttManagerNoRateLimiting.transfer(
+            1 * 10 ** decimals,
+            chainId2,
+            toWormholeFormat(user_B),
+            toWormholeFormat(user_A),
+            false,
+            new bytes(1)
+        );
+    }
+
+    function test_notTransceiver() public {
+        // TODO: this is accepted currently. should we include a check to ensure
+        // only transceivers can be registered? (this would be a convenience check, not a security one)
+        nttManager.setTransceiver(address(0x123));
+    }
+
+    function test_maxOutTransceivers() public {
+        // Let's register a transceiver and then disable it. We now have 2 registered managers
+        // since we register 1 in the setup
+        DummyTransceiver e = new DummyTransceiver(address(nttManager));
+        nttManager.setTransceiver(address(e));
+        nttManager.removeTransceiver(address(e));
+
+        // We should be able to register 64 transceivers total
+        for (uint256 i = 0; i < 62; ++i) {
+            DummyTransceiver d = new DummyTransceiver(address(nttManager));
+            nttManager.setTransceiver(address(d));
+        }
+
+        // Registering a new transceiver should fail as we've hit the cap
+        DummyTransceiver c = new DummyTransceiver(address(nttManager));
+        vm.expectRevert(TransceiverRegistry.TooManyTransceivers.selector);
+        nttManager.setTransceiver(address(c));
+
+        // We should be able to renable an already registered transceiver at the cap
+        nttManager.setTransceiver(address(e));
+    }
+
+    function test_passingInstructionsToTransceivers() public {
+        // Let's register a transceiver and then disable the original transceiver. We now have 2 registered transceivers
+        // since we register 1 in the setup
+        DummyTransceiver e = new DummyTransceiver(address(nttManager));
+        nttManager.setTransceiver(address(e));
+        nttManager.removeTransceiver(address(dummyTransceiver));
+
+        address user_A = address(0x123);
+        address user_B = address(0x456);
+
+        DummyToken token = DummyToken(nttManager.token());
+
+        uint8 decimals = token.decimals();
+
+        nttManager.setPeer(chainId2, toWormholeFormat(address(0x1)), 9, type(uint64).max);
+        nttManager.setOutboundLimit(packTrimmedAmount(type(uint64).max, 8).untrim(decimals));
+
+        token.mintDummy(address(user_A), 5 * 10 ** decimals);
+
+        vm.startPrank(user_A);
+
+        token.approve(address(nttManager), 3 * 10 ** decimals);
+
+        // Pass some instructions for the enabled transceiver
+        TransceiverStructs.TransceiverInstruction memory transceiverInstruction =
+            TransceiverStructs.TransceiverInstruction({index: 1, payload: new bytes(1)});
+        TransceiverStructs.TransceiverInstruction[] memory transceiverInstructions =
+            new TransceiverStructs.TransceiverInstruction[](1);
+        transceiverInstructions[0] = transceiverInstruction;
+        bytes memory instructions =
+            TransceiverStructs.encodeTransceiverInstructions(transceiverInstructions);
+
+        nttManager.transfer(
+            1 * 10 ** decimals,
+            chainId2,
+            toWormholeFormat(user_B),
+            toWormholeFormat(user_A),
+            false,
+            instructions
+        );
+    }
+
+    // == threshold
+
+    function test_cantSetThresholdTooHigh() public {
+        // 1 transceiver set, so can't set threshold to 2
+        vm.expectRevert(abi.encodeWithSelector(IManagerBase.ThresholdTooHigh.selector, 2, 1));
+        nttManager.setThreshold(2);
+    }
+
+    function test_canSetThreshold() public {
+        DummyTransceiver e1 = new DummyTransceiver(address(nttManager));
+        DummyTransceiver e2 = new DummyTransceiver(address(nttManager));
+        nttManager.setTransceiver(address(e1));
+        nttManager.setTransceiver(address(e2));
+
+        nttManager.setThreshold(1);
+        nttManager.setThreshold(2);
+        nttManager.setThreshold(1);
+    }
+
+    function test_cantSetThresholdToZero() public {
+        DummyTransceiver e = new DummyTransceiver(address(nttManager));
+        nttManager.setTransceiver(address(e));
+
+        vm.expectRevert(abi.encodeWithSelector(IManagerBase.ZeroThreshold.selector));
+        nttManager.setThreshold(0);
+    }
+
+    function test_onlyOwnerCanSetThreshold() public {
+        address notOwner = address(0x123);
+        vm.startPrank(notOwner);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, notOwner)
+        );
+        nttManager.setThreshold(1);
+    }
+
+    // == threshold
+
+    function test_peerRegistrationLimitsCantBeUpdated() public {
+        bytes32 peer = toWormholeFormat(address(nttManager));
+        nttManager.setPeer(TransceiverHelpersLib.SENDING_CHAIN_ID, peer, 9, 0);
+
+        IRateLimiter.RateLimitParams memory params =
+            nttManager.getInboundLimitParams(TransceiverHelpersLib.SENDING_CHAIN_ID);
+        assertEq(params.limit.getAmount(), 0);
+        assertEq(params.limit.getDecimals(), 0);
+
+        nttManager.setInboundLimit(type(uint64).max, TransceiverHelpersLib.SENDING_CHAIN_ID);
+        params = nttManager.getInboundLimitParams(TransceiverHelpersLib.SENDING_CHAIN_ID);
+        assertEq(params.limit.getAmount(), 0);
+        assertEq(params.limit.getDecimals(), 0);
+    }
+
+    // === attestation
+
+    function test_onlyEnabledTransceiversCanAttest() public {
+        (DummyTransceiver e1,) = TransceiverHelpersLib.setup_transceivers(nttManagerOther);
+        nttManagerOther.removeTransceiver(address(e1));
+        bytes32 peer = toWormholeFormat(address(nttManager));
+        nttManagerOther.setPeer(TransceiverHelpersLib.SENDING_CHAIN_ID, peer, 9, type(uint64).max);
+
+        bytes memory transceiverMessage;
+        (, transceiverMessage) = TransceiverHelpersLib.buildTransceiverMessageWithNttManagerPayload(
+            0, bytes32(0), peer, toWormholeFormat(address(nttManagerOther)), abi.encode("payload")
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(TransceiverRegistry.CallerNotTransceiver.selector, address(e1))
+        );
+        e1.receiveMessage(transceiverMessage);
+    }
+
+    function test_onlyPeerNttManagerNoRateLimitingCanAttest() public {
+        (DummyTransceiver e1,) = TransceiverHelpersLib.setup_transceivers(nttManagerOther);
+        nttManagerOther.setThreshold(2);
+
+        bytes32 peer = toWormholeFormat(address(nttManager));
+
+        TransceiverStructs.NttManagerMessage memory nttManagerMessage;
+        bytes memory transceiverMessage;
+        (nttManagerMessage, transceiverMessage) = TransceiverHelpersLib
+            .buildTransceiverMessageWithNttManagerPayload(
+            0, bytes32(0), peer, toWormholeFormat(address(nttManagerOther)), abi.encode("payload")
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                INttManager.InvalidPeer.selector, TransceiverHelpersLib.SENDING_CHAIN_ID, peer
+            )
+        );
+        e1.receiveMessage(transceiverMessage);
+    }
+
+    function test_attestSimple() public {
+        (DummyTransceiver e1,) = TransceiverHelpersLib.setup_transceivers(nttManagerOther);
+        nttManagerOther.setThreshold(2);
+
+        // register nttManager peer
+        bytes32 peer = toWormholeFormat(address(nttManager));
+        nttManagerOther.setPeer(TransceiverHelpersLib.SENDING_CHAIN_ID, peer, 9, type(uint64).max);
+
+        TransceiverStructs.NttManagerMessage memory nttManagerMessage;
+        bytes memory transceiverMessage;
+        (nttManagerMessage, transceiverMessage) = TransceiverHelpersLib
+            .buildTransceiverMessageWithNttManagerPayload(
+            0, bytes32(0), peer, toWormholeFormat(address(nttManagerOther)), abi.encode("payload")
+        );
+
+        e1.receiveMessage(transceiverMessage);
+
+        bytes32 hash = TransceiverStructs.nttManagerMessageDigest(
+            TransceiverHelpersLib.SENDING_CHAIN_ID, nttManagerMessage
+        );
+        assertEq(nttManagerOther.messageAttestations(hash), 1);
+    }
+
+    function test_attestTwice() public {
+        (DummyTransceiver e1,) = TransceiverHelpersLib.setup_transceivers(nttManagerOther);
+        nttManagerOther.setThreshold(2);
+
+        // register nttManager peer
+        bytes32 peer = toWormholeFormat(address(nttManager));
+        nttManagerOther.setPeer(TransceiverHelpersLib.SENDING_CHAIN_ID, peer, 9, type(uint64).max);
+
+        TransceiverStructs.NttManagerMessage memory nttManagerMessage;
+        bytes memory transceiverMessage;
+        (nttManagerMessage, transceiverMessage) = TransceiverHelpersLib
+            .buildTransceiverMessageWithNttManagerPayload(
+            0, bytes32(0), peer, toWormholeFormat(address(nttManagerOther)), abi.encode("payload")
+        );
+
+        bytes32 hash = TransceiverStructs.nttManagerMessageDigest(
+            TransceiverHelpersLib.SENDING_CHAIN_ID, nttManagerMessage
+        );
+
+        e1.receiveMessage(transceiverMessage);
+        vm.expectRevert(
+            abi.encodeWithSelector(IManagerBase.TransceiverAlreadyAttestedToMessage.selector, hash)
+        );
+        e1.receiveMessage(transceiverMessage);
+
+        // can't double vote
+        assertEq(nttManagerOther.messageAttestations(hash), 1);
+    }
+
+    function test_attestDisabled() public {
+        (DummyTransceiver e1,) = TransceiverHelpersLib.setup_transceivers(nttManagerOther);
+        nttManagerOther.setThreshold(2);
+
+        bytes32 peer = toWormholeFormat(address(nttManager));
+        nttManagerOther.setPeer(TransceiverHelpersLib.SENDING_CHAIN_ID, peer, 9, type(uint64).max);
+
+        ITransceiverReceiver[] memory transceivers = new ITransceiverReceiver[](1);
+        transceivers[0] = e1;
+
+        TransceiverStructs.NttManagerMessage memory m;
+        (m,) = TransceiverHelpersLib.attestTransceiversHelper(
+            address(0x456),
+            0,
+            chainId,
+            nttManager,
+            nttManagerOther,
+            packTrimmedAmount(50, 8),
+            packTrimmedAmount(type(uint64).max, 8),
+            transceivers
+        );
+
+        nttManagerOther.removeTransceiver(address(e1));
+
+        bytes32 hash =
+            TransceiverStructs.nttManagerMessageDigest(TransceiverHelpersLib.SENDING_CHAIN_ID, m);
+        // a disabled transceiver's vote no longer counts
+        assertEq(nttManagerOther.messageAttestations(hash), 0);
+
+        nttManagerOther.setTransceiver(address(e1));
+        // it counts again when reenabled
+        assertEq(nttManagerOther.messageAttestations(hash), 1);
+    }
+
+    function test_transfer_sequences() public {
+        address user_A = address(0x123);
+        address user_B = address(0x456);
+
+        DummyToken token = DummyToken(nttManager.token());
+
+        uint8 decimals = token.decimals();
+
+        nttManager.setPeer(chainId2, toWormholeFormat(address(0x1)), 9, type(uint64).max);
+        nttManager.setOutboundLimit(packTrimmedAmount(type(uint64).max, 8).untrim(decimals));
+
+        token.mintDummy(address(user_A), 5 * 10 ** decimals);
+
+        vm.startPrank(user_A);
+
+        token.approve(address(nttManager), 3 * 10 ** decimals);
+
+        uint64 s1 = nttManager.transfer(
+            1 * 10 ** decimals,
+            chainId2,
+            toWormholeFormat(user_B),
+            toWormholeFormat(user_A),
+            false,
+            new bytes(1)
+        );
+        uint64 s2 = nttManager.transfer(
+            1 * 10 ** decimals,
+            chainId2,
+            toWormholeFormat(user_B),
+            toWormholeFormat(user_A),
+            false,
+            new bytes(1)
+        );
+        uint64 s3 = nttManager.transfer(
+            1 * 10 ** decimals,
+            chainId2,
+            toWormholeFormat(user_B),
+            toWormholeFormat(user_A),
+            false,
+            new bytes(1)
+        );
+
+        assertEq(s1, 0);
+        assertEq(s2, 1);
+        assertEq(s3, 2);
+    }
+
+    function test_transferWithAmountAndDecimalsThatCouldOverflow() public {
+        // The source chain has 18 decimals trimmed to 8, and the peer has 6 decimals trimmed to 6
+        nttManager.setPeer(chainId2, toWormholeFormat(address(0x1)), 6, type(uint64).max);
+
+        address user_A = address(0x123);
+        address user_B = address(0x456);
+        DummyToken token = DummyToken(nttManager.token());
+        uint8 decimals = token.decimals();
+        assertEq(decimals, 18);
+
+        token.mintDummy(address(user_A), type(uint256).max);
+
+        vm.startPrank(user_A);
+        token.approve(address(nttManager), type(uint256).max);
+
+        // When transferring to a chain with 6 decimals the amount will get trimmed to 6 decimals
+        // and then scaled back up to 8 for local accounting. If we get the trimmed amount to be
+        // type(uint64).max, then when scaling up we could overflow. We safely cast to prevent this.
+
+        uint256 amount = type(uint64).max * 10 ** (decimals - 6);
+
+        vm.expectRevert("SafeCast: value doesn't fit in 64 bits");
+        nttManager.transfer(
+            amount,
+            chainId2,
+            toWormholeFormat(user_B),
+            toWormholeFormat(user_A),
+            false,
+            new bytes(1)
+        );
+
+        // A (slightly) more sensible amount should work normally
+        amount = (type(uint64).max * 10 ** (decimals - 6 - 2)) - 150000000000; // Subtract this to make sure we don't have dust
+        nttManager.transfer(
+            amount,
+            chainId2,
+            toWormholeFormat(user_B),
+            toWormholeFormat(user_A),
+            false,
+            new bytes(1)
+        );
+    }
+
+    function test_attestationQuorum() public {
+        address user_B = address(0x456);
+
+        (DummyTransceiver e1, DummyTransceiver e2) =
+            TransceiverHelpersLib.setup_transceivers(nttManagerOther);
+
+        TrimmedAmount transferAmount = packTrimmedAmount(50, 8);
+
+        TransceiverStructs.NttManagerMessage memory m;
+        bytes memory encodedEm;
+        {
+            ITransceiverReceiver[] memory transceivers = new ITransceiverReceiver[](2);
+            transceivers[0] = e1;
+            transceivers[1] = e2;
+
+            TransceiverStructs.TransceiverMessage memory em;
+            (m, em) = TransceiverHelpersLib.attestTransceiversHelper(
+                user_B,
+                0,
+                chainId,
+                nttManager,
+                nttManagerOther,
+                transferAmount,
+                packTrimmedAmount(type(uint64).max, 8),
+                transceivers
+            );
+            encodedEm = TransceiverStructs.encodeTransceiverMessage(
+                TransceiverHelpersLib.TEST_TRANSCEIVER_PAYLOAD_PREFIX, em
+            );
+        }
+
+        {
+            DummyToken token = DummyToken(nttManager.token());
+            assertEq(token.balanceOf(address(user_B)), transferAmount.untrim(token.decimals()));
+        }
+
+        // replay protection for transceiver
+        vm.recordLogs();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IManagerBase.TransceiverAlreadyAttestedToMessage.selector,
+                TransceiverStructs.nttManagerMessageDigest(
+                    TransceiverHelpersLib.SENDING_CHAIN_ID, m
+                )
+            )
+        );
+        e2.receiveMessage(encodedEm);
+    }
+
+    function test_transfersOnForkedChains() public {
+        uint256 evmChainId = block.chainid;
+
+        address user_A = address(0x123);
+        address user_B = address(0x456);
+
+        DummyToken token = DummyToken(nttManager.token());
+
+        uint8 decimals = token.decimals();
+
+        nttManager.setPeer(
+            TransceiverHelpersLib.SENDING_CHAIN_ID,
+            toWormholeFormat(address(nttManagerOther)),
+            9,
+            type(uint64).max
+        );
+        nttManager.setOutboundLimit(0);
+
+        token.mintDummy(address(user_A), 5 * 10 ** decimals);
+
+        vm.startPrank(user_A);
+
+        token.approve(address(nttManager), 3 * 10 ** decimals);
+
+        uint64 sequence = nttManager.transfer(
+            1 * 10 ** decimals,
+            TransceiverHelpersLib.SENDING_CHAIN_ID,
+            toWormholeFormat(user_B),
+            toWormholeFormat(user_A),
+            true,
+            new bytes(1)
+        );
+
+        vm.warp(vm.getBlockTimestamp() + 1 days);
+
+        vm.chainId(chainId);
+
+        // Queued outbound transfers can't be completed
+        vm.expectRevert(abi.encodeWithSelector(InvalidFork.selector, evmChainId, chainId));
+        nttManager.completeOutboundQueuedTransfer(sequence);
+
+        // Queued outbound transfers can't be cancelled
+        vm.expectRevert(abi.encodeWithSelector(InvalidFork.selector, evmChainId, chainId));
+        nttManager.cancelOutboundQueuedTransfer(sequence);
+
+        // Outbound transfers fail when queued
+        vm.expectRevert(abi.encodeWithSelector(InvalidFork.selector, evmChainId, chainId));
+        nttManager.transfer(
+            1 * 10 ** decimals,
+            TransceiverHelpersLib.SENDING_CHAIN_ID,
+            toWormholeFormat(user_B),
+            toWormholeFormat(user_A),
+            true,
+            new bytes(1)
+        );
+        vm.stopPrank();
+
+        nttManager.setOutboundLimit(packTrimmedAmount(type(uint64).max, 8).untrim(decimals));
+        // Outbound transfers fail when not queued
+        vm.prank(user_A);
+        vm.expectRevert(abi.encodeWithSelector(InvalidFork.selector, evmChainId, chainId));
+        nttManager.transfer(
+            1 * 10 ** decimals,
+            TransceiverHelpersLib.SENDING_CHAIN_ID,
+            toWormholeFormat(user_B),
+            toWormholeFormat(user_A),
+            false,
+            new bytes(1)
+        );
+
+        // INBOUND
+
+        bytes memory tokenTransferMessage = TransceiverStructs.encodeNativeTokenTransfer(
+            TransceiverStructs.NativeTokenTransfer({
+                amount: packTrimmedAmount(100, 8),
+                sourceToken: toWormholeFormat(address(token)),
+                to: toWormholeFormat(user_B),
+                toChain: chainId
+            })
+        );
+
+        bytes memory transceiverMessage;
+        TransceiverStructs.NttManagerMessage memory nttManagerMessage;
+        (nttManagerMessage, transceiverMessage) = TransceiverHelpersLib
+            .buildTransceiverMessageWithNttManagerPayload(
+            0,
+            toWormholeFormat(address(0x1)),
+            toWormholeFormat(address(nttManagerOther)),
+            toWormholeFormat(address(nttManager)),
+            tokenTransferMessage
+        );
+
+        // Inbound transfers can't be completed
+        vm.expectRevert(abi.encodeWithSelector(InvalidFork.selector, evmChainId, chainId));
+        dummyTransceiver.receiveMessage(transceiverMessage);
+
+        // Inbound queued transfers can't be completed
+        nttManager.setInboundLimit(0, TransceiverHelpersLib.SENDING_CHAIN_ID);
+
+        vm.chainId(evmChainId);
+
+        bytes32 hash = TransceiverStructs.nttManagerMessageDigest(
+            TransceiverHelpersLib.SENDING_CHAIN_ID, nttManagerMessage
+        );
+        dummyTransceiver.receiveMessage(transceiverMessage);
+
+        vm.chainId(chainId);
+
+        vm.warp(vm.getBlockTimestamp() + 1 days);
+
+        vm.expectRevert(abi.encodeWithSelector(InvalidFork.selector, evmChainId, chainId));
+        nttManager.completeInboundQueuedTransfer(hash);
+    }
+
+    // TODO:
+    // currently there is no way to test the threshold logic and the duplicate
+    // protection logic without setting up the business logic as well.
+    //
+    // we should separate the business logic out from the transceiver handling.
+    // that way the functionality could be tested separately (and the contracts
+    // would also be more reusable)
+
+    // === storage
+
+    function test_noAutomaticSlot() public {
+        DummyToken t = new DummyToken();
+        MockNttManagerNoRateLimitingContract c =
+            new MockNttManagerNoRateLimitingContract(address(t), IManagerBase.Mode.LOCKING, 1);
+        assertEq(c.lastSlot(), 0x0);
+    }
+
+    function test_constructor() public {
+        DummyToken t = new DummyToken();
+
+        vm.startStateDiffRecording();
+
+        new MockNttManagerNoRateLimitingContract(address(t), IManagerBase.Mode.LOCKING, 1);
+
+        Utils.assertSafeUpgradeableConstructor(vm.stopAndReturnStateDiff());
+    }
+
+    // === token transfer logic
+
+    function test_dustReverts() public {
+        // transfer 3 tokens
+        address from = address(0x123);
+        address to = address(0x456);
+
+        DummyToken token = DummyToken(nttManager.token());
+
+        uint8 decimals = token.decimals();
+
+        uint256 maxAmount = 5 * 10 ** decimals;
+        token.mintDummy(from, maxAmount);
+        nttManager.setPeer(chainId2, toWormholeFormat(address(0x1)), 9, type(uint64).max);
+        nttManager.setOutboundLimit(packTrimmedAmount(type(uint64).max, 8).untrim(decimals));
+        nttManager.setInboundLimit(
+            packTrimmedAmount(type(uint64).max, 8).untrim(decimals),
+            TransceiverHelpersLib.SENDING_CHAIN_ID
+        );
+
+        vm.startPrank(from);
+
+        uint256 transferAmount = 3 * 10 ** decimals;
+        assertEq(
+            transferAmount < maxAmount - 500, true, "Transferring more tokens than what exists"
+        );
+
+        uint256 dustAmount = 500;
+        uint256 amountWithDust = transferAmount + dustAmount; // An amount with 19 digits, which will result in dust due to 18 decimals
+        token.approve(address(nttManager), amountWithDust);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                INttManager.TransferAmountHasDust.selector, amountWithDust, dustAmount
+            )
+        );
+        nttManager.transfer(
+            amountWithDust,
+            chainId2,
+            toWormholeFormat(to),
+            toWormholeFormat(from),
+            false,
+            new bytes(1)
+        );
+
+        vm.stopPrank();
+    }
+
+    // === upgradeability
+    function expectRevert(
+        address contractAddress,
+        bytes memory encodedSignature,
+        bytes memory expectedRevert
+    ) internal {
+        (bool success, bytes memory result) = contractAddress.call(encodedSignature);
+        require(!success, "call did not revert");
+
+        require(keccak256(result) == keccak256(expectedRevert), "call did not revert as expected");
+    }
+
+    function test_upgradeNttManagerNoRateLimiting() public {
+        // The testing strategy here is as follows:
+        // Step 1: Deploy the nttManager contract with two transceivers and
+        //         receive a message through it.
+        // Step 2: Upgrade it to a new nttManager contract an use the same transceivers to receive
+        //         a new message through it.
+        // Step 3: Upgrade back to the standalone contract (with two
+        //           transceivers) and receive a message through it.
+        // This ensures that the storage slots don't get clobbered through the upgrades.
+
+        address user_B = address(0x456);
+        DummyToken token = DummyToken(nttManager.token());
+        TrimmedAmount transferAmount = packTrimmedAmount(50, 8);
+        (ITransceiverReceiver e1, ITransceiverReceiver e2) =
+            TransceiverHelpersLib.setup_transceivers(nttManagerOther);
+
+        // Step 1 (contract is deployed by setUp())
+        ITransceiverReceiver[] memory transceivers = new ITransceiverReceiver[](2);
+        transceivers[0] = e1;
+        transceivers[1] = e2;
+
+        TransceiverStructs.NttManagerMessage memory m;
+        bytes memory encodedEm;
+        {
+            TransceiverStructs.TransceiverMessage memory em;
+            (m, em) = TransceiverHelpersLib.attestTransceiversHelper(
+                user_B,
+                0,
+                chainId,
+                nttManager,
+                nttManagerOther,
+                transferAmount,
+                packTrimmedAmount(type(uint64).max, 8),
+                transceivers
+            );
+            encodedEm = TransceiverStructs.encodeTransceiverMessage(
+                TransceiverHelpersLib.TEST_TRANSCEIVER_PAYLOAD_PREFIX, em
+            );
+        }
+
+        assertEq(token.balanceOf(address(user_B)), transferAmount.untrim(token.decimals()));
+
+        // Step 2 (upgrade to a new nttManager)
+        MockNttManagerNoRateLimitingContract newNttManagerNoRateLimiting = new MockNttManagerNoRateLimitingContract(
+            nttManager.token(), IManagerBase.Mode.LOCKING, chainId
+        );
+        nttManagerOther.upgrade(address(newNttManagerNoRateLimiting));
+
+        TransceiverHelpersLib.attestTransceiversHelper(
+            user_B,
+            bytes32(uint256(1)),
+            chainId,
+            nttManager, // this is the proxy
+            nttManagerOther, // this is the proxy
+            transferAmount,
+            packTrimmedAmount(type(uint64).max, 8),
+            transceivers
+        );
+
+        assertEq(token.balanceOf(address(user_B)), transferAmount.untrim(token.decimals()) * 2);
+    }
+
+    function test_tokenUpgradedAndDecimalsChanged() public {
+        DummyToken dummy1 = new DummyTokenMintAndBurn();
+
+        // Make the token an upgradeable token
+        DummyTokenMintAndBurn t =
+            DummyTokenMintAndBurn(address(new ERC1967Proxy(address(dummy1), "")));
+
+        NttManagerNoRateLimiting implementation =
+            new MockNttManagerNoRateLimitingContract(address(t), IManagerBase.Mode.LOCKING, chainId);
+
+        MockNttManagerNoRateLimitingContract newNttManagerNoRateLimiting =
+        MockNttManagerNoRateLimitingContract(address(new ERC1967Proxy(address(implementation), "")));
+        newNttManagerNoRateLimiting.initialize();
+
+        // register nttManager peer and transceiver
+        bytes32 peer = toWormholeFormat(address(nttManager));
+        newNttManagerNoRateLimiting.setPeer(
+            TransceiverHelpersLib.SENDING_CHAIN_ID, peer, 9, type(uint64).max
+        );
+        {
+            DummyTransceiver e = new DummyTransceiver(address(newNttManagerNoRateLimiting));
+            newNttManagerNoRateLimiting.setTransceiver(address(e));
+        }
+
+        address user_A = address(0x123);
+        address user_B = address(0x456);
+        t.mintDummy(address(user_A), 5 * 10 ** t.decimals());
+
+        // Check that we can initiate a transfer
+        vm.startPrank(user_A);
+        t.approve(address(newNttManagerNoRateLimiting), 3 * 10 ** t.decimals());
+        newNttManagerNoRateLimiting.transfer(
+            1 * 10 ** t.decimals(),
+            TransceiverHelpersLib.SENDING_CHAIN_ID,
+            toWormholeFormat(user_B),
+            toWormholeFormat(user_A),
+            false,
+            new bytes(1)
+        );
+        vm.stopPrank();
+
+        // Check that we can receive a transfer
+        (DummyTransceiver e1,) =
+            TransceiverHelpersLib.setup_transceivers(newNttManagerNoRateLimiting);
+        newNttManagerNoRateLimiting.setThreshold(1);
+
+        bytes memory transceiverMessage;
+        bytes memory tokenTransferMessage;
+
+        TrimmedAmount transferAmount = packTrimmedAmount(100, 8);
+
+        tokenTransferMessage = TransceiverStructs.encodeNativeTokenTransfer(
+            TransceiverStructs.NativeTokenTransfer({
+                amount: transferAmount,
+                sourceToken: toWormholeFormat(address(t)),
+                to: toWormholeFormat(user_B),
+                toChain: chainId
+            })
+        );
+
+        (, transceiverMessage) = TransceiverHelpersLib.buildTransceiverMessageWithNttManagerPayload(
+            0,
+            bytes32(0),
+            peer,
+            toWormholeFormat(address(newNttManagerNoRateLimiting)),
+            tokenTransferMessage
+        );
+
+        e1.receiveMessage(transceiverMessage);
+        uint256 userBBalanceBefore = t.balanceOf(address(user_B));
+        assertEq(userBBalanceBefore, transferAmount.untrim(t.decimals()));
+
+        // If the token decimals change to the same trimmed amount, we should safely receive the correct number of tokens
+        DummyTokenDifferentDecimals dummy2 = new DummyTokenDifferentDecimals(10); // 10 gets trimmed to 8
+        t.upgrade(address(dummy2));
+
+        vm.startPrank(user_A);
+        newNttManagerNoRateLimiting.transfer(
+            1 * 10 ** 10,
+            TransceiverHelpersLib.SENDING_CHAIN_ID,
+            toWormholeFormat(user_B),
+            toWormholeFormat(user_A),
+            false,
+            new bytes(1)
+        );
+        vm.stopPrank();
+
+        (, transceiverMessage) = TransceiverHelpersLib.buildTransceiverMessageWithNttManagerPayload(
+            bytes32("1"),
+            bytes32(0),
+            peer,
+            toWormholeFormat(address(newNttManagerNoRateLimiting)),
+            tokenTransferMessage
+        );
+        e1.receiveMessage(transceiverMessage);
+        assertEq(
+            t.balanceOf(address(user_B)), userBBalanceBefore + transferAmount.untrim(t.decimals())
+        );
+
+        // Now if the token decimals change to a different trimmed amount, we shouldn't be able to send or receive
+        DummyTokenDifferentDecimals dummy3 = new DummyTokenDifferentDecimals(7); // 7 is 7 trimmed
+        t.upgrade(address(dummy3));
+
+        vm.startPrank(user_A);
+        vm.expectRevert(abi.encodeWithSelector(NumberOfDecimalsNotEqual.selector, 8, 7));
+        newNttManagerNoRateLimiting.transfer(
+            1 * 10 ** 7,
+            TransceiverHelpersLib.SENDING_CHAIN_ID,
+            toWormholeFormat(user_B),
+            toWormholeFormat(user_A),
+            false,
+            new bytes(1)
+        );
+        vm.stopPrank();
+
+        (, transceiverMessage) = TransceiverHelpersLib.buildTransceiverMessageWithNttManagerPayload(
+            bytes32("2"),
+            bytes32(0),
+            peer,
+            toWormholeFormat(address(newNttManagerNoRateLimiting)),
+            tokenTransferMessage
+        );
+        vm.expectRevert(abi.encodeWithSelector(NumberOfDecimalsNotEqual.selector, 8, 7));
+        e1.receiveMessage(transceiverMessage);
+    }
+
+    function test_transferWithInstructionIndexOutOfBounds() public {
+        TransceiverStructs.TransceiverInstruction memory TransceiverInstruction =
+            TransceiverStructs.TransceiverInstruction({index: 100, payload: new bytes(1)});
+        TransceiverStructs.TransceiverInstruction[] memory TransceiverInstructions =
+            new TransceiverStructs.TransceiverInstruction[](1);
+        TransceiverInstructions[0] = TransceiverInstruction;
+        bytes memory encodedInstructions =
+            TransceiverStructs.encodeTransceiverInstructions(TransceiverInstructions);
+
+        address user_A = address(0x123);
+        address user_B = address(0x456);
+
+        DummyToken token = DummyToken(nttManager.token());
+
+        uint8 decimals = token.decimals();
+
+        nttManager.setPeer(chainId2, toWormholeFormat(address(0x1)), 9, type(uint64).max);
+        nttManager.setOutboundLimit(packTrimmedAmount(type(uint64).max, 8).untrim(decimals));
+
+        token.mintDummy(address(user_A), 5 * 10 ** decimals);
+
+        vm.startPrank(user_A);
+
+        token.approve(address(nttManager), 3 * 10 ** decimals);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(TransceiverStructs.InvalidInstructionIndex.selector, 100, 1)
+        );
+        nttManager.transfer(
+            1 * 10 ** decimals,
+            chainId2,
+            toWormholeFormat(user_B),
+            toWormholeFormat(user_A),
+            false,
+            encodedInstructions
+        );
+    }
+}

--- a/evm/test/Upgrades.t.sol
+++ b/evm/test/Upgrades.t.sol
@@ -184,6 +184,8 @@ contract TestUpgrades is Test, IRateLimiterEvents {
         basicFunctionality();
     }
 
+    // NOTE: There are additional tests in `Upgrades.t.sol` to verifying downgrading from `NttManagerNoRateLimiting` to `NttManager`.
+
     function test_cannotUpgradeToNoRateLimitingIfItWasEnabled() public {
         // The default set up has rate limiting enabled. When we attempt to upgrade to no rate limiting, the immutable check should panic.
         NttManager rateLimitingImplementation = new MockNttManagerNoRateLimitingContract(

--- a/evm/test/mocks/MockNttManager.sol
+++ b/evm/test/mocks/MockNttManager.sol
@@ -31,9 +31,7 @@ contract MockNttManagerNoRateLimitingContract is NttManagerNoRateLimiting {
     constructor(
         address token,
         Mode mode,
-        uint16 chainId,
-        uint64 rateLimitDuration,
-        bool skipRateLimiting
+        uint16 chainId
     ) NttManagerNoRateLimiting(token, mode, chainId) {}
 
     /// We create a dummy storage variable here with standard solidity slot assignment.

--- a/evm/test/mocks/MockNttManager.sol
+++ b/evm/test/mocks/MockNttManager.sol
@@ -3,6 +3,7 @@
 pragma solidity >=0.8.8 <0.9.0;
 
 import "../../src/NttManager/NttManager.sol";
+import "../../src/NttManager/NttManagerNoRateLimiting.sol";
 
 contract MockNttManagerContract is NttManager {
     constructor(
@@ -12,6 +13,28 @@ contract MockNttManagerContract is NttManager {
         uint64 rateLimitDuration,
         bool skipRateLimiting
     ) NttManager(token, mode, chainId, rateLimitDuration, skipRateLimiting) {}
+
+    /// We create a dummy storage variable here with standard solidity slot assignment.
+    /// Then we check that its assigned slot is 0, i.e. that the super contract doesn't
+    /// define any storage variables (and instead uses deterministic slots).
+    /// See `test_noAutomaticSlot` below.
+    uint256 my_slot;
+
+    function lastSlot() public pure returns (bytes32 result) {
+        assembly ("memory-safe") {
+            result := my_slot.slot
+        }
+    }
+}
+
+contract MockNttManagerNoRateLimitingContract is NttManagerNoRateLimiting {
+    constructor(
+        address token,
+        Mode mode,
+        uint16 chainId,
+        uint64 rateLimitDuration,
+        bool skipRateLimiting
+    ) NttManagerNoRateLimiting(token, mode, chainId) {}
 
     /// We create a dummy storage variable here with standard solidity slot assignment.
     /// Then we check that its assigned slot is 0, i.e. that the super contract doesn't


### PR DESCRIPTION
This PR allows integrators to use NTT without rate limiting, in order to free up more space for adding their own custom features. If an integrator chooses to use `NttManagerNoRateLimiting`, they will have over 6K of head space for custom development, over using the existing `NttManager`.
