### PR TITLE
evm: TransferSent(bytes32), fixes #503

### DIFF
--- a/evm/README.md
+++ b/evm/README.md
@@ -20,6 +20,14 @@ event TransferSent(
 );
 ```
 
+```solidity
+/// @notice Emitted when a message is sent from the nttManager.
+/// @dev Topic0
+///      0x3e6ae56314c6da8b461d872f41c6d0bb69317b9d0232805aaccfa45df1a16fa0.
+/// @param digest The digest of the message.
+event TransferSent(bytes32 indexed digest);
+```
+
 2. **Rate Limit**
 
 A transfer can be rate-limited (see [here](../README.md#rate-limiting-and-cancel-flows) for more details) both on the source and destination chains. If a transfer is rate-limited on the source chain and the `shouldQueue` flag is enabled, it is added to an outbound queue. The transfer can be released after the configured `_rateLimitDuration` has expired via the [`completeOutboundQueuedTransfer`] method. The `OutboundTransferQueued` and `OutboundTransferRateLimited` events are emitted.

--- a/evm/src/NttManager/NttManager.sol
+++ b/evm/src/NttManager/NttManager.sol
@@ -539,6 +539,10 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
             seq
         );
 
+        emit TransferSent(
+            TransceiverStructs._nttManagerMessageDigest(chainId, encodedNttManagerPayload)
+        );
+
         // return the sequence number
         return seq;
     }

--- a/evm/src/interfaces/INttManager.sol
+++ b/evm/src/interfaces/INttManager.sol
@@ -32,6 +32,12 @@ interface INttManager is IManagerBase {
         uint64 msgSequence
     );
 
+    /// @notice Emitted when a message is sent from the nttManager.
+    /// @dev Topic0
+    ///      0x3e6ae56314c6da8b461d872f41c6d0bb69317b9d0232805aaccfa45df1a16fa0.
+    /// @param digest The digest of the message.
+    event TransferSent(bytes32 indexed digest);
+
     /// @notice Emitted when the peer contract is updated.
     /// @dev Topic0
     ///      0x1456404e7f41f35c3daac941bb50bad417a66275c3040061b4287d787719599d.

--- a/evm/src/libraries/TransceiverStructs.sol
+++ b/evm/src/libraries/TransceiverStructs.sol
@@ -59,7 +59,14 @@ library TransceiverStructs {
         uint16 sourceChainId,
         NttManagerMessage memory m
     ) public pure returns (bytes32) {
-        return keccak256(abi.encodePacked(sourceChainId, encodeNttManagerMessage(m)));
+        return _nttManagerMessageDigest(sourceChainId, encodeNttManagerMessage(m));
+    }
+
+    function _nttManagerMessageDigest(
+        uint16 sourceChainId,
+        bytes memory encodedNttManagerMessage
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(sourceChainId, encodedNttManagerMessage));
     }
 
     function encodeNttManagerMessage(


### PR DESCRIPTION
Before
```
| NttManager                            |   23,615 |        961 |
| NttManagerNoRateLimiting              |   18,169 |      6,407 |
```
After
```
| NttManager                            |   23,755 |        821 |
| NttManagerNoRateLimiting              |   18,403 |      6,173 |
```