### PR TITLE
CI: Debug CI for multi-transceiver support

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1288,7 +1288,7 @@ async function deploySolana<N extends Network, C extends SolanaChains>(
         ntt: {
             manager: providedProgramId,
             token: token,
-            transceiver: { wormhole: providedProgramId },
+            transceiver: { wormhole: emitter },
         }
     }) as SolanaNtt<N, C>;
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1798,7 +1798,7 @@ async function nttFromManager<N extends Network, C extends Chain>(
         ntt: {
             manager: nativeManagerAddress,
             token: null,
-            transceiver: { "wormhole": nativeManagerAddress },
+            transceiver: {},
         }
     });
     const diff = await onlyManager.verifyAddresses();

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1798,7 +1798,7 @@ async function nttFromManager<N extends Network, C extends Chain>(
         ntt: {
             manager: nativeManagerAddress,
             token: null,
-            transceiver: {},
+            transceiver: { "wormhole": nativeManagerAddress },
         }
     });
     const diff = await onlyManager.verifyAddresses();

--- a/evm/ts/src/ntt.ts
+++ b/evm/ts/src/ntt.ts
@@ -598,9 +598,7 @@ export class EvmNtt<N extends Network, C extends EvmChains>
       manager: this.managerAddress,
       token: await this.manager.token(),
       transceiver: {
-        ...(this.xcvrs.length > 0 && {
-          wormhole: (await this.manager.getTransceivers())[0]!,
-        }), // TODO: make this more generic
+        wormhole: (await this.manager.getTransceivers())[0]!, // TODO: make this more generic
       },
     };
 

--- a/sdk/__tests__/utils.ts
+++ b/sdk/__tests__/utils.ts
@@ -37,6 +37,7 @@ import solanaTiltKey from "./solana-tilt.json"; // from https://github.com/wormh
 import { Ntt } from "../definitions/src/index.js";
 import "../../evm/ts/src/index.js";
 import "../../solana/ts/sdk/index.js";
+import { NTT } from "../../solana/ts/lib/index.js";
 import { SolanaNtt } from "../../solana/ts/sdk/index.js";
 import { submitAccountantVAA } from "./accountant.js";
 
@@ -579,7 +580,9 @@ async function deploySolana(ctx: Ctx): Promise<Ctx> {
     ...ctx,
     contracts: {
       transceiver: {
-        wormhole: manager.program.programId.toString(),
+        wormhole: NTT.transceiverPdas(manager.program.programId)
+          .emitterAccount()
+          .toString(),
       },
       manager: manager.program.programId.toString(),
       token: mint.toString(),

--- a/sdk/__tests__/utils.ts
+++ b/sdk/__tests__/utils.ts
@@ -525,7 +525,9 @@ async function deploySolana(ctx: Ctx): Promise<Ctx> {
     token: mint.toBase58(),
     manager: managerProgramId,
     transceiver: {
-      wormhole: managerProgramId,
+      wormhole: NTT.transceiverPdas(managerProgramId)
+        .emitterAccount()
+        .toString(),
     },
   };
 

--- a/solana/Anchor.toml
+++ b/solana/Anchor.toml
@@ -9,7 +9,7 @@ skip-lint = false
 [programs.localnet]
 dummy_transfer_hook = "BgabMDLaxsyB7eGMBt9L22MSk9KMrL4zY2iNe14kyFP5"
 example_native_token_transfers = "nttiK1SepaQt6sZ4WGW5whvc9tEnGXGxuKeptcQPCcS"
-ntt-transceiver = "Ee6jpX9oq2EsGuqGb6iZZxvtcpmMGZk8SAUbnQy4jcHR"
+ntt_transceiver = "Ee6jpX9oq2EsGuqGb6iZZxvtcpmMGZk8SAUbnQy4jcHR"
 ntt_quoter = "9jFBLvMZZERVmeY4tbq5MejbXRE18paGEuoB6xVJZgGe"
 wormhole_governance = "wgvEiKVzX9yyEoh41jZAdC6JqGUTS4CFXbFGBV5TKdZ"
 

--- a/solana/scripts/anchor-lint.sh
+++ b/solana/scripts/anchor-lint.sh
@@ -3,7 +3,12 @@ set -uo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 TARGET=${SCRIPT_DIR}/../programs
-RESULTS=$(find "${TARGET}" -name "*.rs" -type f -exec anchor idl parse -o /dev/null --file {} \; 2>&1 | grep -v '^Error: Program module not found$')
+
+# Anchor IDL does not handle nested imports well (https://github.com/coral-xyz/anchor/issues/1099)
+# This directory has a workaround for it but that is not recognized by idl parse - hence it is skipped
+SKIP_DIR="${TARGET}/ntt-transceiver/src"
+ 
+RESULTS=$(find "${TARGET}" -path "${SKIP_DIR}" -prune -o -name "*.rs" -type f -exec anchor idl parse -o /dev/null --file {} \; 2>&1 | grep -v '^Error: Program module not found$')
 if [[ -n "$RESULTS" ]]; then
 	echo "${RESULTS}"
 	exit 1

--- a/solana/tests/anchor.test.ts
+++ b/solana/tests/anchor.test.ts
@@ -1,6 +1,7 @@
 import * as anchor from "@coral-xyz/anchor";
 import * as spl from "@solana/spl-token";
 import {
+  AccountAddress,
   ChainAddress,
   ChainContext,
   Signer,
@@ -13,7 +14,6 @@ import {
   serialize,
   serializePayload,
   signSendWait as ssw,
-  AccountAddress,
 } from "@wormhole-foundation/sdk";
 import * as testing from "@wormhole-foundation/sdk-definitions/testing";
 import {
@@ -26,14 +26,15 @@ import * as fs from "fs";
 
 import {
   PublicKey,
-  sendAndConfirmTransaction,
   SystemProgram,
   Transaction,
+  sendAndConfirmTransaction,
 } from "@solana/web3.js";
 import { DummyTransferHook } from "../ts/idl/1_0_0/ts/dummy_transfer_hook.js";
 import { type NttTransceiver as NttTransceiverIdlType } from "../ts/idl/2_0_0/ts/ntt_transceiver.js";
-import { SolanaNtt } from "../ts/sdk/index.js";
+import { NTT } from "../ts/index.js";
 import { derivePda } from "../ts/lib/utils.js";
+import { SolanaNtt } from "../ts/sdk/index.js";
 
 const solanaRootDir = `${__dirname}/../`;
 
@@ -434,6 +435,22 @@ describe("example-native-token-transfers", () => {
         );
         expect(version).toBe("2.0.0");
       });
+
+      test("It initializes using `emitterAccount` as transceiver address", async function () {
+        const overrideEmitter: (typeof overrides)["Solana"] = JSON.parse(
+          JSON.stringify(overrides["Solana"])
+        );
+        overrideEmitter.transceiver.wormhole = NTT.transceiverPdas(NTT_ADDRESS)
+          .emitterAccount()
+          .toBase58();
+
+        const ntt = new SolanaNtt("Devnet", "Solana", connection, {
+          ...ctx.config.contracts,
+          ...{ ntt: overrideEmitter },
+        });
+        expect(ntt).toBeTruthy();
+      });
+
       test("It gets the correct transceiver type", async function () {
         const ntt = new SolanaNtt("Devnet", "Solana", connection, {
           ...ctx.config.contracts,

--- a/solana/ts/sdk/ntt.ts
+++ b/solana/ts/sdk/ntt.ts
@@ -375,7 +375,11 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
             )
           );
           if (!whTransceiver.pdas.emitterAccount().equals(transceiverKey)) {
-            throw new Error("invalid emitterAccount provided");
+            throw new Error(
+              `Invalid emitterAccount provided. Expected: ${whTransceiver.pdas
+                .emitterAccount()
+                .toBase58()}; Actual: ${transceiverKey.toBase58()}`
+            );
           }
           this.transceivers.push(whTransceiver.program);
         } else {


### PR DESCRIPTION
* Allow `SolanaNtt` constructor to take in Wormhole transceiver address as either `emitterAccount` (if using baked-in transceiver) or the transceiver `programId` (if using standalone)
* Add test case to handle initialization using `emitterAccount`
* Update CLI and SDK tests to correctly pass in the `emitterAddress` as transceiver address
* Update `verifyAddresses` to return remote Wormhole transceiver address regardless of local case

This PR aims to fix the CI issues related to the SDK and CLI as a result of the changes introduced by #535.