### PR TITLE
Update to wormhole SDK 1.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -15,6 +15,9 @@
   },
   "dependencies": {
     "@wormhole-foundation/sdk": "^1.0.0",
+    "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
+    "@wormhole-foundation/sdk-solana-ntt": "0.5.0",
+    "@wormhole-foundation/sdk-evm-ntt": "0.5.0",
     "chalk": "^5.3.0",
     "yargs": "^17.7.2"
   }

--- a/cli/package.json
+++ b/cli/package.json
@@ -14,7 +14,6 @@
     "ntt": "src/index.ts"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "^1.0.0",
     "chalk": "^5.3.0",
     "yargs": "^17.7.2"
   }

--- a/cli/package.json
+++ b/cli/package.json
@@ -15,9 +15,6 @@
   },
   "dependencies": {
     "@wormhole-foundation/sdk": "^1.0.0",
-    "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
-    "@wormhole-foundation/sdk-solana-ntt": "0.5.0",
-    "@wormhole-foundation/sdk-evm-ntt": "0.5.0",
     "chalk": "^5.3.0",
     "yargs": "^17.7.2"
   }

--- a/cli/package.json
+++ b/cli/package.json
@@ -14,6 +14,7 @@
     "ntt": "src/index.ts"
   },
   "dependencies": {
+    "@wormhole-foundation/sdk": "^1.0.0",
     "chalk": "^5.3.0",
     "yargs": "^17.7.2"
   }

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wormhole-foundation/ntt-cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "module": "src/index.ts",
   "type": "module",
   "devDependencies": {

--- a/evm/ts/package.json
+++ b/evm/ts/package.json
@@ -54,11 +54,6 @@
     "@wormhole-foundation/sdk-evm-core": "^1.0.0"
   },
   "devDependencies": {
-    "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-base": "^1.0.0",
-    "@wormhole-foundation/sdk-definitions": "^1.0.0",
-    "@wormhole-foundation/sdk-evm": "^1.0.0",
-    "@wormhole-foundation/sdk-evm-core": "^1.0.0",
     "@typechain/ethers-v6": "^0.5.1",
     "tsx": "^4.7.2",
     "typechain": "^8.3.2"

--- a/evm/ts/package.json
+++ b/evm/ts/package.json
@@ -44,10 +44,10 @@
     "test": "jest --config ./jest.config.ts"
   },
   "dependencies": {
+    "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
     "ethers": "^6.5.1"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
     "@wormhole-foundation/sdk-base": "^1.0.0",
     "@wormhole-foundation/sdk-definitions": "^1.0.0",
     "@wormhole-foundation/sdk-evm": "^1.0.0",

--- a/evm/ts/package.json
+++ b/evm/ts/package.json
@@ -44,21 +44,21 @@
     "test": "jest --config ./jest.config.ts"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk-base": "^0.12.0",
-    "@wormhole-foundation/sdk-definitions": "^0.12.0",
-    "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-evm": "^0.12.0",
-    "@wormhole-foundation/sdk-evm-core": "^0.12.0",
     "ethers": "^6.5.1"
   },
   "peerDependencies": {
     "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-base": "^0.12.0",
-    "@wormhole-foundation/sdk-definitions": "^0.12.0",
-    "@wormhole-foundation/sdk-evm": "^0.12.0",
-    "@wormhole-foundation/sdk-evm-core": "^0.12.0"
+    "@wormhole-foundation/sdk-base": "^1.0.0",
+    "@wormhole-foundation/sdk-definitions": "^1.0.0",
+    "@wormhole-foundation/sdk-evm": "^1.0.0",
+    "@wormhole-foundation/sdk-evm-core": "^1.0.0"
   },
   "devDependencies": {
+    "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
+    "@wormhole-foundation/sdk-base": "^1.0.0",
+    "@wormhole-foundation/sdk-definitions": "^1.0.0",
+    "@wormhole-foundation/sdk-evm": "^1.0.0",
+    "@wormhole-foundation/sdk-evm-core": "^1.0.0",
     "@typechain/ethers-v6": "^0.5.1",
     "tsx": "^4.7.2",
     "typechain": "^8.3.2"

--- a/evm/ts/package.json
+++ b/evm/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wormhole-foundation/sdk-evm-ntt",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wormhole-foundation/example-native-token-transfers.git"
@@ -47,7 +47,7 @@
     "ethers": "^6.5.1"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
+    "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
     "@wormhole-foundation/sdk-base": "^1.0.0",
     "@wormhole-foundation/sdk-definitions": "^1.0.0",
     "@wormhole-foundation/sdk-evm": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3918,6 +3918,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-0.12.0.tgz",
       "integrity": "sha512-l756B8658G0yRscm4XIg2tC1NWFBftp2qdUEFTleO3j+AqIXyVk6h0MDIL9B7+FvUcPGd5H3Y4KM38JnNz5O6w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-algorand": "0.12.0",
@@ -3954,6 +3955,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-0.12.0.tgz",
       "integrity": "sha512-NoNMNFFwcX2owG5RgrxXp+30k2yecnsqR5M8im/PBbOjblOKCAW7QE7Rnx3tAv0GDpQDzU/xGh83J9UUXXeIUQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "0.12.0",
@@ -3967,6 +3969,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-0.12.0.tgz",
       "integrity": "sha512-LPaeRebRJCrftxy/1MzQwT6W0gnoFAUxnHBS1ckq+g5lBrCTuNd83tKZl/VIjUoQUUCUW62CRCGoBYfptYpzOQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-algorand": "0.12.0",
@@ -3980,6 +3983,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-0.12.0.tgz",
       "integrity": "sha512-xCfpV89N9786VqK7thm6QPA1c3c+8PJsF/IAzFocqIO8Hv/U4vVY80XC5eAUFdfb/xgPjL4wIw7dAV325jlOzA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-algorand": "0.12.0",
@@ -3994,6 +3998,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-0.12.0.tgz",
       "integrity": "sha512-TL+PK7CflQF2I4WxaMhbW7ud2kS2BOyKHcZQb9SGpL49aoaxCb6SD9rAIkJUH7JZeDHl5QRAUI2C1cqDMtiqOg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "0.12.0",
@@ -4007,6 +4012,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-0.12.0.tgz",
       "integrity": "sha512-+C/ACo0FAWZw720aFixNc6JIhK02wlAjBCQ7nM0rnVa7+5Z4DP0d9k63vMZ00jln7VkG+RUsWWi1T2XvVSLG1A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-aptos": "0.12.0",
@@ -4020,6 +4026,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-0.12.0.tgz",
       "integrity": "sha512-ZYBZRutboG7zV7jKjh8gcnncAHELOmc5340yq3MEN3tTFze/wYRMCYnn8WTwXVY+xuMatpmE0al3Hgp4toPB7Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-aptos": "0.12.0",
@@ -4042,6 +4049,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-0.12.0.tgz",
       "integrity": "sha512-zJFaiZ6QIHB5Edkg5OjrikvcEAMXS8rgtyBYfkAxw5yK/J5WOJIlhYaY8kWohObly1xaQUE/EuFmKlb8tvDBXA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-base": "0.12.0",
@@ -4056,6 +4064,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-0.12.0.tgz",
       "integrity": "sha512-gmXgoSrGr3mLMq+FZ0QMBqmk6llzkDN7fSvDEK7IX+c4eMtHIKw8GA/82MFCNUrj2T7OGJqKAMrRP+fjifVeJw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
@@ -4073,6 +4082,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-0.12.0.tgz",
       "integrity": "sha512-pSj0gOCgdrtAOwFoErdGWZe9KXDIh8qHKNTXFNJtr87eXW2qc4rFxoRcWwn/b1yPnfg2AQ5dZKjeBysDnHje+Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
@@ -4089,6 +4099,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-0.12.0.tgz",
       "integrity": "sha512-d8uWfU16L89Ds1ulwt+P4qroZcFaVt8yBNkLPZUb36V63lifXAKRKvXHTr9NzulSApGVWophwTODqDJQzL/Crw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
@@ -4107,6 +4118,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-0.12.0.tgz",
       "integrity": "sha512-4pD8Cy3p9WzU3DVBWsOsW5nX9GzIX/Jvt5CwtH+xFn/ekWrC0v/euWrkMu+cYuc0o89FFqRT9XUuJWYpPucQnQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
@@ -4136,6 +4148,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-0.12.0.tgz",
       "integrity": "sha512-HdlYPc1t+UTaNlh11Uiz+JSmXEZLJx55Bl/K6Oi6MvK7bIz4BQ0k53bUBlJUpYwHlNlklWLpRZ+3H36F5+/D/g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "0.12.0",
@@ -4149,6 +4162,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-0.12.0.tgz",
       "integrity": "sha512-PuldQP49QcQjADtcwEcjTeQsqiHIbJNfS+ZzLf1CvHkQcpBR2yqy2wjKa/cGWaNYlq+ZAkY7DZqzxqmVgFBeMg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "0.12.0",
@@ -4163,6 +4177,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-0.12.0.tgz",
       "integrity": "sha512-9oaSnWosdKTTOLUmtFbIqceIm0QutAQCJEO4HQcYJ+a3szi+8bGZxhghIfxO3dlKFDnxv7vVF7KMCClAeUmXbw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "0.12.0",
@@ -4181,6 +4196,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-0.12.0.tgz",
       "integrity": "sha512-o4Jlr8MkrYRwWSmUdr0bNMQ/YPbK6HJn9rq0I75OGPtLz5nG3t4XK7QKIngzyGM/zAlR2Txlwkyg2Gs15ybryA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "0.12.0",
@@ -4197,6 +4213,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-0.12.0.tgz",
       "integrity": "sha512-hryxL9binj8Fev5bMb5uC+Jd8GQmMVeIUmaWR6oyg+c8LepzxVLUPy1Xzvvn9g/oDKTWxgxgLA1H9rwaIcnUWw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "0.12.0",
@@ -4220,6 +4237,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-0.12.0.tgz",
       "integrity": "sha512-95eBRsjF4Rf/XvnFfi6JPli3KxS0dd51SVE9YhEDu8tZ8NzKHxu8agYBnNaJyG/tKksIgXznxKQaukbNQJNicQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
@@ -4237,6 +4255,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-0.12.0.tgz",
       "integrity": "sha512-NQ/xqVaXUCmpmbp7mKSSnPN3UrTH+3qhbTk4L2ffm2lJ/TifFdzfwGNpArpgNU5tBoKVy/FBlgahLd9e3If55w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
@@ -4253,6 +4272,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-0.12.0.tgz",
       "integrity": "sha512-v/5fFW8eUJ1Ts99NlfbMGphWOWlcVmMx+jDdFmhU8EgO9os7urTJ4GrdruXh2E+BwPlQh5VfCnXAU/hvawC/2Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
@@ -4273,6 +4293,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-0.12.0.tgz",
       "integrity": "sha512-PCN014InH5Iqlm1E6jfYyglan2AGbUUQ9elsAwbFWCBQhQQXDctnAn0yv8QaKMrWQhoN/E21dMWi2+Xs6dvEmw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
@@ -4290,6 +4311,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-0.12.0.tgz",
       "integrity": "sha512-uIo+ftb8h1iPjNhby62NsmQbiprTH5Q+m/n0n2TFV1InCnHIAD1S97SFuaL+kOYS0R+JIVCVuKoxhCab75OYeQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
@@ -4303,6 +4325,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-0.12.0.tgz",
       "integrity": "sha512-1ycCDzdK2kOUt5ZgTM5tu7CBC0MTtVfFErFfj/1tCq8HO+gy9Uc3MnY0AhChEcpr5WhQ/rFEuRA1gOxk2rEmsg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
@@ -4317,6 +4340,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-0.12.0.tgz",
       "integrity": "sha512-u2E4LZU7WPchdp7m7ij0MlQCKfH69mt2/AUR8TnfajYnsJe874TLhvrW0XK5B93WH+VVHDZD7uu4O/BcgyJdRg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
@@ -13069,7 +13093,7 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk": "^0.12.0",
+        "@wormhole-foundation/sdk": "^1.0.0",
         "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
         "@wormhole-foundation/sdk-evm-ntt": "0.4.0",
         "@wormhole-foundation/sdk-route-ntt": "0.4.0",
@@ -13081,6 +13105,375 @@
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
         "tsx": "^4.7.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.0.0.tgz",
+      "integrity": "sha512-QIkRaFe6+3DsOydShqzpTg4h6fiNI0i9N59hgCg33UiSbG87LI0g5bZZgiC1q4cpjBBcgj8w6uo2dAVrBr069Q==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-algorand": "1.0.0",
+        "@wormhole-foundation/sdk-algorand-core": "1.0.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "1.0.0",
+        "@wormhole-foundation/sdk-aptos": "1.0.0",
+        "@wormhole-foundation/sdk-aptos-core": "1.0.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "1.0.0",
+        "@wormhole-foundation/sdk-base": "1.0.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "1.0.0",
+        "@wormhole-foundation/sdk-definitions": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
+        "@wormhole-foundation/sdk-evm-cctp": "1.0.0",
+        "@wormhole-foundation/sdk-evm-core": "1.0.0",
+        "@wormhole-foundation/sdk-evm-portico": "1.0.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.0.0",
+        "@wormhole-foundation/sdk-solana": "1.0.0",
+        "@wormhole-foundation/sdk-solana-cctp": "1.0.0",
+        "@wormhole-foundation/sdk-solana-core": "1.0.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "1.0.0",
+        "@wormhole-foundation/sdk-sui": "1.0.0",
+        "@wormhole-foundation/sdk-sui-core": "1.0.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-algorand": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.0.0.tgz",
+      "integrity": "sha512-XoRuyAOcLU1eJ26bGdeN2mzP6thvaoshHrt25d/KnHKYLpjgvAhCyWgAka6qzig0CGrG8z4y0K7SkeThmtwakg==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "algosdk": "2.7.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-algorand-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.0.0.tgz",
+      "integrity": "sha512-brGzOliC/Zn4uAYxYAKXtJWStQy3FtAmVPLhQkglusIhmk69PNFLBFJ9p8o9sUR/IDgLnVz3/OEOdHANletqsA==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-algorand": "1.0.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-8CFFdqi78SuKDmCF9gTmkCFYSoPoDaqBsQdvKpUPvBQmDDJDl1NJ6JZrtKbK87FMrSKvDciXk4Dfb3ecezclPQ==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-algorand": "1.0.0",
+        "@wormhole-foundation/sdk-algorand-core": "1.0.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-aptos": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.0.0.tgz",
+      "integrity": "sha512-7SPLjjLsVVKuvNBRt1b87IEo0DMOvjxjIiUeM9sTDXdI7As3mLXaA4IliOQXi9+jLHpbq4q5Sk6XSxFgjsGgPQ==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "aptos": "1.21.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-aptos-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.0.0.tgz",
+      "integrity": "sha512-u6ZkvJxTq+xr2RCJejZ8Z8/AErnmTtREZfcYStbXprqsGb+MALrYUwF+sMERVZRrY9ltNs2q2/DAxNyRSH0cjw==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-aptos": "1.0.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-LxGkjdQItl2IFGupNGwJiJuN/HYdIP/emmWikMSlcZh4oBAaQrYkU+Pbrp/+gjmLcFp/jTK7G/Mg7Y7DWMx5XQ==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-aptos": "1.0.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.0.tgz",
+      "integrity": "sha512-PbfvGG/G6qDo3QtW+9R74iAFGeXziOfSumSSRJvH5gAmQmZWUmQ0C8WaBJIzYDoV+67IYenXHYfupVWsblTP3g==",
+      "dependencies": {
+        "@scure/base": "^1.1.3"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
+      "integrity": "sha512-Q6od8r+tA0TNcyOW0aYVLSyzSymLZscg62fZDY0jXpqec31fFH5zhyEmwAjyaeXvJGYG5TrzbnHVFImwRj08Mg==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-base": "1.0.0",
+        "@wormhole-foundation/sdk-definitions": "1.0.0",
+        "axios": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-cosmwasm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.0.0.tgz",
+      "integrity": "sha512-4Fxdz/zxuTq/obZ3ROv7ht+/9f/LS8wBt1n/L31cgYsNxO3B5/w4Rj82EKMiWDnQ0Y0kJKKkrlc08OmYu2F/Kw==",
+      "dependencies": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@cosmjs/proto-signing": "^0.32.0",
+        "@cosmjs/stargate": "^0.32.0",
+        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "cosmjs-types": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.0.0.tgz",
+      "integrity": "sha512-bVy015m/nnagbA5r80iylFzY+pnMFJndM3ZPHfM0FkW6mlIppTVrs9o0/NrwV823nEfgdCKdR4n0O/EKUnBY8Q==",
+      "dependencies": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@cosmjs/stargate": "^0.32.0",
+        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.0.0.tgz",
+      "integrity": "sha512-pNMDDbpqNIp3UpKf6Xt85jCRFJSGZ0oNMlEa/B3pJNIsRWTNntcisooSUcXVG2DXoSDcsKioiWAg7qmNe11LIQ==",
+      "dependencies": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@cosmjs/stargate": "^0.32.0",
+        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.0.0",
+        "cosmjs-types": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-F2tCLtapdoMwqc8FwyuJpsrmC7ItoAG1S/JklJrABlW7914KCcVqM2I5GzXprWzzWrl8sgtpeA/B+5euIHlKAQ==",
+      "dependencies": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-definitions": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.0.0.tgz",
+      "integrity": "sha512-lKME4k4lXMCYy6FotibtBVq5F4V5GuDtOyprGuTER47SdY5ZICK7xK8RKjcXlf+2T81sNQ6PkF7VIDteKiRfoA==",
+      "dependencies": {
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.3.1",
+        "@wormhole-foundation/sdk-base": "1.0.0"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-evm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.0.0.tgz",
+      "integrity": "sha512-uS6ypLuTT5oGmu3TdC+E2MzMhywTKRfIq9ASUGA9AyfZszSnStvhwz7wBi1uhX6ukyTJXFmmsk0nCuOqTTN+DA==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "ethers": "^6.5.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-evm-cctp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.0.0.tgz",
+      "integrity": "sha512-GKNdFpYcti5Ul6EeEbdNHLV46VWg6D65cL3A66RREeei9VbNChGIegLCtrpU0yFkTVZ7a1svkXFNlX17Gr4LaQ==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
+        "ethers": "^6.5.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-evm-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.0.0.tgz",
+      "integrity": "sha512-eDjTqJfosBFmRMv6TNGEku+CLTJcjLpgTvXO2oQ27ckCDCq7rJ/dwEi+DGS2ZQCW/D0e5ires50zaRURApRWjw==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
+        "ethers": "^6.5.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-evm-portico": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.0.0.tgz",
+      "integrity": "sha512-5uqUr8BCQXWRzAB6yj4PrI8RqEFXUstTGkvUjb7DwVH+fraoZwlkELStkTuVY73mpUnLW5lQFk0+7AXV/rHxqQ==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
+        "@wormhole-foundation/sdk-evm-core": "1.0.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.0.0",
+        "ethers": "^6.5.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-2lSSG3EIRnXSFzm6fIsAgnN9oS4bszm57WIO9fvt5Za5zO8ne7BqbYmnerdDx9fhp8nbC1oeJ+sQmGHOpV6QXA==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
+        "@wormhole-foundation/sdk-evm-core": "1.0.0",
+        "ethers": "^6.5.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-solana": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.0.0.tgz",
+      "integrity": "sha512-iNSXi3vQ6JRyNOlIto7J5EHksRt9avzVptqtrSllGnvm4+X/FENOAorpN887kMvI3qE3KgFtwrUPZa8rqwGxWA==",
+      "dependencies": {
+        "@coral-xyz/anchor": "0.29.0",
+        "@coral-xyz/borsh": "0.29.0",
+        "@solana/spl-token": "0.3.9",
+        "@solana/web3.js": "^1.95.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "rpc-websockets": "^7.10.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-solana-cctp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.0.0.tgz",
+      "integrity": "sha512-rD83p7Gyk3MNy/WEZu2LEm5eOHkRyFZu1MQ0qnQk7N9GwnL/atXmzWPJP5gJAwHpfe5GFEz6jeBxRMWZbK5png==",
+      "dependencies": {
+        "@coral-xyz/anchor": "0.29.0",
+        "@solana/spl-token": "0.3.9",
+        "@solana/web3.js": "^1.95.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-solana": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-solana-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.0.0.tgz",
+      "integrity": "sha512-fjETlCMqdkLfs3UNRYfrwHiDh2Nv/7L5wEXZpPiMFy6flSEwU0+QBTpeqdtMnqOJO+Fw6vSzQ+k4XS3CmmNdnA==",
+      "dependencies": {
+        "@coral-xyz/anchor": "0.29.0",
+        "@coral-xyz/borsh": "0.29.0",
+        "@solana/web3.js": "^1.95.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-solana": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-WgmcSknJafEFSYco/SXq7NI8NUfIMJFv5QDDNTwMp0cK85c4vQdLN0R3jlM5bllvK6wmoWIlyaCG0hsk1KedYg==",
+      "dependencies": {
+        "@coral-xyz/anchor": "0.29.0",
+        "@solana/spl-token": "0.3.9",
+        "@solana/web3.js": "^1.95.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-solana": "1.0.0",
+        "@wormhole-foundation/sdk-solana-core": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-sui": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.0.0.tgz",
+      "integrity": "sha512-PHzR/mNwd0DwDrW2Mho3JQQIAGTBkixbFnlbjZgs2U29+hHzoNjPD6Upx2xWNGC/KcS477yd6mqnj8YARfNG0A==",
+      "dependencies": {
+        "@mysten/sui.js": "^0.50.1",
+        "@wormhole-foundation/sdk-connect": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-sui-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.0.0.tgz",
+      "integrity": "sha512-PVvt7ibiAFrw3mIYnB7ETzUqaE3KYxonG2jPk7nU1xxTeCbtltopKQOWawA+Q0GgbOLtfoSIoJodYE8nGJXVMg==",
+      "dependencies": {
+        "@mysten/sui.js": "^0.50.1",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-sui": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/examples/node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-vv9Aew0qYLqVFYmN4gRVidncl1c4Sa4YUh9wn98GKEB/14BSIBHkWSqw3Y4cjli/K2kL1ZLfdp0UMViVgruSzA==",
+      "dependencies": {
+        "@mysten/sui.js": "^0.50.1",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-sui": "1.0.0",
+        "@wormhole-foundation/sdk-sui-core": "1.0.0"
       },
       "engines": {
         "node": ">=16"

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,15 +92,15 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "^0.12.0",
-        "@wormhole-foundation/sdk-definitions": "^0.12.0",
-        "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-        "@wormhole-foundation/sdk-evm": "^0.12.0",
-        "@wormhole-foundation/sdk-evm-core": "^0.12.0",
         "ethers": "^6.5.1"
       },
       "devDependencies": {
         "@typechain/ethers-v6": "^0.5.1",
+        "@wormhole-foundation/sdk-base": "^1.0.0",
+        "@wormhole-foundation/sdk-definitions": "^1.0.0",
+        "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
+        "@wormhole-foundation/sdk-evm": "^1.0.0",
+        "@wormhole-foundation/sdk-evm-core": "^1.0.0",
         "tsx": "^4.7.2",
         "typechain": "^8.3.2"
       },
@@ -108,11 +108,72 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^0.12.0",
-        "@wormhole-foundation/sdk-definitions": "^0.12.0",
+        "@wormhole-foundation/sdk-base": "^1.0.0",
+        "@wormhole-foundation/sdk-definitions": "^1.0.0",
         "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-        "@wormhole-foundation/sdk-evm": "^0.12.0",
-        "@wormhole-foundation/sdk-evm-core": "^0.12.0"
+        "@wormhole-foundation/sdk-evm": "^1.0.0",
+        "@wormhole-foundation/sdk-evm-core": "^1.0.0"
+      }
+    },
+    "evm/ts/node_modules/@wormhole-foundation/sdk-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.0.tgz",
+      "integrity": "sha512-PbfvGG/G6qDo3QtW+9R74iAFGeXziOfSumSSRJvH5gAmQmZWUmQ0C8WaBJIzYDoV+67IYenXHYfupVWsblTP3g==",
+      "dev": true,
+      "dependencies": {
+        "@scure/base": "^1.1.3"
+      }
+    },
+    "evm/ts/node_modules/@wormhole-foundation/sdk-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
+      "integrity": "sha512-Q6od8r+tA0TNcyOW0aYVLSyzSymLZscg62fZDY0jXpqec31fFH5zhyEmwAjyaeXvJGYG5TrzbnHVFImwRj08Mg==",
+      "dev": true,
+      "dependencies": {
+        "@wormhole-foundation/sdk-base": "1.0.0",
+        "@wormhole-foundation/sdk-definitions": "1.0.0",
+        "axios": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "evm/ts/node_modules/@wormhole-foundation/sdk-definitions": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.0.0.tgz",
+      "integrity": "sha512-lKME4k4lXMCYy6FotibtBVq5F4V5GuDtOyprGuTER47SdY5ZICK7xK8RKjcXlf+2T81sNQ6PkF7VIDteKiRfoA==",
+      "dev": true,
+      "dependencies": {
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.3.1",
+        "@wormhole-foundation/sdk-base": "1.0.0"
+      }
+    },
+    "evm/ts/node_modules/@wormhole-foundation/sdk-evm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.0.0.tgz",
+      "integrity": "sha512-uS6ypLuTT5oGmu3TdC+E2MzMhywTKRfIq9ASUGA9AyfZszSnStvhwz7wBi1uhX6ukyTJXFmmsk0nCuOqTTN+DA==",
+      "dev": true,
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "ethers": "^6.5.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "evm/ts/node_modules/@wormhole-foundation/sdk-evm-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.0.0.tgz",
+      "integrity": "sha512-eDjTqJfosBFmRMv6TNGEku+CLTJcjLpgTvXO2oQ27ckCDCq7rJ/dwEi+DGS2ZQCW/D0e5ires50zaRURApRWjw==",
+      "dev": true,
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
+        "ethers": "^6.5.1"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -13045,13 +13106,11 @@
       "name": "@wormhole-foundation/sdk-route-ntt",
       "version": "0.4.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "^0.12.0",
+      "devDependencies": {
+        "@wormhole-foundation/sdk-connect": "^1.0.0",
         "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
         "@wormhole-foundation/sdk-evm-ntt": "0.4.0",
-        "@wormhole-foundation/sdk-solana-ntt": "0.4.0"
-      },
-      "devDependencies": {
+        "@wormhole-foundation/sdk-solana-ntt": "0.4.0",
         "nock": "^13.3.3",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2"
@@ -13060,10 +13119,44 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-connect": "^0.12.0",
+        "@wormhole-foundation/sdk-connect": "^1.0.0",
         "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
         "@wormhole-foundation/sdk-evm-ntt": "0.4.0",
         "@wormhole-foundation/sdk-solana-ntt": "0.4.0"
+      }
+    },
+    "sdk/route/node_modules/@wormhole-foundation/sdk-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.0.tgz",
+      "integrity": "sha512-PbfvGG/G6qDo3QtW+9R74iAFGeXziOfSumSSRJvH5gAmQmZWUmQ0C8WaBJIzYDoV+67IYenXHYfupVWsblTP3g==",
+      "dev": true,
+      "dependencies": {
+        "@scure/base": "^1.1.3"
+      }
+    },
+    "sdk/route/node_modules/@wormhole-foundation/sdk-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
+      "integrity": "sha512-Q6od8r+tA0TNcyOW0aYVLSyzSymLZscg62fZDY0jXpqec31fFH5zhyEmwAjyaeXvJGYG5TrzbnHVFImwRj08Mg==",
+      "dev": true,
+      "dependencies": {
+        "@wormhole-foundation/sdk-base": "1.0.0",
+        "@wormhole-foundation/sdk-definitions": "1.0.0",
+        "axios": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "sdk/route/node_modules/@wormhole-foundation/sdk-definitions": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.0.0.tgz",
+      "integrity": "sha512-lKME4k4lXMCYy6FotibtBVq5F4V5GuDtOyprGuTER47SdY5ZICK7xK8RKjcXlf+2T81sNQ6PkF7VIDteKiRfoA==",
+      "dev": true,
+      "dependencies": {
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.3.1",
+        "@wormhole-foundation/sdk-base": "1.0.0"
       }
     },
     "solana": {
@@ -13075,14 +13168,15 @@
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.4.0",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-base": "^0.12.0",
-        "@wormhole-foundation/sdk-definitions": "^0.12.0",
-        "@wormhole-foundation/sdk-solana": "^0.12.0",
-        "@wormhole-foundation/sdk-solana-core": "^0.12.0",
         "bn.js": "5.2.1"
       },
       "devDependencies": {
         "@types/bn.js": "^5.1.5",
+        "@wormhole-foundation/sdk-base": "^1.0.0",
+        "@wormhole-foundation/sdk-definitions": "^1.0.0",
+        "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
+        "@wormhole-foundation/sdk-solana": "^1.0.0",
+        "@wormhole-foundation/sdk-solana-core": "^1.0.0",
         "nock": "^13.3.3",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
@@ -13092,11 +13186,11 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^0.12.0",
-        "@wormhole-foundation/sdk-definitions": "^0.12.0",
+        "@wormhole-foundation/sdk-base": "^1.0.0",
+        "@wormhole-foundation/sdk-definitions": "^1.0.0",
         "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-        "@wormhole-foundation/sdk-solana": "^0.12.0",
-        "@wormhole-foundation/sdk-solana-core": "^0.12.0"
+        "@wormhole-foundation/sdk-solana": "^1.0.0",
+        "@wormhole-foundation/sdk-solana-core": "^1.0.0"
       }
     },
     "solana/node_modules/@solana/codecs-core": {
@@ -13179,6 +13273,90 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "solana/node_modules/@wormhole-foundation/sdk-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.0.tgz",
+      "integrity": "sha512-PbfvGG/G6qDo3QtW+9R74iAFGeXziOfSumSSRJvH5gAmQmZWUmQ0C8WaBJIzYDoV+67IYenXHYfupVWsblTP3g==",
+      "dev": true,
+      "dependencies": {
+        "@scure/base": "^1.1.3"
+      }
+    },
+    "solana/node_modules/@wormhole-foundation/sdk-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
+      "integrity": "sha512-Q6od8r+tA0TNcyOW0aYVLSyzSymLZscg62fZDY0jXpqec31fFH5zhyEmwAjyaeXvJGYG5TrzbnHVFImwRj08Mg==",
+      "dev": true,
+      "dependencies": {
+        "@wormhole-foundation/sdk-base": "1.0.0",
+        "@wormhole-foundation/sdk-definitions": "1.0.0",
+        "axios": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "solana/node_modules/@wormhole-foundation/sdk-definitions": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.0.0.tgz",
+      "integrity": "sha512-lKME4k4lXMCYy6FotibtBVq5F4V5GuDtOyprGuTER47SdY5ZICK7xK8RKjcXlf+2T81sNQ6PkF7VIDteKiRfoA==",
+      "dev": true,
+      "dependencies": {
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.3.1",
+        "@wormhole-foundation/sdk-base": "1.0.0"
+      }
+    },
+    "solana/node_modules/@wormhole-foundation/sdk-solana": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.0.0.tgz",
+      "integrity": "sha512-iNSXi3vQ6JRyNOlIto7J5EHksRt9avzVptqtrSllGnvm4+X/FENOAorpN887kMvI3qE3KgFtwrUPZa8rqwGxWA==",
+      "dev": true,
+      "dependencies": {
+        "@coral-xyz/anchor": "0.29.0",
+        "@coral-xyz/borsh": "0.29.0",
+        "@solana/spl-token": "0.3.9",
+        "@solana/web3.js": "^1.95.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "rpc-websockets": "^7.10.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "solana/node_modules/@wormhole-foundation/sdk-solana-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.0.0.tgz",
+      "integrity": "sha512-fjETlCMqdkLfs3UNRYfrwHiDh2Nv/7L5wEXZpPiMFy6flSEwU0+QBTpeqdtMnqOJO+Fw6vSzQ+k4XS3CmmNdnA==",
+      "dev": true,
+      "dependencies": {
+        "@coral-xyz/anchor": "0.29.0",
+        "@coral-xyz/borsh": "0.29.0",
+        "@solana/web3.js": "^1.95.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-solana": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "solana/node_modules/@wormhole-foundation/sdk-solana/node_modules/@solana/spl-token": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.9.tgz",
+      "integrity": "sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==",
+      "dev": true,
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.47.4"
       }
     },
     "solana/node_modules/fastestsmallesttextencoderdecoder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       "name": "@wormhole-foundation/ntt-cli",
       "version": "0.4.0",
       "dependencies": {
+        "@wormhole-foundation/sdk": "^1.0.0",
         "chalk": "^5.3.0",
         "yargs": "^17.7.2"
       },
@@ -45,6 +46,357 @@
       },
       "peerDependencies": {
         "typescript": "^5.0.0"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.0.0.tgz",
+      "integrity": "sha512-QIkRaFe6+3DsOydShqzpTg4h6fiNI0i9N59hgCg33UiSbG87LI0g5bZZgiC1q4cpjBBcgj8w6uo2dAVrBr069Q==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-algorand": "1.0.0",
+        "@wormhole-foundation/sdk-algorand-core": "1.0.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "1.0.0",
+        "@wormhole-foundation/sdk-aptos": "1.0.0",
+        "@wormhole-foundation/sdk-aptos-core": "1.0.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "1.0.0",
+        "@wormhole-foundation/sdk-base": "1.0.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "1.0.0",
+        "@wormhole-foundation/sdk-definitions": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
+        "@wormhole-foundation/sdk-evm-cctp": "1.0.0",
+        "@wormhole-foundation/sdk-evm-core": "1.0.0",
+        "@wormhole-foundation/sdk-evm-portico": "1.0.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.0.0",
+        "@wormhole-foundation/sdk-solana": "1.0.0",
+        "@wormhole-foundation/sdk-solana-cctp": "1.0.0",
+        "@wormhole-foundation/sdk-solana-core": "1.0.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "1.0.0",
+        "@wormhole-foundation/sdk-sui": "1.0.0",
+        "@wormhole-foundation/sdk-sui-core": "1.0.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-algorand": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.0.0.tgz",
+      "integrity": "sha512-XoRuyAOcLU1eJ26bGdeN2mzP6thvaoshHrt25d/KnHKYLpjgvAhCyWgAka6qzig0CGrG8z4y0K7SkeThmtwakg==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "algosdk": "2.7.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-algorand-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.0.0.tgz",
+      "integrity": "sha512-brGzOliC/Zn4uAYxYAKXtJWStQy3FtAmVPLhQkglusIhmk69PNFLBFJ9p8o9sUR/IDgLnVz3/OEOdHANletqsA==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-algorand": "1.0.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-8CFFdqi78SuKDmCF9gTmkCFYSoPoDaqBsQdvKpUPvBQmDDJDl1NJ6JZrtKbK87FMrSKvDciXk4Dfb3ecezclPQ==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-algorand": "1.0.0",
+        "@wormhole-foundation/sdk-algorand-core": "1.0.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-aptos": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.0.0.tgz",
+      "integrity": "sha512-7SPLjjLsVVKuvNBRt1b87IEo0DMOvjxjIiUeM9sTDXdI7As3mLXaA4IliOQXi9+jLHpbq4q5Sk6XSxFgjsGgPQ==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "aptos": "1.21.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-aptos-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.0.0.tgz",
+      "integrity": "sha512-u6ZkvJxTq+xr2RCJejZ8Z8/AErnmTtREZfcYStbXprqsGb+MALrYUwF+sMERVZRrY9ltNs2q2/DAxNyRSH0cjw==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-aptos": "1.0.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-LxGkjdQItl2IFGupNGwJiJuN/HYdIP/emmWikMSlcZh4oBAaQrYkU+Pbrp/+gjmLcFp/jTK7G/Mg7Y7DWMx5XQ==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-aptos": "1.0.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
+      "integrity": "sha512-Q6od8r+tA0TNcyOW0aYVLSyzSymLZscg62fZDY0jXpqec31fFH5zhyEmwAjyaeXvJGYG5TrzbnHVFImwRj08Mg==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-base": "1.0.0",
+        "@wormhole-foundation/sdk-definitions": "1.0.0",
+        "axios": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-cosmwasm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.0.0.tgz",
+      "integrity": "sha512-4Fxdz/zxuTq/obZ3ROv7ht+/9f/LS8wBt1n/L31cgYsNxO3B5/w4Rj82EKMiWDnQ0Y0kJKKkrlc08OmYu2F/Kw==",
+      "dependencies": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@cosmjs/proto-signing": "^0.32.0",
+        "@cosmjs/stargate": "^0.32.0",
+        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "cosmjs-types": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.0.0.tgz",
+      "integrity": "sha512-bVy015m/nnagbA5r80iylFzY+pnMFJndM3ZPHfM0FkW6mlIppTVrs9o0/NrwV823nEfgdCKdR4n0O/EKUnBY8Q==",
+      "dependencies": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@cosmjs/stargate": "^0.32.0",
+        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.0.0.tgz",
+      "integrity": "sha512-pNMDDbpqNIp3UpKf6Xt85jCRFJSGZ0oNMlEa/B3pJNIsRWTNntcisooSUcXVG2DXoSDcsKioiWAg7qmNe11LIQ==",
+      "dependencies": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@cosmjs/stargate": "^0.32.0",
+        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.0.0",
+        "cosmjs-types": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-F2tCLtapdoMwqc8FwyuJpsrmC7ItoAG1S/JklJrABlW7914KCcVqM2I5GzXprWzzWrl8sgtpeA/B+5euIHlKAQ==",
+      "dependencies": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-evm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.0.0.tgz",
+      "integrity": "sha512-uS6ypLuTT5oGmu3TdC+E2MzMhywTKRfIq9ASUGA9AyfZszSnStvhwz7wBi1uhX6ukyTJXFmmsk0nCuOqTTN+DA==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "ethers": "^6.5.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-evm-cctp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.0.0.tgz",
+      "integrity": "sha512-GKNdFpYcti5Ul6EeEbdNHLV46VWg6D65cL3A66RREeei9VbNChGIegLCtrpU0yFkTVZ7a1svkXFNlX17Gr4LaQ==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
+        "ethers": "^6.5.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-evm-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.0.0.tgz",
+      "integrity": "sha512-eDjTqJfosBFmRMv6TNGEku+CLTJcjLpgTvXO2oQ27ckCDCq7rJ/dwEi+DGS2ZQCW/D0e5ires50zaRURApRWjw==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
+        "ethers": "^6.5.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-evm-portico": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.0.0.tgz",
+      "integrity": "sha512-5uqUr8BCQXWRzAB6yj4PrI8RqEFXUstTGkvUjb7DwVH+fraoZwlkELStkTuVY73mpUnLW5lQFk0+7AXV/rHxqQ==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
+        "@wormhole-foundation/sdk-evm-core": "1.0.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.0.0",
+        "ethers": "^6.5.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-2lSSG3EIRnXSFzm6fIsAgnN9oS4bszm57WIO9fvt5Za5zO8ne7BqbYmnerdDx9fhp8nbC1oeJ+sQmGHOpV6QXA==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
+        "@wormhole-foundation/sdk-evm-core": "1.0.0",
+        "ethers": "^6.5.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-solana": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.0.0.tgz",
+      "integrity": "sha512-iNSXi3vQ6JRyNOlIto7J5EHksRt9avzVptqtrSllGnvm4+X/FENOAorpN887kMvI3qE3KgFtwrUPZa8rqwGxWA==",
+      "dependencies": {
+        "@coral-xyz/anchor": "0.29.0",
+        "@coral-xyz/borsh": "0.29.0",
+        "@solana/spl-token": "0.3.9",
+        "@solana/web3.js": "^1.95.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "rpc-websockets": "^7.10.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-solana-cctp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.0.0.tgz",
+      "integrity": "sha512-rD83p7Gyk3MNy/WEZu2LEm5eOHkRyFZu1MQ0qnQk7N9GwnL/atXmzWPJP5gJAwHpfe5GFEz6jeBxRMWZbK5png==",
+      "dependencies": {
+        "@coral-xyz/anchor": "0.29.0",
+        "@solana/spl-token": "0.3.9",
+        "@solana/web3.js": "^1.95.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-solana": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-solana-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.0.0.tgz",
+      "integrity": "sha512-fjETlCMqdkLfs3UNRYfrwHiDh2Nv/7L5wEXZpPiMFy6flSEwU0+QBTpeqdtMnqOJO+Fw6vSzQ+k4XS3CmmNdnA==",
+      "dependencies": {
+        "@coral-xyz/anchor": "0.29.0",
+        "@coral-xyz/borsh": "0.29.0",
+        "@solana/web3.js": "^1.95.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-solana": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-WgmcSknJafEFSYco/SXq7NI8NUfIMJFv5QDDNTwMp0cK85c4vQdLN0R3jlM5bllvK6wmoWIlyaCG0hsk1KedYg==",
+      "dependencies": {
+        "@coral-xyz/anchor": "0.29.0",
+        "@solana/spl-token": "0.3.9",
+        "@solana/web3.js": "^1.95.2",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-solana": "1.0.0",
+        "@wormhole-foundation/sdk-solana-core": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-sui": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.0.0.tgz",
+      "integrity": "sha512-PHzR/mNwd0DwDrW2Mho3JQQIAGTBkixbFnlbjZgs2U29+hHzoNjPD6Upx2xWNGC/KcS477yd6mqnj8YARfNG0A==",
+      "dependencies": {
+        "@mysten/sui.js": "^0.50.1",
+        "@wormhole-foundation/sdk-connect": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-sui-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.0.0.tgz",
+      "integrity": "sha512-PVvt7ibiAFrw3mIYnB7ETzUqaE3KYxonG2jPk7nU1xxTeCbtltopKQOWawA+Q0GgbOLtfoSIoJodYE8nGJXVMg==",
+      "dependencies": {
+        "@mysten/sui.js": "^0.50.1",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-sui": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "cli/node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-vv9Aew0qYLqVFYmN4gRVidncl1c4Sa4YUh9wn98GKEB/14BSIBHkWSqw3Y4cjli/K2kL1ZLfdp0UMViVgruSzA==",
+      "dependencies": {
+        "@mysten/sui.js": "^0.50.1",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-sui": "1.0.0",
+        "@wormhole-foundation/sdk-sui-core": "1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "cli/node_modules/chalk": {
@@ -13491,6 +13843,11 @@
       "name": "@wormhole-foundation/sdk-route-ntt",
       "version": "0.4.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
+        "@wormhole-foundation/sdk-evm-ntt": "0.4.0",
+        "@wormhole-foundation/sdk-solana-ntt": "0.4.0"
+      },
       "devDependencies": {
         "nock": "^13.3.3",
         "ts-jest": "^29.1.2",
@@ -13500,10 +13857,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-connect": "^1.0.0",
-        "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-        "@wormhole-foundation/sdk-evm-ntt": "0.4.0",
-        "@wormhole-foundation/sdk-solana-ntt": "0.4.0"
+        "@wormhole-foundation/sdk-connect": "^1.0.0"
       }
     },
     "sdk/route/node_modules/@wormhole-foundation/sdk-connect": {
@@ -13529,6 +13883,7 @@
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.4.0",
         "@solana/web3.js": "^1.95.2",
+        "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
         "bn.js": "5.2.1"
       },
       "devDependencies": {
@@ -13544,7 +13899,6 @@
       "peerDependencies": {
         "@wormhole-foundation/sdk-base": "^1.0.0",
         "@wormhole-foundation/sdk-definitions": "^1.0.0",
-        "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
         "@wormhole-foundation/sdk-solana": "^1.0.0",
         "@wormhole-foundation/sdk-solana-core": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,10 +33,6 @@
       "name": "@wormhole-foundation/ntt-cli",
       "version": "0.5.0",
       "dependencies": {
-        "@wormhole-foundation/sdk": "^1.0.0",
-        "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
-        "@wormhole-foundation/sdk-evm-ntt": "0.5.0",
-        "@wormhole-foundation/sdk-solana-ntt": "0.5.0",
         "chalk": "^5.3.0",
         "yargs": "^17.7.2"
       },
@@ -96,6 +92,7 @@
       "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
         "ethers": "^6.5.1"
       },
       "devDependencies": {
@@ -109,7 +106,6 @@
       "peerDependencies": {
         "@wormhole-foundation/sdk-base": "^1.0.0",
         "@wormhole-foundation/sdk-definitions": "^1.0.0",
-        "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
         "@wormhole-foundation/sdk-evm": "^1.0.0",
         "@wormhole-foundation/sdk-evm-core": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@solana/web3.js": "^1.95.2",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.2",
-        "@wormhole-foundation/sdk": "^0.12.0",
+        "@wormhole-foundation/sdk": "^1.0.0",
         "@wormhole-foundation/wormchain-sdk": "^0.0.1",
         "ethers": "^6.5.1",
         "ts-jest": "^29.1.2",
@@ -46,357 +46,6 @@
       },
       "peerDependencies": {
         "typescript": "^5.0.0"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.0.0.tgz",
-      "integrity": "sha512-QIkRaFe6+3DsOydShqzpTg4h6fiNI0i9N59hgCg33UiSbG87LI0g5bZZgiC1q4cpjBBcgj8w6uo2dAVrBr069Q==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.0.0",
-        "@wormhole-foundation/sdk-algorand-core": "1.0.0",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "1.0.0",
-        "@wormhole-foundation/sdk-aptos": "1.0.0",
-        "@wormhole-foundation/sdk-aptos-core": "1.0.0",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "1.0.0",
-        "@wormhole-foundation/sdk-base": "1.0.0",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "1.0.0",
-        "@wormhole-foundation/sdk-definitions": "1.0.0",
-        "@wormhole-foundation/sdk-evm": "1.0.0",
-        "@wormhole-foundation/sdk-evm-cctp": "1.0.0",
-        "@wormhole-foundation/sdk-evm-core": "1.0.0",
-        "@wormhole-foundation/sdk-evm-portico": "1.0.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "1.0.0",
-        "@wormhole-foundation/sdk-solana": "1.0.0",
-        "@wormhole-foundation/sdk-solana-cctp": "1.0.0",
-        "@wormhole-foundation/sdk-solana-core": "1.0.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "1.0.0",
-        "@wormhole-foundation/sdk-sui": "1.0.0",
-        "@wormhole-foundation/sdk-sui-core": "1.0.0",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.0.0.tgz",
-      "integrity": "sha512-XoRuyAOcLU1eJ26bGdeN2mzP6thvaoshHrt25d/KnHKYLpjgvAhCyWgAka6qzig0CGrG8z4y0K7SkeThmtwakg==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "algosdk": "2.7.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.0.0.tgz",
-      "integrity": "sha512-brGzOliC/Zn4uAYxYAKXtJWStQy3FtAmVPLhQkglusIhmk69PNFLBFJ9p8o9sUR/IDgLnVz3/OEOdHANletqsA==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.0.0",
-        "@wormhole-foundation/sdk-connect": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.0.0.tgz",
-      "integrity": "sha512-8CFFdqi78SuKDmCF9gTmkCFYSoPoDaqBsQdvKpUPvBQmDDJDl1NJ6JZrtKbK87FMrSKvDciXk4Dfb3ecezclPQ==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.0.0",
-        "@wormhole-foundation/sdk-algorand-core": "1.0.0",
-        "@wormhole-foundation/sdk-connect": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.0.0.tgz",
-      "integrity": "sha512-7SPLjjLsVVKuvNBRt1b87IEo0DMOvjxjIiUeM9sTDXdI7As3mLXaA4IliOQXi9+jLHpbq4q5Sk6XSxFgjsGgPQ==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "aptos": "1.21.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.0.0.tgz",
-      "integrity": "sha512-u6ZkvJxTq+xr2RCJejZ8Z8/AErnmTtREZfcYStbXprqsGb+MALrYUwF+sMERVZRrY9ltNs2q2/DAxNyRSH0cjw==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "1.0.0",
-        "@wormhole-foundation/sdk-connect": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.0.0.tgz",
-      "integrity": "sha512-LxGkjdQItl2IFGupNGwJiJuN/HYdIP/emmWikMSlcZh4oBAaQrYkU+Pbrp/+gjmLcFp/jTK7G/Mg7Y7DWMx5XQ==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "1.0.0",
-        "@wormhole-foundation/sdk-connect": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
-      "integrity": "sha512-Q6od8r+tA0TNcyOW0aYVLSyzSymLZscg62fZDY0jXpqec31fFH5zhyEmwAjyaeXvJGYG5TrzbnHVFImwRj08Mg==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.0.0",
-        "@wormhole-foundation/sdk-definitions": "1.0.0",
-        "axios": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.0.0.tgz",
-      "integrity": "sha512-4Fxdz/zxuTq/obZ3ROv7ht+/9f/LS8wBt1n/L31cgYsNxO3B5/w4Rj82EKMiWDnQ0Y0kJKKkrlc08OmYu2F/Kw==",
-      "dependencies": {
-        "@cosmjs/cosmwasm-stargate": "^0.32.0",
-        "@cosmjs/proto-signing": "^0.32.0",
-        "@cosmjs/stargate": "^0.32.0",
-        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "cosmjs-types": "^0.9.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.0.0.tgz",
-      "integrity": "sha512-bVy015m/nnagbA5r80iylFzY+pnMFJndM3ZPHfM0FkW6mlIppTVrs9o0/NrwV823nEfgdCKdR4n0O/EKUnBY8Q==",
-      "dependencies": {
-        "@cosmjs/cosmwasm-stargate": "^0.32.0",
-        "@cosmjs/stargate": "^0.32.0",
-        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.0.0.tgz",
-      "integrity": "sha512-pNMDDbpqNIp3UpKf6Xt85jCRFJSGZ0oNMlEa/B3pJNIsRWTNntcisooSUcXVG2DXoSDcsKioiWAg7qmNe11LIQ==",
-      "dependencies": {
-        "@cosmjs/cosmwasm-stargate": "^0.32.0",
-        "@cosmjs/stargate": "^0.32.0",
-        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "1.0.0",
-        "cosmjs-types": "^0.9.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.0.0.tgz",
-      "integrity": "sha512-F2tCLtapdoMwqc8FwyuJpsrmC7ItoAG1S/JklJrABlW7914KCcVqM2I5GzXprWzzWrl8sgtpeA/B+5euIHlKAQ==",
-      "dependencies": {
-        "@cosmjs/cosmwasm-stargate": "^0.32.0",
-        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.0.0.tgz",
-      "integrity": "sha512-uS6ypLuTT5oGmu3TdC+E2MzMhywTKRfIq9ASUGA9AyfZszSnStvhwz7wBi1uhX6ukyTJXFmmsk0nCuOqTTN+DA==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "ethers": "^6.5.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.0.0.tgz",
-      "integrity": "sha512-GKNdFpYcti5Ul6EeEbdNHLV46VWg6D65cL3A66RREeei9VbNChGIegLCtrpU0yFkTVZ7a1svkXFNlX17Gr4LaQ==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-evm": "1.0.0",
-        "ethers": "^6.5.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.0.0.tgz",
-      "integrity": "sha512-eDjTqJfosBFmRMv6TNGEku+CLTJcjLpgTvXO2oQ27ckCDCq7rJ/dwEi+DGS2ZQCW/D0e5ires50zaRURApRWjw==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-evm": "1.0.0",
-        "ethers": "^6.5.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.0.0.tgz",
-      "integrity": "sha512-5uqUr8BCQXWRzAB6yj4PrI8RqEFXUstTGkvUjb7DwVH+fraoZwlkELStkTuVY73mpUnLW5lQFk0+7AXV/rHxqQ==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-evm": "1.0.0",
-        "@wormhole-foundation/sdk-evm-core": "1.0.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "1.0.0",
-        "ethers": "^6.5.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.0.0.tgz",
-      "integrity": "sha512-2lSSG3EIRnXSFzm6fIsAgnN9oS4bszm57WIO9fvt5Za5zO8ne7BqbYmnerdDx9fhp8nbC1oeJ+sQmGHOpV6QXA==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-evm": "1.0.0",
-        "@wormhole-foundation/sdk-evm-core": "1.0.0",
-        "ethers": "^6.5.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.0.0.tgz",
-      "integrity": "sha512-iNSXi3vQ6JRyNOlIto7J5EHksRt9avzVptqtrSllGnvm4+X/FENOAorpN887kMvI3qE3KgFtwrUPZa8rqwGxWA==",
-      "dependencies": {
-        "@coral-xyz/anchor": "0.29.0",
-        "@coral-xyz/borsh": "0.29.0",
-        "@solana/spl-token": "0.3.9",
-        "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "rpc-websockets": "^7.10.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.0.0.tgz",
-      "integrity": "sha512-rD83p7Gyk3MNy/WEZu2LEm5eOHkRyFZu1MQ0qnQk7N9GwnL/atXmzWPJP5gJAwHpfe5GFEz6jeBxRMWZbK5png==",
-      "dependencies": {
-        "@coral-xyz/anchor": "0.29.0",
-        "@solana/spl-token": "0.3.9",
-        "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-solana": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.0.0.tgz",
-      "integrity": "sha512-fjETlCMqdkLfs3UNRYfrwHiDh2Nv/7L5wEXZpPiMFy6flSEwU0+QBTpeqdtMnqOJO+Fw6vSzQ+k4XS3CmmNdnA==",
-      "dependencies": {
-        "@coral-xyz/anchor": "0.29.0",
-        "@coral-xyz/borsh": "0.29.0",
-        "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-solana": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.0.0.tgz",
-      "integrity": "sha512-WgmcSknJafEFSYco/SXq7NI8NUfIMJFv5QDDNTwMp0cK85c4vQdLN0R3jlM5bllvK6wmoWIlyaCG0hsk1KedYg==",
-      "dependencies": {
-        "@coral-xyz/anchor": "0.29.0",
-        "@solana/spl-token": "0.3.9",
-        "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-solana": "1.0.0",
-        "@wormhole-foundation/sdk-solana-core": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.0.0.tgz",
-      "integrity": "sha512-PHzR/mNwd0DwDrW2Mho3JQQIAGTBkixbFnlbjZgs2U29+hHzoNjPD6Upx2xWNGC/KcS477yd6mqnj8YARfNG0A==",
-      "dependencies": {
-        "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.0.0.tgz",
-      "integrity": "sha512-PVvt7ibiAFrw3mIYnB7ETzUqaE3KYxonG2jPk7nU1xxTeCbtltopKQOWawA+Q0GgbOLtfoSIoJodYE8nGJXVMg==",
-      "dependencies": {
-        "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-sui": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.0.0.tgz",
-      "integrity": "sha512-vv9Aew0qYLqVFYmN4gRVidncl1c4Sa4YUh9wn98GKEB/14BSIBHkWSqw3Y4cjli/K2kL1ZLfdp0UMViVgruSzA==",
-      "dependencies": {
-        "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-sui": "1.0.0",
-        "@wormhole-foundation/sdk-sui-core": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "cli/node_modules/chalk": {
@@ -462,52 +111,10 @@
         "@wormhole-foundation/sdk-evm-core": "^1.0.0"
       }
     },
-    "evm/ts/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
-      "integrity": "sha512-Q6od8r+tA0TNcyOW0aYVLSyzSymLZscg62fZDY0jXpqec31fFH5zhyEmwAjyaeXvJGYG5TrzbnHVFImwRj08Mg==",
-      "peer": true,
-      "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.0.0",
-        "@wormhole-foundation/sdk-definitions": "1.0.0",
-        "axios": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "evm/ts/node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.0.0.tgz",
-      "integrity": "sha512-uS6ypLuTT5oGmu3TdC+E2MzMhywTKRfIq9ASUGA9AyfZszSnStvhwz7wBi1uhX6ukyTJXFmmsk0nCuOqTTN+DA==",
-      "peer": true,
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "ethers": "^6.5.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "evm/ts/node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.0.0.tgz",
-      "integrity": "sha512-eDjTqJfosBFmRMv6TNGEku+CLTJcjLpgTvXO2oQ27ckCDCq7rJ/dwEi+DGS2ZQCW/D0e5ires50zaRURApRWjw==",
-      "peer": true,
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-evm": "1.0.0",
-        "ethers": "^6.5.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.8.tgz",
-      "integrity": "sha512-8BG6woLtDMvXB9Ajb/uE+Zr/U7y4qJ3upXi0JQHZmsKUJa7HjF/gFvmL2f3/mSmfZoQGRr9VoY97LCX2uaFMzA==",
-      "license": "MIT",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.11.tgz",
+      "integrity": "sha512-xuSJ9WXwTmtngWkbdEoopMo6F8NLtjy84UNAMsAr5C3/2SgAL/dEU10TMqTIsipqPQ8HA/7WzeqQ9DEQxSvPPA==",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       },
@@ -521,7 +128,6 @@
       "version": "1.12.16",
       "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.12.16.tgz",
       "integrity": "sha512-B5pyYVH93Etv7xjT6IfB7QtMBdaaC07yjbhN6v8H7KgFStMkPvi+oWYBTibMFRMY89qwc9H8YixXg8SXDVgYWw==",
-      "license": "MIT",
       "dependencies": {
         "@gql.tada/internal": "^1.0.0",
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
@@ -554,7 +160,6 @@
       "version": "3.11.8",
       "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.11.8.tgz",
       "integrity": "sha512-CgG1wbtMjsV2pRGe/eYITmV5B8lXUCYljB2gB/6jWTFQcrvirUVvKg7qtFdjYkQSFbIffU1IDyxgeaN81eTjbA==",
-      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -597,7 +202,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-client/-/aptos-client-0.1.1.tgz",
       "integrity": "sha512-kJsoy4fAPTOhzVr7Vwq8s/AUg6BQiJDa7WOqRzev4zsuIS3+JCuIZ6vUd7UBsjnxtmguJJulMRs9qWCzVBt2XA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "axios": "1.7.4",
         "got": "^11.8.6"
@@ -610,7 +214,6 @@
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
       "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -1354,7 +957,6 @@
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
       "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/crypto": "^0.32.4",
         "@cosmjs/encoding": "^0.32.4",
@@ -1366,7 +968,6 @@
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.4.tgz",
       "integrity": "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
@@ -1384,7 +985,6 @@
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.4.tgz",
       "integrity": "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/encoding": "^0.32.4",
         "@cosmjs/math": "^0.32.4",
@@ -1399,7 +999,6 @@
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
       "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
@@ -1410,7 +1009,6 @@
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.4.tgz",
       "integrity": "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/stream": "^0.32.4",
         "xstream": "^11.14.0"
@@ -1500,7 +1098,6 @@
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
       "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "bn.js": "^5.2.0"
       }
@@ -1509,7 +1106,6 @@
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
       "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
@@ -1523,7 +1119,6 @@
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.4.tgz",
       "integrity": "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/stream": "^0.32.4",
         "isomorphic-ws": "^4.0.1",
@@ -1535,7 +1130,6 @@
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.4.tgz",
       "integrity": "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@confio/ics23": "^0.6.8",
         "@cosmjs/amino": "^0.32.4",
@@ -1553,7 +1147,6 @@
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.4.tgz",
       "integrity": "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A==",
-      "license": "Apache-2.0",
       "dependencies": {
         "xstream": "^11.14.0"
       }
@@ -1562,7 +1155,6 @@
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.4.tgz",
       "integrity": "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/crypto": "^0.32.4",
         "@cosmjs/encoding": "^0.32.4",
@@ -1579,8 +1171,7 @@
     "node_modules/@cosmjs/utils": {
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.4.tgz",
-      "integrity": "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -2723,7 +2314,6 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.6.3.tgz",
       "integrity": "sha512-jFFSY8OxYeBxdKi58UzeMXG1tdm4FVjXa8WHIi66Gzu9JWtCE6mqom3a8xkmSw+mVaybFW5EN2WXf1WztJVNyQ==",
-      "license": "MIT",
       "dependencies": {
         "@0no-co/graphqlsp": "^1.12.13",
         "@gql.tada/internal": "1.0.8",
@@ -2749,7 +2339,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.0.8.tgz",
       "integrity": "sha512-XYdxJhtHC5WtZfdDqtKjcQ4d7R1s0d1rnlSs3OcBEUbYiPoJJfZU7tWsVXuv047Z6msvmr4ompJ7eLSK5Km57g==",
-      "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5"
       },
@@ -2762,7 +2351,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
       "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
-      "license": "MIT",
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
@@ -2780,10 +2368,9 @@
       }
     },
     "node_modules/@injectivelabs/core-proto-ts": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-0.0.21.tgz",
-      "integrity": "sha512-RBxSkRBCty60R/l55/D1jsSW0Aof5dyGFhCFdN3A010KjMv/SzZGGr+6DZPY/hflyFeaJzDv/VTopCymKNRBvQ==",
-      "license": "MIT",
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-0.0.34.tgz",
+      "integrity": "sha512-kg25j+aCFCR/zkfn6U7JlH4Be4VEHO77cjfSLCQfOavQZ2nrXy9pvc9X88OBTYTCL7wLngIqAe0edt39bDk3tQ==",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -2794,15 +2381,13 @@
     "node_modules/@injectivelabs/core-proto-ts/node_modules/long": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/@injectivelabs/core-proto-ts/node_modules/protobufjs": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
       "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2825,7 +2410,6 @@
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/@injectivelabs/dmm-proto-ts/-/dmm-proto-ts-1.0.20.tgz",
       "integrity": "sha512-S9vGOAZbNNa+N5QDW2HcXn7ohvU/4qze6wELA9gF8zu8uWbE+UKWTqzkZ+B4XuG1MkJwoHL7pVcj3M+nC9Qe4A==",
-      "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -2836,15 +2420,13 @@
     "node_modules/@injectivelabs/dmm-proto-ts/node_modules/long": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/@injectivelabs/dmm-proto-ts/node_modules/protobufjs": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
       "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2864,16 +2446,13 @@
       }
     },
     "node_modules/@injectivelabs/exceptions": {
-      "version": "1.14.13",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.14.13.tgz",
-      "integrity": "sha512-yFtB0jQtZI6D3AuaP6ObYtlVgDB4vriCWuV+6GY3frduv7i3kz1ZYVsPKsKSKBCOD5QegZXcEmGJL4RiDi1OKA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
+      "version": "1.14.16",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.14.16.tgz",
+      "integrity": "sha512-6kDldpoLjc69kH2i0RMCYTE/KQ2xnpd37A9et2K6IlhIZTVmAy3t5mBSj956Gzsg/82Q7K9fX8UNoG0iGQiOTw==",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
-        "@injectivelabs/ts-types": "^1.14.13",
+        "@injectivelabs/ts-types": "^1.14.16",
         "http-status-codes": "^2.2.0",
-        "link-module-alias": "^1.2.0",
         "shx": "^0.3.2"
       }
     },
@@ -2881,7 +2460,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@injectivelabs/grpc-web/-/grpc-web-0.0.1.tgz",
       "integrity": "sha512-Pu5YgaZp+OvR5UWfqbrPdHer3+gDf+b5fQoY+t2VZx1IAVHX8bzbN9EreYTvTYtFeDpYRWM8P7app2u4EX5wTw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "browser-headers": "^0.4.1"
       },
@@ -2893,7 +2471,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@injectivelabs/grpc-web-node-http-transport/-/grpc-web-node-http-transport-0.0.2.tgz",
       "integrity": "sha512-rpyhXLiGY/UMs6v6YmgWHJHiO9l0AgDyVNv+jcutNVt4tQrmNvnpvz2wCAGOFtq5LuX/E9ChtTVpk3gWGqXcGA==",
-      "license": "Apache-2.0",
       "peerDependencies": {
         "@injectivelabs/grpc-web": ">=0.0.1"
       }
@@ -2902,16 +2479,14 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@injectivelabs/grpc-web-react-native-transport/-/grpc-web-react-native-transport-0.0.2.tgz",
       "integrity": "sha512-mk+aukQXnYNgPsPnu3KBi+FD0ZHQpazIlaBZ2jNZG7QAVmxTWtv3R66Zoq99Wx2dnE946NsZBYAoa0K5oSjnow==",
-      "license": "Apache-2.0",
       "peerDependencies": {
         "@injectivelabs/grpc-web": ">=0.0.1"
       }
     },
     "node_modules/@injectivelabs/indexer-proto-ts": {
-      "version": "1.11.42",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.11.42.tgz",
-      "integrity": "sha512-6ejCpcWZWOSsELFIfUf2+xuJPOH+YdiJtwtB3d9x2H7dnrCBjXMxlPCSxoKEUbDH6w/lY2mO6TJm65rNy9piew==",
-      "license": "MIT",
+      "version": "1.11.56",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.11.56.tgz",
+      "integrity": "sha512-hEnN7DTVLGsol9Y/zaaDMDt1BZS/4KpMG419oCyM+MP1FVEOTp2BG/TDnIu7kXOwf66hCugBbnV84bvp2aY7SA==",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -2922,15 +2497,13 @@
     "node_modules/@injectivelabs/indexer-proto-ts/node_modules/long": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/@injectivelabs/indexer-proto-ts/node_modules/protobufjs": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
       "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2953,7 +2526,6 @@
       "version": "1.0.65",
       "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.0.65.tgz",
       "integrity": "sha512-kceZP68QrgFop387RYyO7tkfJCYxoktuceHTs9DQP3dJceLqj/V2mz0NlpkkacjgE5NhYkQ/zc0Z40hr8tnYqQ==",
-      "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -2964,15 +2536,13 @@
     "node_modules/@injectivelabs/mito-proto-ts/node_modules/long": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/@injectivelabs/mito-proto-ts/node_modules/protobufjs": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
       "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2992,43 +2562,38 @@
       }
     },
     "node_modules/@injectivelabs/networks": {
-      "version": "1.14.13",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.13.tgz",
-      "integrity": "sha512-P+eCQXWpbk4LbPxgTmi2gY7OzdZTNsIEUvDoh59Ma0CkqSFaYMtgB8fZVxpkKM0UPla587EDlEEIVxprDBcnZg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
+      "version": "1.14.16",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.16.tgz",
+      "integrity": "sha512-t0gF4uxv/39oAOHsnelX9QUfirxvNKgQYZwNpHvhE6JnEYjRYmaEifqB/LZBZ06Xj+SS/f2DZ7DwNdVTYuvaAw==",
       "dependencies": {
-        "@injectivelabs/exceptions": "^1.14.13",
-        "@injectivelabs/ts-types": "^1.14.13",
-        "@injectivelabs/utils": "^1.14.13",
-        "link-module-alias": "^1.2.0",
+        "@injectivelabs/exceptions": "^1.14.16",
+        "@injectivelabs/ts-types": "^1.14.16",
+        "@injectivelabs/utils": "^1.14.16",
         "shx": "^0.3.2"
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.14.13",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.13.tgz",
-      "integrity": "sha512-qcLoIu+hEMpuvdG0iXGNJvWQD05NkcO59tL3ijEhYmshlJWBMWJtpJJGt/E/hV9YxJfNTl20Rhi/5i7l0y8Hfg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
+      "version": "1.14.16",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.16.tgz",
+      "integrity": "sha512-D8/7CbjK1h3DCNm8p/Lp3RcVnnHI5+JX70Y5rJ2ewjjCZSsWixIEta2mnLX6eH5zQUpfHLl3EC3/mN2Q0MaJww==",
       "dependencies": {
         "@apollo/client": "^3.5.8",
         "@cosmjs/amino": "^0.32.3",
         "@cosmjs/proto-signing": "^0.32.3",
         "@cosmjs/stargate": "^0.32.3",
         "@ethersproject/bytes": "^5.7.0",
-        "@injectivelabs/core-proto-ts": "^0.0.21",
+        "@injectivelabs/core-proto-ts": "0.0.34",
         "@injectivelabs/dmm-proto-ts": "1.0.20",
-        "@injectivelabs/exceptions": "^1.14.13",
+        "@injectivelabs/exceptions": "^1.14.16",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts": "1.11.42",
+        "@injectivelabs/indexer-proto-ts": "1.11.56",
         "@injectivelabs/mito-proto-ts": "1.0.65",
-        "@injectivelabs/networks": "^1.14.13",
-        "@injectivelabs/test-utils": "^1.14.13",
-        "@injectivelabs/ts-types": "^1.14.13",
-        "@injectivelabs/utils": "^1.14.13",
+        "@injectivelabs/networks": "^1.14.16",
+        "@injectivelabs/test-utils": "^1.14.16",
+        "@injectivelabs/ts-types": "^1.14.16",
+        "@injectivelabs/utils": "^1.14.16",
         "@metamask/eth-sig-util": "^4.0.0",
         "@noble/curves": "^1.4.0",
         "axios": "^1.6.4",
@@ -3043,7 +2608,6 @@
         "js-sha3": "^0.8.0",
         "jscrypto": "^1.0.3",
         "keccak256": "^1.0.6",
-        "link-module-alias": "^1.2.0",
         "secp256k1": "^4.0.3",
         "shx": "^0.3.2",
         "snakecase-keys": "^5.4.1"
@@ -3052,48 +2616,42 @@
     "node_modules/@injectivelabs/sdk-ts/node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "license": "MIT"
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/@injectivelabs/test-utils": {
-      "version": "1.14.13",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/test-utils/-/test-utils-1.14.13.tgz",
-      "integrity": "sha512-wa5TQcWLvORRm36mw4Hee+XF7lBlArVK3DM1ebC0uBvVcUgrmm3g/nh1pV/NzLN16WtrLLsvnTsE5uiNEcgYdw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
+      "version": "1.14.16",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/test-utils/-/test-utils-1.14.16.tgz",
+      "integrity": "sha512-GCIEctKhQIxka7OexiG/3kUvua4XDA54oH5ltimFncLKKSWH1EQ8xk5euonW0q+3G3VV/YKScxmZ4LcKXtEf4Q==",
       "dependencies": {
+        "@injectivelabs/exceptions": "^1.14.16",
+        "@injectivelabs/networks": "^1.14.16",
+        "@injectivelabs/ts-types": "^1.14.16",
+        "@injectivelabs/utils": "^1.14.16",
         "axios": "^1.6.4",
         "bignumber.js": "^9.0.1",
-        "link-module-alias": "^1.2.0",
         "shx": "^0.3.2",
         "snakecase-keys": "^5.1.2",
         "store2": "^2.12.0"
       }
     },
     "node_modules/@injectivelabs/ts-types": {
-      "version": "1.14.13",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.14.13.tgz",
-      "integrity": "sha512-jkR4+JnQ91n7LWAdt+cZuvXFfqhv9RVlTE2pezAjZab7z7VeDonYwktjia5OcbqTKjlirvVHFALIZ0pmYd0j+A==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
+      "version": "1.14.16",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.14.16.tgz",
+      "integrity": "sha512-JzAwMQ0jneOCKQZWCHQD400HU5DFUnwD0DYxXCpcHE149BSorova3d+5oTL+HxibOzhr25j9zrCQVVsTC/+MmA==",
       "dependencies": {
-        "link-module-alias": "^1.2.0",
         "shx": "^0.3.2"
       }
     },
     "node_modules/@injectivelabs/utils": {
-      "version": "1.14.13",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.13.tgz",
-      "integrity": "sha512-djmSq28R7HDSb2Mezan+EFjqQgmDRydY+fLOmkODwOCYA04xOGQo7yna+WVovV85aKpwPjn864AWPy65xiHUZg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
+      "version": "1.14.16",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.16.tgz",
+      "integrity": "sha512-eS4SED2VqDD1m20drau8LrGjxmg8W+2CZj1hNXRB1bDk5+dAk92bw1/0LwiwzPsRX1bHV45w9sL0pk0VSZvV6w==",
       "dependencies": {
-        "@injectivelabs/exceptions": "^1.14.13",
-        "@injectivelabs/ts-types": "^1.14.13",
+        "@injectivelabs/exceptions": "^1.14.16",
+        "@injectivelabs/ts-types": "^1.14.16",
         "axios": "^1.6.4",
         "bignumber.js": "^9.0.1",
         "http-status-codes": "^2.2.0",
-        "link-module-alias": "^1.2.0",
         "shx": "^0.3.2",
         "snakecase-keys": "^5.1.2",
         "store2": "^2.12.0"
@@ -3480,7 +3038,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
       "integrity": "sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==",
-      "license": "ISC",
       "dependencies": {
         "ethereumjs-abi": "^0.6.8",
         "ethereumjs-util": "^6.2.1",
@@ -3496,7 +3053,6 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -3504,14 +3060,12 @@
     "node_modules/@metamask/eth-sig-util/node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-      "license": "MIT"
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/@metamask/eth-sig-util/node_modules/ethereumjs-util": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
       "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -3526,7 +3080,6 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
       "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "bs58": "^5.0.0"
       }
@@ -3534,14 +3087,12 @@
     "node_modules/@mysten/bcs/node_modules/base-x": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==",
-      "license": "MIT"
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/@mysten/bcs/node_modules/bs58": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
       "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
-      "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
       }
@@ -3551,7 +3102,6 @@
       "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
       "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
       "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
-      "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
         "@mysten/bcs": "0.11.1",
@@ -3573,14 +3123,12 @@
     "node_modules/@mysten/sui.js/node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "license": "MIT"
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/@mysten/sui.js/node_modules/superstruct": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
       "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3690,7 +3238,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.5.0.tgz",
       "integrity": "sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==",
-      "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.6.0",
         "@noble/hashes": "~1.5.0",
@@ -3704,7 +3251,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
       "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
-      "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3716,7 +3262,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
       "integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
-      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "~1.5.0",
         "@scure/base": "~1.1.8"
@@ -3729,7 +3274,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
       "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
-      "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3747,7 +3291,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3896,8 +3439,7 @@
     "node_modules/@suchipi/femver": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@suchipi/femver/-/femver-1.0.0.tgz",
-      "integrity": "sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg==",
-      "license": "MIT"
+      "integrity": "sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg=="
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.12",
@@ -3911,7 +3453,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-      "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
       },
@@ -4087,7 +3628,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-      "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "^3.1.4",
@@ -4116,8 +3656,7 @@
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
-      "license": "MIT"
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -4157,7 +3696,6 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -4179,7 +3717,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.2.tgz",
       "integrity": "sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -4194,7 +3731,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -4203,7 +3739,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.6.tgz",
       "integrity": "sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -4247,50 +3782,46 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-0.12.0.tgz",
-      "integrity": "sha512-l756B8658G0yRscm4XIg2tC1NWFBftp2qdUEFTleO3j+AqIXyVk6h0MDIL9B7+FvUcPGd5H3Y4KM38JnNz5O6w==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.0.0.tgz",
+      "integrity": "sha512-QIkRaFe6+3DsOydShqzpTg4h6fiNI0i9N59hgCg33UiSbG87LI0g5bZZgiC1q4cpjBBcgj8w6uo2dAVrBr069Q==",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.12.0",
-        "@wormhole-foundation/sdk-algorand-core": "0.12.0",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "0.12.0",
-        "@wormhole-foundation/sdk-aptos": "0.12.0",
-        "@wormhole-foundation/sdk-aptos-core": "0.12.0",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "0.12.0",
-        "@wormhole-foundation/sdk-base": "0.12.0",
-        "@wormhole-foundation/sdk-connect": "0.12.0",
-        "@wormhole-foundation/sdk-cosmwasm": "0.12.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "0.12.0",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "0.12.0",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "0.12.0",
-        "@wormhole-foundation/sdk-definitions": "0.12.0",
-        "@wormhole-foundation/sdk-evm": "0.12.0",
-        "@wormhole-foundation/sdk-evm-cctp": "0.12.0",
-        "@wormhole-foundation/sdk-evm-core": "0.12.0",
-        "@wormhole-foundation/sdk-evm-portico": "0.12.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "0.12.0",
-        "@wormhole-foundation/sdk-solana": "0.12.0",
-        "@wormhole-foundation/sdk-solana-cctp": "0.12.0",
-        "@wormhole-foundation/sdk-solana-core": "0.12.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "0.12.0",
-        "@wormhole-foundation/sdk-sui": "0.12.0",
-        "@wormhole-foundation/sdk-sui-core": "0.12.0",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "0.12.0"
+        "@wormhole-foundation/sdk-algorand": "1.0.0",
+        "@wormhole-foundation/sdk-algorand-core": "1.0.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "1.0.0",
+        "@wormhole-foundation/sdk-aptos": "1.0.0",
+        "@wormhole-foundation/sdk-aptos-core": "1.0.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "1.0.0",
+        "@wormhole-foundation/sdk-base": "1.0.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "1.0.0",
+        "@wormhole-foundation/sdk-definitions": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
+        "@wormhole-foundation/sdk-evm-cctp": "1.0.0",
+        "@wormhole-foundation/sdk-evm-core": "1.0.0",
+        "@wormhole-foundation/sdk-evm-portico": "1.0.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.0.0",
+        "@wormhole-foundation/sdk-solana": "1.0.0",
+        "@wormhole-foundation/sdk-solana-cctp": "1.0.0",
+        "@wormhole-foundation/sdk-solana-core": "1.0.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "1.0.0",
+        "@wormhole-foundation/sdk-sui": "1.0.0",
+        "@wormhole-foundation/sdk-sui-core": "1.0.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "1.0.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-0.12.0.tgz",
-      "integrity": "sha512-NoNMNFFwcX2owG5RgrxXp+30k2yecnsqR5M8im/PBbOjblOKCAW7QE7Rnx3tAv0GDpQDzU/xGh83J9UUXXeIUQ==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.0.0.tgz",
+      "integrity": "sha512-XoRuyAOcLU1eJ26bGdeN2mzP6thvaoshHrt25d/KnHKYLpjgvAhCyWgAka6qzig0CGrG8z4y0K7SkeThmtwakg==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.12.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -4298,42 +3829,36 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-0.12.0.tgz",
-      "integrity": "sha512-LPaeRebRJCrftxy/1MzQwT6W0gnoFAUxnHBS1ckq+g5lBrCTuNd83tKZl/VIjUoQUUCUW62CRCGoBYfptYpzOQ==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.0.0.tgz",
+      "integrity": "sha512-brGzOliC/Zn4uAYxYAKXtJWStQy3FtAmVPLhQkglusIhmk69PNFLBFJ9p8o9sUR/IDgLnVz3/OEOdHANletqsA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.12.0",
-        "@wormhole-foundation/sdk-connect": "0.12.0"
+        "@wormhole-foundation/sdk-algorand": "1.0.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-0.12.0.tgz",
-      "integrity": "sha512-xCfpV89N9786VqK7thm6QPA1c3c+8PJsF/IAzFocqIO8Hv/U4vVY80XC5eAUFdfb/xgPjL4wIw7dAV325jlOzA==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-8CFFdqi78SuKDmCF9gTmkCFYSoPoDaqBsQdvKpUPvBQmDDJDl1NJ6JZrtKbK87FMrSKvDciXk4Dfb3ecezclPQ==",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "0.12.0",
-        "@wormhole-foundation/sdk-algorand-core": "0.12.0",
-        "@wormhole-foundation/sdk-connect": "0.12.0"
+        "@wormhole-foundation/sdk-algorand": "1.0.0",
+        "@wormhole-foundation/sdk-algorand-core": "1.0.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-0.12.0.tgz",
-      "integrity": "sha512-TL+PK7CflQF2I4WxaMhbW7ud2kS2BOyKHcZQb9SGpL49aoaxCb6SD9rAIkJUH7JZeDHl5QRAUI2C1cqDMtiqOg==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.0.0.tgz",
+      "integrity": "sha512-7SPLjjLsVVKuvNBRt1b87IEo0DMOvjxjIiUeM9sTDXdI7As3mLXaA4IliOQXi9+jLHpbq4q5Sk6XSxFgjsGgPQ==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.12.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
         "aptos": "1.21.0"
       },
       "engines": {
@@ -4341,28 +3866,24 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-0.12.0.tgz",
-      "integrity": "sha512-+C/ACo0FAWZw720aFixNc6JIhK02wlAjBCQ7nM0rnVa7+5Z4DP0d9k63vMZ00jln7VkG+RUsWWi1T2XvVSLG1A==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.0.0.tgz",
+      "integrity": "sha512-u6ZkvJxTq+xr2RCJejZ8Z8/AErnmTtREZfcYStbXprqsGb+MALrYUwF+sMERVZRrY9ltNs2q2/DAxNyRSH0cjw==",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "0.12.0",
-        "@wormhole-foundation/sdk-connect": "0.12.0"
+        "@wormhole-foundation/sdk-aptos": "1.0.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-0.12.0.tgz",
-      "integrity": "sha512-ZYBZRutboG7zV7jKjh8gcnncAHELOmc5340yq3MEN3tTFze/wYRMCYnn8WTwXVY+xuMatpmE0al3Hgp4toPB7Q==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-LxGkjdQItl2IFGupNGwJiJuN/HYdIP/emmWikMSlcZh4oBAaQrYkU+Pbrp/+gjmLcFp/jTK7G/Mg7Y7DWMx5XQ==",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "0.12.0",
-        "@wormhole-foundation/sdk-connect": "0.12.0"
+        "@wormhole-foundation/sdk-aptos": "1.0.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0"
       },
       "engines": {
         "node": ">=16"
@@ -4377,52 +3898,28 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-0.12.0.tgz",
-      "integrity": "sha512-zJFaiZ6QIHB5Edkg5OjrikvcEAMXS8rgtyBYfkAxw5yK/J5WOJIlhYaY8kWohObly1xaQUE/EuFmKlb8tvDBXA==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
+      "integrity": "sha512-Q6od8r+tA0TNcyOW0aYVLSyzSymLZscg62fZDY0jXpqec31fFH5zhyEmwAjyaeXvJGYG5TrzbnHVFImwRj08Mg==",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "0.12.0",
-        "@wormhole-foundation/sdk-definitions": "0.12.0",
+        "@wormhole-foundation/sdk-base": "1.0.0",
+        "@wormhole-foundation/sdk-definitions": "1.0.0",
         "axios": "^1.4.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-connect/node_modules/@wormhole-foundation/sdk-base": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.12.0.tgz",
-      "integrity": "sha512-Js/+Eb7yqdMzOVehZmzTmeibRUAny/Yb+tgcfijzjABFT5NITJMFqNlWFSPDIitYU/LJoJzre8IInRqO0EoeOw==",
-      "dev": true,
-      "dependencies": {
-        "@scure/base": "^1.1.3"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-connect/node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.12.0.tgz",
-      "integrity": "sha512-lbX3XUoOLlrq4eqC5NRpjIGdo06zrod5ls5WP6/cdBylE6A+fFlaWZG7z2AU1lufZ5HABHBx9L8kNx4JP6SGRA==",
-      "dev": true,
-      "dependencies": {
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "0.12.0"
-      }
-    },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-0.12.0.tgz",
-      "integrity": "sha512-gmXgoSrGr3mLMq+FZ0QMBqmk6llzkDN7fSvDEK7IX+c4eMtHIKw8GA/82MFCNUrj2T7OGJqKAMrRP+fjifVeJw==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.0.0.tgz",
+      "integrity": "sha512-4Fxdz/zxuTq/obZ3ROv7ht+/9f/LS8wBt1n/L31cgYsNxO3B5/w4Rj82EKMiWDnQ0Y0kJKKkrlc08OmYu2F/Kw==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.12.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -4430,35 +3927,31 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-0.12.0.tgz",
-      "integrity": "sha512-pSj0gOCgdrtAOwFoErdGWZe9KXDIh8qHKNTXFNJtr87eXW2qc4rFxoRcWwn/b1yPnfg2AQ5dZKjeBysDnHje+Q==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.0.0.tgz",
+      "integrity": "sha512-bVy015m/nnagbA5r80iylFzY+pnMFJndM3ZPHfM0FkW6mlIppTVrs9o0/NrwV823nEfgdCKdR4n0O/EKUnBY8Q==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.12.0",
-        "@wormhole-foundation/sdk-cosmwasm": "0.12.0"
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.0.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-0.12.0.tgz",
-      "integrity": "sha512-d8uWfU16L89Ds1ulwt+P4qroZcFaVt8yBNkLPZUb36V63lifXAKRKvXHTr9NzulSApGVWophwTODqDJQzL/Crw==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.0.0.tgz",
+      "integrity": "sha512-pNMDDbpqNIp3UpKf6Xt85jCRFJSGZ0oNMlEa/B3pJNIsRWTNntcisooSUcXVG2DXoSDcsKioiWAg7qmNe11LIQ==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.12.0",
-        "@wormhole-foundation/sdk-cosmwasm": "0.12.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "0.12.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.0.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -4466,16 +3959,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-0.12.0.tgz",
-      "integrity": "sha512-4pD8Cy3p9WzU3DVBWsOsW5nX9GzIX/Jvt5CwtH+xFn/ekWrC0v/euWrkMu+cYuc0o89FFqRT9XUuJWYpPucQnQ==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-F2tCLtapdoMwqc8FwyuJpsrmC7ItoAG1S/JklJrABlW7914KCcVqM2I5GzXprWzzWrl8sgtpeA/B+5euIHlKAQ==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "0.12.0",
-        "@wormhole-foundation/sdk-cosmwasm": "0.12.0"
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.0.0"
       },
       "engines": {
         "node": ">=16"
@@ -4496,13 +3987,11 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-0.12.0.tgz",
-      "integrity": "sha512-HdlYPc1t+UTaNlh11Uiz+JSmXEZLJx55Bl/K6Oi6MvK7bIz4BQ0k53bUBlJUpYwHlNlklWLpRZ+3H36F5+/D/g==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.0.0.tgz",
+      "integrity": "sha512-uS6ypLuTT5oGmu3TdC+E2MzMhywTKRfIq9ASUGA9AyfZszSnStvhwz7wBi1uhX6ukyTJXFmmsk0nCuOqTTN+DA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.12.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4510,14 +3999,12 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-0.12.0.tgz",
-      "integrity": "sha512-PuldQP49QcQjADtcwEcjTeQsqiHIbJNfS+ZzLf1CvHkQcpBR2yqy2wjKa/cGWaNYlq+ZAkY7DZqzxqmVgFBeMg==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.0.0.tgz",
+      "integrity": "sha512-GKNdFpYcti5Ul6EeEbdNHLV46VWg6D65cL3A66RREeei9VbNChGIegLCtrpU0yFkTVZ7a1svkXFNlX17Gr4LaQ==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.12.0",
-        "@wormhole-foundation/sdk-evm": "0.12.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4525,14 +4012,12 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-0.12.0.tgz",
-      "integrity": "sha512-9oaSnWosdKTTOLUmtFbIqceIm0QutAQCJEO4HQcYJ+a3szi+8bGZxhghIfxO3dlKFDnxv7vVF7KMCClAeUmXbw==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.0.0.tgz",
+      "integrity": "sha512-eDjTqJfosBFmRMv6TNGEku+CLTJcjLpgTvXO2oQ27ckCDCq7rJ/dwEi+DGS2ZQCW/D0e5ires50zaRURApRWjw==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.12.0",
-        "@wormhole-foundation/sdk-evm": "0.12.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4544,16 +4029,14 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-0.12.0.tgz",
-      "integrity": "sha512-o4Jlr8MkrYRwWSmUdr0bNMQ/YPbK6HJn9rq0I75OGPtLz5nG3t4XK7QKIngzyGM/zAlR2Txlwkyg2Gs15ybryA==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.0.0.tgz",
+      "integrity": "sha512-5uqUr8BCQXWRzAB6yj4PrI8RqEFXUstTGkvUjb7DwVH+fraoZwlkELStkTuVY73mpUnLW5lQFk0+7AXV/rHxqQ==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.12.0",
-        "@wormhole-foundation/sdk-evm": "0.12.0",
-        "@wormhole-foundation/sdk-evm-core": "0.12.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "0.12.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
+        "@wormhole-foundation/sdk-evm-core": "1.0.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.0.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4561,15 +4044,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-0.12.0.tgz",
-      "integrity": "sha512-hryxL9binj8Fev5bMb5uC+Jd8GQmMVeIUmaWR6oyg+c8LepzxVLUPy1Xzvvn9g/oDKTWxgxgLA1H9rwaIcnUWw==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-2lSSG3EIRnXSFzm6fIsAgnN9oS4bszm57WIO9fvt5Za5zO8ne7BqbYmnerdDx9fhp8nbC1oeJ+sQmGHOpV6QXA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "0.12.0",
-        "@wormhole-foundation/sdk-evm": "0.12.0",
-        "@wormhole-foundation/sdk-evm-core": "0.12.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-evm": "1.0.0",
+        "@wormhole-foundation/sdk-evm-core": "1.0.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4585,17 +4066,15 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-0.12.0.tgz",
-      "integrity": "sha512-95eBRsjF4Rf/XvnFfi6JPli3KxS0dd51SVE9YhEDu8tZ8NzKHxu8agYBnNaJyG/tKksIgXznxKQaukbNQJNicQ==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.0.0.tgz",
+      "integrity": "sha512-iNSXi3vQ6JRyNOlIto7J5EHksRt9avzVptqtrSllGnvm4+X/FENOAorpN887kMvI3qE3KgFtwrUPZa8rqwGxWA==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "0.12.0",
+        "@wormhole-foundation/sdk-connect": "1.0.0",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -4603,34 +4082,30 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-0.12.0.tgz",
-      "integrity": "sha512-NQ/xqVaXUCmpmbp7mKSSnPN3UrTH+3qhbTk4L2ffm2lJ/TifFdzfwGNpArpgNU5tBoKVy/FBlgahLd9e3If55w==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.0.0.tgz",
+      "integrity": "sha512-rD83p7Gyk3MNy/WEZu2LEm5eOHkRyFZu1MQ0qnQk7N9GwnL/atXmzWPJP5gJAwHpfe5GFEz6jeBxRMWZbK5png==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "0.12.0",
-        "@wormhole-foundation/sdk-solana": "0.12.0"
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-solana": "1.0.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-0.12.0.tgz",
-      "integrity": "sha512-v/5fFW8eUJ1Ts99NlfbMGphWOWlcVmMx+jDdFmhU8EgO9os7urTJ4GrdruXh2E+BwPlQh5VfCnXAU/hvawC/2Q==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.0.0.tgz",
+      "integrity": "sha512-fjETlCMqdkLfs3UNRYfrwHiDh2Nv/7L5wEXZpPiMFy6flSEwU0+QBTpeqdtMnqOJO+Fw6vSzQ+k4XS3CmmNdnA==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "0.12.0",
-        "@wormhole-foundation/sdk-solana": "0.12.0"
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-solana": "1.0.0"
       },
       "engines": {
         "node": ">=16"
@@ -4641,86 +4116,58 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-0.12.0.tgz",
-      "integrity": "sha512-PCN014InH5Iqlm1E6jfYyglan2AGbUUQ9elsAwbFWCBQhQQXDctnAn0yv8QaKMrWQhoN/E21dMWi2+Xs6dvEmw==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-WgmcSknJafEFSYco/SXq7NI8NUfIMJFv5QDDNTwMp0cK85c4vQdLN0R3jlM5bllvK6wmoWIlyaCG0hsk1KedYg==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "0.12.0",
-        "@wormhole-foundation/sdk-solana": "0.12.0",
-        "@wormhole-foundation/sdk-solana-core": "0.12.0"
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-solana": "1.0.0",
+        "@wormhole-foundation/sdk-solana-core": "1.0.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-0.12.0.tgz",
-      "integrity": "sha512-uIo+ftb8h1iPjNhby62NsmQbiprTH5Q+m/n0n2TFV1InCnHIAD1S97SFuaL+kOYS0R+JIVCVuKoxhCab75OYeQ==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.0.0.tgz",
+      "integrity": "sha512-PHzR/mNwd0DwDrW2Mho3JQQIAGTBkixbFnlbjZgs2U29+hHzoNjPD6Upx2xWNGC/KcS477yd6mqnj8YARfNG0A==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.12.0"
+        "@wormhole-foundation/sdk-connect": "1.0.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-0.12.0.tgz",
-      "integrity": "sha512-1ycCDzdK2kOUt5ZgTM5tu7CBC0MTtVfFErFfj/1tCq8HO+gy9Uc3MnY0AhChEcpr5WhQ/rFEuRA1gOxk2rEmsg==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.0.0.tgz",
+      "integrity": "sha512-PVvt7ibiAFrw3mIYnB7ETzUqaE3KYxonG2jPk7nU1xxTeCbtltopKQOWawA+Q0GgbOLtfoSIoJodYE8nGJXVMg==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.12.0",
-        "@wormhole-foundation/sdk-sui": "0.12.0"
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-sui": "1.0.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-0.12.0.tgz",
-      "integrity": "sha512-u2E4LZU7WPchdp7m7ij0MlQCKfH69mt2/AUR8TnfajYnsJe874TLhvrW0XK5B93WH+VVHDZD7uu4O/BcgyJdRg==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.0.0.tgz",
+      "integrity": "sha512-vv9Aew0qYLqVFYmN4gRVidncl1c4Sa4YUh9wn98GKEB/14BSIBHkWSqw3Y4cjli/K2kL1ZLfdp0UMViVgruSzA==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "0.12.0",
-        "@wormhole-foundation/sdk-sui": "0.12.0",
-        "@wormhole-foundation/sdk-sui-core": "0.12.0"
+        "@wormhole-foundation/sdk-connect": "1.0.0",
+        "@wormhole-foundation/sdk-sui": "1.0.0",
+        "@wormhole-foundation/sdk-sui-core": "1.0.0"
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk/node_modules/@wormhole-foundation/sdk-base": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.12.0.tgz",
-      "integrity": "sha512-Js/+Eb7yqdMzOVehZmzTmeibRUAny/Yb+tgcfijzjABFT5NITJMFqNlWFSPDIitYU/LJoJzre8IInRqO0EoeOw==",
-      "dev": true,
-      "dependencies": {
-        "@scure/base": "^1.1.3"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk/node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.12.0.tgz",
-      "integrity": "sha512-lbX3XUoOLlrq4eqC5NRpjIGdo06zrod5ls5WP6/cdBylE6A+fFlaWZG7z2AU1lufZ5HABHBx9L8kNx4JP6SGRA==",
-      "dev": true,
-      "dependencies": {
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "0.12.0"
       }
     },
     "node_modules/@wormhole-foundation/wormchain-sdk": {
@@ -6246,7 +5693,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
       "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -6258,7 +5704,6 @@
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
       "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -6270,7 +5715,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
       "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -6282,7 +5726,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
       "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -6385,7 +5828,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-2.7.0.tgz",
       "integrity": "sha512-sBE9lpV7bup3rZ+q2j3JQaFAE9JwZvjWKX00vPlG8e9txctXbgLL56jZhSWZndqhDI9oI+0P4NldkuQIWdrUyg==",
-      "license": "MIT",
       "dependencies": {
         "algo-msgpack-with-bigint": "^2.1.1",
         "buffer": "^6.0.3",
@@ -6458,7 +5900,6 @@
       "resolved": "https://registry.npmjs.org/aptos/-/aptos-1.21.0.tgz",
       "integrity": "sha512-PRKjoFgL8tVEc9+oS7eJUv8GNxx8n3+0byH2+m7CP3raYOD6yFKOecuwjVMIJmgfpjp6xH0P0HDMGZAXmSyU0Q==",
       "deprecated": "Package aptos is no longer supported, please migrate to https://www.npmjs.com/package/@aptos-labs/ts-sdk",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/aptos-client": "^0.1.0",
         "@noble/hashes": "1.3.3",
@@ -6475,7 +5916,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
       "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
-      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -6487,7 +5927,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
       "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
-      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "~1.3.0",
         "@scure/base": "~1.1.0"
@@ -6499,8 +5938,7 @@
     "node_modules/aptos/node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -6755,8 +6193,7 @@
     "node_modules/blakejs": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
-      "license": "MIT"
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
@@ -6815,7 +6252,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-      "license": "MIT",
       "dependencies": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -6939,8 +6375,7 @@
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-      "license": "MIT"
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
     },
     "node_modules/bufferutil": {
       "version": "4.0.8",
@@ -6996,7 +6431,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "license": "MIT",
       "engines": {
         "node": ">=10.6.0"
       }
@@ -7005,7 +6439,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-      "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -7134,7 +6567,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
       },
@@ -7326,8 +6758,7 @@
     "node_modules/cosmjs-types": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
-      "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ=="
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
@@ -7529,7 +6960,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -7544,7 +6974,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -7590,7 +7019,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -7764,7 +7192,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -7925,7 +7352,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
       "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "license": "MIT",
       "dependencies": {
         "@types/pbkdf2": "^3.0.0",
         "@types/secp256k1": "^4.0.1",
@@ -7948,7 +7374,7 @@
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
       "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
-      "license": "MIT",
+      "deprecated": "This library has been deprecated and usage is discouraged.",
       "dependencies": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"
@@ -7958,7 +7384,6 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -7966,14 +7391,12 @@
     "node_modules/ethereumjs-abi/node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-      "license": "MIT"
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
       "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -7988,7 +7411,6 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
       "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
-      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
@@ -8083,7 +7505,6 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
       "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-      "license": "MIT",
       "dependencies": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
@@ -8102,7 +7523,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "license": "MIT",
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -8381,7 +7801,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -8467,7 +7886,6 @@
       "version": "11.8.6",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-      "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -8492,7 +7910,6 @@
       "version": "1.8.10",
       "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.10.tgz",
       "integrity": "sha512-FrvSxgz838FYVPgZHGOSgbpOjhR+yq44rCzww3oOPJYi0OvBJjAgCiP6LEokZIYND2fUTXzQAyLgcvgw1yNP5A==",
-      "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5",
         "@0no-co/graphqlsp": "^1.12.13",
@@ -8517,7 +7934,6 @@
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
       "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
-      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -8526,7 +7942,6 @@
       "version": "2.12.6",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
       "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -8631,7 +8046,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -8659,8 +8073,7 @@
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-      "license": "BSD-2-Clause"
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
@@ -8680,14 +8093,12 @@
     "node_modules/http-status-codes": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
-      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
-      "license": "MIT"
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA=="
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-      "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -8808,7 +8219,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -8853,7 +8263,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
       "integrity": "sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==",
-      "license": "MIT",
       "engines": {
         "node": ">=6.5.0",
         "npm": ">=3"
@@ -10691,8 +10100,7 @@
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "license": "MIT"
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -10778,7 +10186,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -10812,8 +10219,7 @@
     "node_modules/libsodium-sumo": {
       "version": "0.7.15",
       "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.15.tgz",
-      "integrity": "sha512-5tPmqPmq8T8Nikpm1Nqj0hBHvsLFCXvdhBFV7SGOitQPZAA6jso8XoL0r4L7vmfKXr486fiQInvErHtEvizFMw==",
-      "license": "ISC"
+      "integrity": "sha512-5tPmqPmq8T8Nikpm1Nqj0hBHvsLFCXvdhBFV7SGOitQPZAA6jso8XoL0r4L7vmfKXr486fiQInvErHtEvizFMw=="
     },
     "node_modules/libsodium-wrappers": {
       "version": "0.7.13",
@@ -10828,7 +10234,6 @@
       "version": "0.7.15",
       "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.15.tgz",
       "integrity": "sha512-aSWY8wKDZh5TC7rMvEdTHoyppVq/1dTSAeAR7H6pzd6QRT3vQWcT5pGwCotLcpPEOLXX6VvqihSPkpEhYAjANA==",
-      "license": "ISC",
       "dependencies": {
         "libsodium-sumo": "^0.7.15"
       }
@@ -10839,92 +10244,6 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/link-module-alias": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/link-module-alias/-/link-module-alias-1.2.0.tgz",
-      "integrity": "sha512-ahPjXepbSVKbahTB6LxR//VHm8HPfI+QQygCH+E82spBY4HR5VPJTvlhKBc9F7muVxnS6C1rRfoPOXAbWO/fyw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.1"
-      },
-      "bin": {
-        "link-module-alias": "index.js"
-      },
-      "engines": {
-        "node": "> 8.0.0"
-      }
-    },
-    "node_modules/link-module-alias/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/link-module-alias/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/link-module-alias/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/link-module-alias/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/link-module-alias/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/link-module-alias/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/link-module-alias/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -10966,7 +10285,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -10986,7 +10304,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -11073,7 +10390,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -11144,7 +10460,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -11293,7 +10608,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -11325,7 +10639,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11366,7 +10679,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.0.tgz",
       "integrity": "sha512-tGn8+REwLRNFnb9WmcY5IfpOqeX2kpaYJ1s6Ae3mn12AeydLkR3j+jSCmVQFoXqU8D41PAJ1RG1rCRNWmNZVmQ==",
-      "license": "MIT",
       "dependencies": {
         "@wry/caches": "^1.0.0",
         "@wry/context": "^0.7.0",
@@ -11378,7 +10690,6 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
       "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -11390,7 +10701,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -11518,7 +10828,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
       "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
-      "license": "MIT",
       "dependencies": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -11636,7 +10945,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -11694,7 +11002,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
       "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
-      "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -11738,7 +11045,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -11750,7 +11056,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -11758,8 +11063,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -11808,7 +11112,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
       "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
-      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "*"
@@ -11856,8 +11159,7 @@
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "license": "MIT"
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -11905,7 +11207,6 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
       "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -11914,7 +11215,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-      "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
       },
@@ -11951,7 +11251,6 @@
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
       "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
-      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^5.2.0"
       },
@@ -12078,8 +11377,7 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "license": "MIT"
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
@@ -12120,7 +11418,6 @@
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
       "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -12137,7 +11434,6 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
       "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
-      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.3",
         "shelljs": "^0.8.5"
@@ -12185,7 +11481,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.5.0.tgz",
       "integrity": "sha512-r3kRtnoPu3FxGJ3fny6PKNnU3pteb29o6qAa0ugzhSseKNWRkw1dw8nIjXMyyKaU9vQxxVIE62Mb3bKbdrgpiw==",
-      "license": "MIT",
       "dependencies": {
         "map-obj": "^4.1.0",
         "snake-case": "^3.0.4",
@@ -12199,7 +11494,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
       "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=14.16"
       },
@@ -12249,8 +11543,7 @@
     "node_modules/store2": {
       "version": "2.14.3",
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.3.tgz",
-      "integrity": "sha512-4QcZ+yx7nzEFiV4BMLnr/pRa5HYzNITX2ri0Zh6sT9EyQHbBHacC6YigllUPU9X3D0f/22QCgfokpKs52YRrUg==",
-      "license": "MIT"
+      "integrity": "sha512-4QcZ+yx7nzEFiV4BMLnr/pRa5HYzNITX2ri0Zh6sT9EyQHbBHacC6YigllUPU9X3D0f/22QCgfokpKs52YRrUg=="
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -12328,7 +11621,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
       "integrity": "sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==",
-      "license": "MIT",
       "dependencies": {
         "is-hex-prefixed": "1.0.0"
       },
@@ -12399,7 +11691,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
       "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
@@ -12608,7 +11899,6 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
       "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -12923,8 +12213,7 @@
     "node_modules/tweetnacl-util": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
-      "license": "Unlicense"
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -13414,14 +12703,12 @@
     "node_modules/zen-observable": {
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-      "license": "MIT"
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "node_modules/zen-observable-ts": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
       "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
-      "license": "MIT",
       "dependencies": {
         "zen-observable": "0.8.15"
       }
@@ -13477,357 +12764,6 @@
         "node": ">=16"
       }
     },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.0.0.tgz",
-      "integrity": "sha512-QIkRaFe6+3DsOydShqzpTg4h6fiNI0i9N59hgCg33UiSbG87LI0g5bZZgiC1q4cpjBBcgj8w6uo2dAVrBr069Q==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.0.0",
-        "@wormhole-foundation/sdk-algorand-core": "1.0.0",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "1.0.0",
-        "@wormhole-foundation/sdk-aptos": "1.0.0",
-        "@wormhole-foundation/sdk-aptos-core": "1.0.0",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "1.0.0",
-        "@wormhole-foundation/sdk-base": "1.0.0",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "1.0.0",
-        "@wormhole-foundation/sdk-definitions": "1.0.0",
-        "@wormhole-foundation/sdk-evm": "1.0.0",
-        "@wormhole-foundation/sdk-evm-cctp": "1.0.0",
-        "@wormhole-foundation/sdk-evm-core": "1.0.0",
-        "@wormhole-foundation/sdk-evm-portico": "1.0.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "1.0.0",
-        "@wormhole-foundation/sdk-solana": "1.0.0",
-        "@wormhole-foundation/sdk-solana-cctp": "1.0.0",
-        "@wormhole-foundation/sdk-solana-core": "1.0.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "1.0.0",
-        "@wormhole-foundation/sdk-sui": "1.0.0",
-        "@wormhole-foundation/sdk-sui-core": "1.0.0",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.0.0.tgz",
-      "integrity": "sha512-XoRuyAOcLU1eJ26bGdeN2mzP6thvaoshHrt25d/KnHKYLpjgvAhCyWgAka6qzig0CGrG8z4y0K7SkeThmtwakg==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "algosdk": "2.7.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.0.0.tgz",
-      "integrity": "sha512-brGzOliC/Zn4uAYxYAKXtJWStQy3FtAmVPLhQkglusIhmk69PNFLBFJ9p8o9sUR/IDgLnVz3/OEOdHANletqsA==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.0.0",
-        "@wormhole-foundation/sdk-connect": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.0.0.tgz",
-      "integrity": "sha512-8CFFdqi78SuKDmCF9gTmkCFYSoPoDaqBsQdvKpUPvBQmDDJDl1NJ6JZrtKbK87FMrSKvDciXk4Dfb3ecezclPQ==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.0.0",
-        "@wormhole-foundation/sdk-algorand-core": "1.0.0",
-        "@wormhole-foundation/sdk-connect": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.0.0.tgz",
-      "integrity": "sha512-7SPLjjLsVVKuvNBRt1b87IEo0DMOvjxjIiUeM9sTDXdI7As3mLXaA4IliOQXi9+jLHpbq4q5Sk6XSxFgjsGgPQ==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "aptos": "1.21.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.0.0.tgz",
-      "integrity": "sha512-u6ZkvJxTq+xr2RCJejZ8Z8/AErnmTtREZfcYStbXprqsGb+MALrYUwF+sMERVZRrY9ltNs2q2/DAxNyRSH0cjw==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "1.0.0",
-        "@wormhole-foundation/sdk-connect": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.0.0.tgz",
-      "integrity": "sha512-LxGkjdQItl2IFGupNGwJiJuN/HYdIP/emmWikMSlcZh4oBAaQrYkU+Pbrp/+gjmLcFp/jTK7G/Mg7Y7DWMx5XQ==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "1.0.0",
-        "@wormhole-foundation/sdk-connect": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
-      "integrity": "sha512-Q6od8r+tA0TNcyOW0aYVLSyzSymLZscg62fZDY0jXpqec31fFH5zhyEmwAjyaeXvJGYG5TrzbnHVFImwRj08Mg==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.0.0",
-        "@wormhole-foundation/sdk-definitions": "1.0.0",
-        "axios": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.0.0.tgz",
-      "integrity": "sha512-4Fxdz/zxuTq/obZ3ROv7ht+/9f/LS8wBt1n/L31cgYsNxO3B5/w4Rj82EKMiWDnQ0Y0kJKKkrlc08OmYu2F/Kw==",
-      "dependencies": {
-        "@cosmjs/cosmwasm-stargate": "^0.32.0",
-        "@cosmjs/proto-signing": "^0.32.0",
-        "@cosmjs/stargate": "^0.32.0",
-        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "cosmjs-types": "^0.9.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.0.0.tgz",
-      "integrity": "sha512-bVy015m/nnagbA5r80iylFzY+pnMFJndM3ZPHfM0FkW6mlIppTVrs9o0/NrwV823nEfgdCKdR4n0O/EKUnBY8Q==",
-      "dependencies": {
-        "@cosmjs/cosmwasm-stargate": "^0.32.0",
-        "@cosmjs/stargate": "^0.32.0",
-        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.0.0.tgz",
-      "integrity": "sha512-pNMDDbpqNIp3UpKf6Xt85jCRFJSGZ0oNMlEa/B3pJNIsRWTNntcisooSUcXVG2DXoSDcsKioiWAg7qmNe11LIQ==",
-      "dependencies": {
-        "@cosmjs/cosmwasm-stargate": "^0.32.0",
-        "@cosmjs/stargate": "^0.32.0",
-        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "1.0.0",
-        "cosmjs-types": "^0.9.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.0.0.tgz",
-      "integrity": "sha512-F2tCLtapdoMwqc8FwyuJpsrmC7ItoAG1S/JklJrABlW7914KCcVqM2I5GzXprWzzWrl8sgtpeA/B+5euIHlKAQ==",
-      "dependencies": {
-        "@cosmjs/cosmwasm-stargate": "^0.32.0",
-        "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-cosmwasm": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.0.0.tgz",
-      "integrity": "sha512-uS6ypLuTT5oGmu3TdC+E2MzMhywTKRfIq9ASUGA9AyfZszSnStvhwz7wBi1uhX6ukyTJXFmmsk0nCuOqTTN+DA==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "ethers": "^6.5.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.0.0.tgz",
-      "integrity": "sha512-GKNdFpYcti5Ul6EeEbdNHLV46VWg6D65cL3A66RREeei9VbNChGIegLCtrpU0yFkTVZ7a1svkXFNlX17Gr4LaQ==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-evm": "1.0.0",
-        "ethers": "^6.5.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.0.0.tgz",
-      "integrity": "sha512-eDjTqJfosBFmRMv6TNGEku+CLTJcjLpgTvXO2oQ27ckCDCq7rJ/dwEi+DGS2ZQCW/D0e5ires50zaRURApRWjw==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-evm": "1.0.0",
-        "ethers": "^6.5.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.0.0.tgz",
-      "integrity": "sha512-5uqUr8BCQXWRzAB6yj4PrI8RqEFXUstTGkvUjb7DwVH+fraoZwlkELStkTuVY73mpUnLW5lQFk0+7AXV/rHxqQ==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-evm": "1.0.0",
-        "@wormhole-foundation/sdk-evm-core": "1.0.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "1.0.0",
-        "ethers": "^6.5.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.0.0.tgz",
-      "integrity": "sha512-2lSSG3EIRnXSFzm6fIsAgnN9oS4bszm57WIO9fvt5Za5zO8ne7BqbYmnerdDx9fhp8nbC1oeJ+sQmGHOpV6QXA==",
-      "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-evm": "1.0.0",
-        "@wormhole-foundation/sdk-evm-core": "1.0.0",
-        "ethers": "^6.5.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.0.0.tgz",
-      "integrity": "sha512-iNSXi3vQ6JRyNOlIto7J5EHksRt9avzVptqtrSllGnvm4+X/FENOAorpN887kMvI3qE3KgFtwrUPZa8rqwGxWA==",
-      "dependencies": {
-        "@coral-xyz/anchor": "0.29.0",
-        "@coral-xyz/borsh": "0.29.0",
-        "@solana/spl-token": "0.3.9",
-        "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "rpc-websockets": "^7.10.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.0.0.tgz",
-      "integrity": "sha512-rD83p7Gyk3MNy/WEZu2LEm5eOHkRyFZu1MQ0qnQk7N9GwnL/atXmzWPJP5gJAwHpfe5GFEz6jeBxRMWZbK5png==",
-      "dependencies": {
-        "@coral-xyz/anchor": "0.29.0",
-        "@solana/spl-token": "0.3.9",
-        "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-solana": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.0.0.tgz",
-      "integrity": "sha512-fjETlCMqdkLfs3UNRYfrwHiDh2Nv/7L5wEXZpPiMFy6flSEwU0+QBTpeqdtMnqOJO+Fw6vSzQ+k4XS3CmmNdnA==",
-      "dependencies": {
-        "@coral-xyz/anchor": "0.29.0",
-        "@coral-xyz/borsh": "0.29.0",
-        "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-solana": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.0.0.tgz",
-      "integrity": "sha512-WgmcSknJafEFSYco/SXq7NI8NUfIMJFv5QDDNTwMp0cK85c4vQdLN0R3jlM5bllvK6wmoWIlyaCG0hsk1KedYg==",
-      "dependencies": {
-        "@coral-xyz/anchor": "0.29.0",
-        "@solana/spl-token": "0.3.9",
-        "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-solana": "1.0.0",
-        "@wormhole-foundation/sdk-solana-core": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.0.0.tgz",
-      "integrity": "sha512-PHzR/mNwd0DwDrW2Mho3JQQIAGTBkixbFnlbjZgs2U29+hHzoNjPD6Upx2xWNGC/KcS477yd6mqnj8YARfNG0A==",
-      "dependencies": {
-        "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.0.0.tgz",
-      "integrity": "sha512-PVvt7ibiAFrw3mIYnB7ETzUqaE3KYxonG2jPk7nU1xxTeCbtltopKQOWawA+Q0GgbOLtfoSIoJodYE8nGJXVMg==",
-      "dependencies": {
-        "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-sui": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.0.0.tgz",
-      "integrity": "sha512-vv9Aew0qYLqVFYmN4gRVidncl1c4Sa4YUh9wn98GKEB/14BSIBHkWSqw3Y4cjli/K2kL1ZLfdp0UMViVgruSzA==",
-      "dependencies": {
-        "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-sui": "1.0.0",
-        "@wormhole-foundation/sdk-sui-core": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "sdk/examples/node_modules/dotenv": {
       "version": "16.4.5",
       "dev": true,
@@ -13858,20 +12794,6 @@
       },
       "peerDependencies": {
         "@wormhole-foundation/sdk-connect": "^1.0.0"
-      }
-    },
-    "sdk/route/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
-      "integrity": "sha512-Q6od8r+tA0TNcyOW0aYVLSyzSymLZscg62fZDY0jXpqec31fFH5zhyEmwAjyaeXvJGYG5TrzbnHVFImwRj08Mg==",
-      "peer": true,
-      "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.0.0",
-        "@wormhole-foundation/sdk-definitions": "1.0.0",
-        "axios": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "solana": {
@@ -13983,70 +12905,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "solana/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
-      "integrity": "sha512-Q6od8r+tA0TNcyOW0aYVLSyzSymLZscg62fZDY0jXpqec31fFH5zhyEmwAjyaeXvJGYG5TrzbnHVFImwRj08Mg==",
-      "peer": true,
-      "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.0.0",
-        "@wormhole-foundation/sdk-definitions": "1.0.0",
-        "axios": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "solana/node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.0.0.tgz",
-      "integrity": "sha512-iNSXi3vQ6JRyNOlIto7J5EHksRt9avzVptqtrSllGnvm4+X/FENOAorpN887kMvI3qE3KgFtwrUPZa8rqwGxWA==",
-      "peer": true,
-      "dependencies": {
-        "@coral-xyz/anchor": "0.29.0",
-        "@coral-xyz/borsh": "0.29.0",
-        "@solana/spl-token": "0.3.9",
-        "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "rpc-websockets": "^7.10.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "solana/node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.0.0.tgz",
-      "integrity": "sha512-fjETlCMqdkLfs3UNRYfrwHiDh2Nv/7L5wEXZpPiMFy6flSEwU0+QBTpeqdtMnqOJO+Fw6vSzQ+k4XS3CmmNdnA==",
-      "peer": true,
-      "dependencies": {
-        "@coral-xyz/anchor": "0.29.0",
-        "@coral-xyz/borsh": "0.29.0",
-        "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "1.0.0",
-        "@wormhole-foundation/sdk-solana": "1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "solana/node_modules/@wormhole-foundation/sdk-solana/node_modules/@solana/spl-token": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.9.tgz",
-      "integrity": "sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==",
-      "peer": true,
-      "dependencies": {
-        "@solana/buffer-layout": "^4.0.0",
-        "@solana/buffer-layout-utils": "^0.2.0",
-        "buffer": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@solana/web3.js": "^1.47.4"
       }
     },
     "solana/node_modules/fastestsmallesttextencoderdecoder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ntt",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ntt",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "workspaces": [
         "sdk/definitions",
@@ -31,7 +31,7 @@
     },
     "cli": {
       "name": "@wormhole-foundation/ntt-cli",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@wormhole-foundation/sdk": "^1.0.0",
         "chalk": "^5.3.0",
@@ -441,7 +441,7 @@
     },
     "evm/ts": {
       "name": "@wormhole-foundation/sdk-evm-ntt",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ethers": "^6.5.1"
@@ -457,7 +457,7 @@
       "peerDependencies": {
         "@wormhole-foundation/sdk-base": "^1.0.0",
         "@wormhole-foundation/sdk-definitions": "^1.0.0",
-        "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
+        "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
         "@wormhole-foundation/sdk-evm": "^1.0.0",
         "@wormhole-foundation/sdk-evm-core": "^1.0.0"
       }
@@ -13428,7 +13428,7 @@
     },
     "sdk/definitions": {
       "name": "@wormhole-foundation/sdk-definitions-ntt",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "peerDependencies": {
         "@wormhole-foundation/sdk-base": "^1.0.0",
         "@wormhole-foundation/sdk-definitions": "^1.0.0"
@@ -13457,14 +13457,14 @@
     },
     "sdk/examples": {
       "name": "@wormhole-foundation/sdk-examples-ntt",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk": "^1.0.0",
-        "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-        "@wormhole-foundation/sdk-evm-ntt": "0.4.0",
-        "@wormhole-foundation/sdk-route-ntt": "0.4.0",
-        "@wormhole-foundation/sdk-solana-ntt": "0.4.0"
+        "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
+        "@wormhole-foundation/sdk-evm-ntt": "0.5.0",
+        "@wormhole-foundation/sdk-route-ntt": "0.5.0",
+        "@wormhole-foundation/sdk-solana-ntt": "0.5.0"
       },
       "devDependencies": {
         "dotenv": "^16.4.5",
@@ -13841,12 +13841,12 @@
     },
     "sdk/route": {
       "name": "@wormhole-foundation/sdk-route-ntt",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-        "@wormhole-foundation/sdk-evm-ntt": "0.4.0",
-        "@wormhole-foundation/sdk-solana-ntt": "0.4.0"
+        "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
+        "@wormhole-foundation/sdk-evm-ntt": "0.5.0",
+        "@wormhole-foundation/sdk-solana-ntt": "0.5.0"
       },
       "devDependencies": {
         "nock": "^13.3.3",
@@ -13876,14 +13876,14 @@
     },
     "solana": {
       "name": "@wormhole-foundation/sdk-solana-ntt",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.4.0",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
+        "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
         "bn.js": "5.2.1"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,11 +96,6 @@
       },
       "devDependencies": {
         "@typechain/ethers-v6": "^0.5.1",
-        "@wormhole-foundation/sdk-base": "^1.0.0",
-        "@wormhole-foundation/sdk-definitions": "^1.0.0",
-        "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-        "@wormhole-foundation/sdk-evm": "^1.0.0",
-        "@wormhole-foundation/sdk-evm-core": "^1.0.0",
         "tsx": "^4.7.2",
         "typechain": "^8.3.2"
       },
@@ -119,7 +114,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.0.tgz",
       "integrity": "sha512-PbfvGG/G6qDo3QtW+9R74iAFGeXziOfSumSSRJvH5gAmQmZWUmQ0C8WaBJIzYDoV+67IYenXHYfupVWsblTP3g==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@scure/base": "^1.1.3"
       }
@@ -128,7 +123,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
       "integrity": "sha512-Q6od8r+tA0TNcyOW0aYVLSyzSymLZscg62fZDY0jXpqec31fFH5zhyEmwAjyaeXvJGYG5TrzbnHVFImwRj08Mg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@wormhole-foundation/sdk-base": "1.0.0",
         "@wormhole-foundation/sdk-definitions": "1.0.0",
@@ -142,7 +137,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.0.0.tgz",
       "integrity": "sha512-lKME4k4lXMCYy6FotibtBVq5F4V5GuDtOyprGuTER47SdY5ZICK7xK8RKjcXlf+2T81sNQ6PkF7VIDteKiRfoA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
@@ -153,7 +148,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.0.0.tgz",
       "integrity": "sha512-uS6ypLuTT5oGmu3TdC+E2MzMhywTKRfIq9ASUGA9AyfZszSnStvhwz7wBi1uhX6ukyTJXFmmsk0nCuOqTTN+DA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.0.0",
         "ethers": "^6.5.1"
@@ -166,7 +161,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.0.0.tgz",
       "integrity": "sha512-eDjTqJfosBFmRMv6TNGEku+CLTJcjLpgTvXO2oQ27ckCDCq7rJ/dwEi+DGS2ZQCW/D0e5ires50zaRURApRWjw==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.0.0",
         "@wormhole-foundation/sdk-evm": "1.0.0",
@@ -13107,10 +13102,6 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@wormhole-foundation/sdk-connect": "^1.0.0",
-        "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-        "@wormhole-foundation/sdk-evm-ntt": "0.4.0",
-        "@wormhole-foundation/sdk-solana-ntt": "0.4.0",
         "nock": "^13.3.3",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2"
@@ -13129,7 +13120,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.0.tgz",
       "integrity": "sha512-PbfvGG/G6qDo3QtW+9R74iAFGeXziOfSumSSRJvH5gAmQmZWUmQ0C8WaBJIzYDoV+67IYenXHYfupVWsblTP3g==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@scure/base": "^1.1.3"
       }
@@ -13138,7 +13129,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
       "integrity": "sha512-Q6od8r+tA0TNcyOW0aYVLSyzSymLZscg62fZDY0jXpqec31fFH5zhyEmwAjyaeXvJGYG5TrzbnHVFImwRj08Mg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@wormhole-foundation/sdk-base": "1.0.0",
         "@wormhole-foundation/sdk-definitions": "1.0.0",
@@ -13152,7 +13143,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.0.0.tgz",
       "integrity": "sha512-lKME4k4lXMCYy6FotibtBVq5F4V5GuDtOyprGuTER47SdY5ZICK7xK8RKjcXlf+2T81sNQ6PkF7VIDteKiRfoA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
@@ -13172,11 +13163,6 @@
       },
       "devDependencies": {
         "@types/bn.js": "^5.1.5",
-        "@wormhole-foundation/sdk-base": "^1.0.0",
-        "@wormhole-foundation/sdk-definitions": "^1.0.0",
-        "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-        "@wormhole-foundation/sdk-solana": "^1.0.0",
-        "@wormhole-foundation/sdk-solana-core": "^1.0.0",
         "nock": "^13.3.3",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
@@ -13279,7 +13265,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.0.tgz",
       "integrity": "sha512-PbfvGG/G6qDo3QtW+9R74iAFGeXziOfSumSSRJvH5gAmQmZWUmQ0C8WaBJIzYDoV+67IYenXHYfupVWsblTP3g==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@scure/base": "^1.1.3"
       }
@@ -13288,7 +13274,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
       "integrity": "sha512-Q6od8r+tA0TNcyOW0aYVLSyzSymLZscg62fZDY0jXpqec31fFH5zhyEmwAjyaeXvJGYG5TrzbnHVFImwRj08Mg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@wormhole-foundation/sdk-base": "1.0.0",
         "@wormhole-foundation/sdk-definitions": "1.0.0",
@@ -13302,7 +13288,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.0.0.tgz",
       "integrity": "sha512-lKME4k4lXMCYy6FotibtBVq5F4V5GuDtOyprGuTER47SdY5ZICK7xK8RKjcXlf+2T81sNQ6PkF7VIDteKiRfoA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
@@ -13313,7 +13299,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.0.0.tgz",
       "integrity": "sha512-iNSXi3vQ6JRyNOlIto7J5EHksRt9avzVptqtrSllGnvm4+X/FENOAorpN887kMvI3qE3KgFtwrUPZa8rqwGxWA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
@@ -13330,7 +13316,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.0.0.tgz",
       "integrity": "sha512-fjETlCMqdkLfs3UNRYfrwHiDh2Nv/7L5wEXZpPiMFy6flSEwU0+QBTpeqdtMnqOJO+Fw6vSzQ+k4XS3CmmNdnA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
@@ -13346,7 +13332,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.9.tgz",
       "integrity": "sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,9 @@
       "version": "0.5.0",
       "dependencies": {
         "@wormhole-foundation/sdk": "^1.0.0",
+        "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
+        "@wormhole-foundation/sdk-evm-ntt": "0.5.0",
+        "@wormhole-foundation/sdk-solana-ntt": "0.5.0",
         "chalk": "^5.3.0",
         "yargs": "^17.7.2"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,15 +110,6 @@
         "@wormhole-foundation/sdk-evm-core": "^1.0.0"
       }
     },
-    "evm/ts/node_modules/@wormhole-foundation/sdk-base": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.0.tgz",
-      "integrity": "sha512-PbfvGG/G6qDo3QtW+9R74iAFGeXziOfSumSSRJvH5gAmQmZWUmQ0C8WaBJIzYDoV+67IYenXHYfupVWsblTP3g==",
-      "peer": true,
-      "dependencies": {
-        "@scure/base": "^1.1.3"
-      }
-    },
     "evm/ts/node_modules/@wormhole-foundation/sdk-connect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
@@ -131,17 +122,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "evm/ts/node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.0.0.tgz",
-      "integrity": "sha512-lKME4k4lXMCYy6FotibtBVq5F4V5GuDtOyprGuTER47SdY5ZICK7xK8RKjcXlf+2T81sNQ6PkF7VIDteKiRfoA==",
-      "peer": true,
-      "dependencies": {
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "1.0.0"
       }
     },
     "evm/ts/node_modules/@wormhole-foundation/sdk-evm": {
@@ -4037,10 +4017,9 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.12.0.tgz",
-      "integrity": "sha512-Js/+Eb7yqdMzOVehZmzTmeibRUAny/Yb+tgcfijzjABFT5NITJMFqNlWFSPDIitYU/LJoJzre8IInRqO0EoeOw==",
-      "license": "Apache-2.0",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.0.tgz",
+      "integrity": "sha512-PbfvGG/G6qDo3QtW+9R74iAFGeXziOfSumSSRJvH5gAmQmZWUmQ0C8WaBJIzYDoV+67IYenXHYfupVWsblTP3g==",
       "dependencies": {
         "@scure/base": "^1.1.3"
       }
@@ -4058,6 +4037,26 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-connect/node_modules/@wormhole-foundation/sdk-base": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.12.0.tgz",
+      "integrity": "sha512-Js/+Eb7yqdMzOVehZmzTmeibRUAny/Yb+tgcfijzjABFT5NITJMFqNlWFSPDIitYU/LJoJzre8IInRqO0EoeOw==",
+      "dev": true,
+      "dependencies": {
+        "@scure/base": "^1.1.3"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-connect/node_modules/@wormhole-foundation/sdk-definitions": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.12.0.tgz",
+      "integrity": "sha512-lbX3XUoOLlrq4eqC5NRpjIGdo06zrod5ls5WP6/cdBylE6A+fFlaWZG7z2AU1lufZ5HABHBx9L8kNx4JP6SGRA==",
+      "dev": true,
+      "dependencies": {
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.3.1",
+        "@wormhole-foundation/sdk-base": "0.12.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
@@ -4131,13 +4130,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.12.0.tgz",
-      "integrity": "sha512-lbX3XUoOLlrq4eqC5NRpjIGdo06zrod5ls5WP6/cdBylE6A+fFlaWZG7z2AU1lufZ5HABHBx9L8kNx4JP6SGRA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.0.0.tgz",
+      "integrity": "sha512-lKME4k4lXMCYy6FotibtBVq5F4V5GuDtOyprGuTER47SdY5ZICK7xK8RKjcXlf+2T81sNQ6PkF7VIDteKiRfoA==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "0.12.0"
+        "@wormhole-foundation/sdk-base": "1.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions-ntt": {
@@ -4350,6 +4349,26 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk/node_modules/@wormhole-foundation/sdk-base": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.12.0.tgz",
+      "integrity": "sha512-Js/+Eb7yqdMzOVehZmzTmeibRUAny/Yb+tgcfijzjABFT5NITJMFqNlWFSPDIitYU/LJoJzre8IInRqO0EoeOw==",
+      "dev": true,
+      "dependencies": {
+        "@scure/base": "^1.1.3"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk/node_modules/@wormhole-foundation/sdk-definitions": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.12.0.tgz",
+      "integrity": "sha512-lbX3XUoOLlrq4eqC5NRpjIGdo06zrod5ls5WP6/cdBylE6A+fFlaWZG7z2AU1lufZ5HABHBx9L8kNx4JP6SGRA==",
+      "dev": true,
+      "dependencies": {
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.3.1",
+        "@wormhole-foundation/sdk-base": "0.12.0"
       }
     },
     "node_modules/@wormhole-foundation/wormchain-sdk": {
@@ -13058,13 +13077,9 @@
     "sdk/definitions": {
       "name": "@wormhole-foundation/sdk-definitions-ntt",
       "version": "0.4.0",
-      "dependencies": {
-        "@wormhole-foundation/sdk-base": "^0.12.0",
-        "@wormhole-foundation/sdk-definitions": "^0.12.0"
-      },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^0.12.0",
-        "@wormhole-foundation/sdk-definitions": "^0.12.0"
+        "@wormhole-foundation/sdk-base": "^1.0.0",
+        "@wormhole-foundation/sdk-definitions": "^1.0.0"
       }
     },
     "sdk/evm": {
@@ -13218,14 +13233,6 @@
         "node": ">=16"
       }
     },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-base": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.0.tgz",
-      "integrity": "sha512-PbfvGG/G6qDo3QtW+9R74iAFGeXziOfSumSSRJvH5gAmQmZWUmQ0C8WaBJIzYDoV+67IYenXHYfupVWsblTP3g==",
-      "dependencies": {
-        "@scure/base": "^1.1.3"
-      }
-    },
     "sdk/examples/node_modules/@wormhole-foundation/sdk-connect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
@@ -13299,16 +13306,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "sdk/examples/node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.0.0.tgz",
-      "integrity": "sha512-lKME4k4lXMCYy6FotibtBVq5F4V5GuDtOyprGuTER47SdY5ZICK7xK8RKjcXlf+2T81sNQ6PkF7VIDteKiRfoA==",
-      "dependencies": {
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "1.0.0"
       }
     },
     "sdk/examples/node_modules/@wormhole-foundation/sdk-evm": {
@@ -13509,15 +13506,6 @@
         "@wormhole-foundation/sdk-solana-ntt": "0.4.0"
       }
     },
-    "sdk/route/node_modules/@wormhole-foundation/sdk-base": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.0.tgz",
-      "integrity": "sha512-PbfvGG/G6qDo3QtW+9R74iAFGeXziOfSumSSRJvH5gAmQmZWUmQ0C8WaBJIzYDoV+67IYenXHYfupVWsblTP3g==",
-      "peer": true,
-      "dependencies": {
-        "@scure/base": "^1.1.3"
-      }
-    },
     "sdk/route/node_modules/@wormhole-foundation/sdk-connect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
@@ -13530,17 +13518,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "sdk/route/node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.0.0.tgz",
-      "integrity": "sha512-lKME4k4lXMCYy6FotibtBVq5F4V5GuDtOyprGuTER47SdY5ZICK7xK8RKjcXlf+2T81sNQ6PkF7VIDteKiRfoA==",
-      "peer": true,
-      "dependencies": {
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "1.0.0"
       }
     },
     "solana": {
@@ -13654,15 +13631,6 @@
         "node": ">=16"
       }
     },
-    "solana/node_modules/@wormhole-foundation/sdk-base": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.0.tgz",
-      "integrity": "sha512-PbfvGG/G6qDo3QtW+9R74iAFGeXziOfSumSSRJvH5gAmQmZWUmQ0C8WaBJIzYDoV+67IYenXHYfupVWsblTP3g==",
-      "peer": true,
-      "dependencies": {
-        "@scure/base": "^1.1.3"
-      }
-    },
     "solana/node_modules/@wormhole-foundation/sdk-connect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.0.tgz",
@@ -13675,17 +13643,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "solana/node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.0.0.tgz",
-      "integrity": "sha512-lKME4k4lXMCYy6FotibtBVq5F4V5GuDtOyprGuTER47SdY5ZICK7xK8RKjcXlf+2T81sNQ6PkF7VIDteKiRfoA==",
-      "peer": true,
-      "dependencies": {
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "1.0.0"
       }
     },
     "solana/node_modules/@wormhole-foundation/sdk-solana": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ntt",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "license": "Apache-2.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@solana/web3.js": "^1.95.2",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.2",
-    "@wormhole-foundation/sdk": "^0.12.0",
+    "@wormhole-foundation/sdk": "^1.0.0",
     "@wormhole-foundation/wormchain-sdk": "^0.0.1",
     "ethers": "^6.5.1",
     "ts-jest": "^29.1.2",

--- a/sdk/definitions/package.json
+++ b/sdk/definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wormhole-foundation/sdk-definitions-ntt",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wormhole-foundation/example-native-token-transfers.git"

--- a/sdk/definitions/package.json
+++ b/sdk/definitions/package.json
@@ -48,13 +48,9 @@
     "clean": "rm -rf ./dist",
     "test": "jest --config ./jest.config.ts"
   },
-  "dependencies": {
-    "@wormhole-foundation/sdk-base": "^0.12.0",
-    "@wormhole-foundation/sdk-definitions": "^0.12.0"
-  },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "^0.12.0",
-    "@wormhole-foundation/sdk-definitions": "^0.12.0"
+    "@wormhole-foundation/sdk-base": "^1.0.0",
+    "@wormhole-foundation/sdk-definitions": "^1.0.0"
   },
   "type": "module"
 }

--- a/sdk/examples/package.json
+++ b/sdk/examples/package.json
@@ -32,7 +32,7 @@
     "tsx": "^4.7.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "^0.12.0",
+    "@wormhole-foundation/sdk": "^1.0.0",
     "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
     "@wormhole-foundation/sdk-evm-ntt": "0.4.0",
     "@wormhole-foundation/sdk-solana-ntt": "0.4.0",

--- a/sdk/examples/package.json
+++ b/sdk/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wormhole-foundation/sdk-examples-ntt",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "types": "./dist/cjs/index.d.ts",
@@ -33,9 +33,9 @@
   },
   "dependencies": {
     "@wormhole-foundation/sdk": "^1.0.0",
-    "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-evm-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-solana-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-route-ntt": "0.4.0"
+    "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
+    "@wormhole-foundation/sdk-evm-ntt": "0.5.0",
+    "@wormhole-foundation/sdk-solana-ntt": "0.5.0",
+    "@wormhole-foundation/sdk-route-ntt": "0.5.0"
   }
 }

--- a/sdk/route/package.json
+++ b/sdk/route/package.json
@@ -44,10 +44,12 @@
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
     "@wormhole-foundation/sdk-solana-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-evm-ntt": "0.4.0",
+    "@wormhole-foundation/sdk-evm-ntt": "0.4.0"
+  },
+  "peerDependencies": {
     "@wormhole-foundation/sdk-connect": "^1.0.0"
   },
   "type": "module",

--- a/sdk/route/package.json
+++ b/sdk/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wormhole-foundation/sdk-route-ntt",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wormhole-foundation/example-native-token-transfers.git"
@@ -45,9 +45,9 @@
     "ts-node": "^10.9.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-solana-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-evm-ntt": "0.4.0"
+    "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
+    "@wormhole-foundation/sdk-solana-ntt": "0.5.0",
+    "@wormhole-foundation/sdk-evm-ntt": "0.5.0"
   },
   "peerDependencies": {
     "@wormhole-foundation/sdk-connect": "^1.0.0"

--- a/sdk/route/package.json
+++ b/sdk/route/package.json
@@ -40,21 +40,19 @@
     "clean": "rm -rf ./dist"
   },
   "devDependencies": {
+    "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
+    "@wormhole-foundation/sdk-solana-ntt": "0.4.0",
+    "@wormhole-foundation/sdk-evm-ntt": "0.4.0",
+    "@wormhole-foundation/sdk-connect": "^1.0.0",
     "nock": "^13.3.3",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
     "@wormhole-foundation/sdk-solana-ntt": "0.4.0",
     "@wormhole-foundation/sdk-evm-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-connect": "^0.12.0"
-  },
-  "peerDependencies": {
-    "@wormhole-foundation/sdk-connect": "^0.12.0",
-    "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-solana-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-evm-ntt": "0.4.0"
+    "@wormhole-foundation/sdk-connect": "^1.0.0"
   },
   "type": "module",
   "exports": {

--- a/sdk/route/package.json
+++ b/sdk/route/package.json
@@ -40,10 +40,6 @@
     "clean": "rm -rf ./dist"
   },
   "devDependencies": {
-    "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-solana-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-evm-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-connect": "^1.0.0",
     "nock": "^13.3.3",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2"

--- a/solana/package.json
+++ b/solana/package.json
@@ -42,11 +42,6 @@
     "build:contracts": "make build"
   },
   "devDependencies": {
-    "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-base": "^1.0.0",
-    "@wormhole-foundation/sdk-definitions": "^1.0.0",
-    "@wormhole-foundation/sdk-solana": "^1.0.0",
-    "@wormhole-foundation/sdk-solana-core": "^1.0.0",
     "@types/bn.js": "^5.1.5",
     "nock": "^13.3.3",
     "ts-jest": "^29.1.2",

--- a/solana/package.json
+++ b/solana/package.json
@@ -53,10 +53,10 @@
     "@coral-xyz/borsh": "0.29.0",
     "@solana/spl-token": "0.4.0",
     "@solana/web3.js": "^1.95.2",
-    "bn.js": "5.2.1"
+    "bn.js": "5.2.1",
+    "@wormhole-foundation/sdk-definitions-ntt": "0.4.0"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
     "@wormhole-foundation/sdk-base": "^1.0.0",
     "@wormhole-foundation/sdk-definitions": "^1.0.0",
     "@wormhole-foundation/sdk-solana": "^1.0.0",

--- a/solana/package.json
+++ b/solana/package.json
@@ -42,6 +42,11 @@
     "build:contracts": "make build"
   },
   "devDependencies": {
+    "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
+    "@wormhole-foundation/sdk-base": "^1.0.0",
+    "@wormhole-foundation/sdk-definitions": "^1.0.0",
+    "@wormhole-foundation/sdk-solana": "^1.0.0",
+    "@wormhole-foundation/sdk-solana-core": "^1.0.0",
     "@types/bn.js": "^5.1.5",
     "nock": "^13.3.3",
     "ts-jest": "^29.1.2",
@@ -53,18 +58,14 @@
     "@coral-xyz/borsh": "0.29.0",
     "@solana/spl-token": "0.4.0",
     "@solana/web3.js": "^1.95.2",
-    "@wormhole-foundation/sdk-base": "^0.12.0",
-    "@wormhole-foundation/sdk-definitions": "^0.12.0",
-    "@wormhole-foundation/sdk-solana": "^0.12.0",
-    "@wormhole-foundation/sdk-solana-core": "^0.12.0",
     "bn.js": "5.2.1"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "^0.12.0",
-    "@wormhole-foundation/sdk-definitions": "^0.12.0",
     "@wormhole-foundation/sdk-definitions-ntt": "0.4.0",
-    "@wormhole-foundation/sdk-solana": "^0.12.0",
-    "@wormhole-foundation/sdk-solana-core": "^0.12.0"
+    "@wormhole-foundation/sdk-base": "^1.0.0",
+    "@wormhole-foundation/sdk-definitions": "^1.0.0",
+    "@wormhole-foundation/sdk-solana": "^1.0.0",
+    "@wormhole-foundation/sdk-solana-core": "^1.0.0"
   },
   "type": "module",
   "exports": {

--- a/solana/package.json
+++ b/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wormhole-foundation/sdk-solana-ntt",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wormhole-foundation/example-native-token-transfers.git"
@@ -54,7 +54,7 @@
     "@solana/spl-token": "0.4.0",
     "@solana/web3.js": "^1.95.2",
     "bn.js": "5.2.1",
-    "@wormhole-foundation/sdk-definitions-ntt": "0.4.0"
+    "@wormhole-foundation/sdk-definitions-ntt": "0.5.0"
   },
   "peerDependencies": {
     "@wormhole-foundation/sdk-base": "^1.0.0",


### PR DESCRIPTION
- Updates Wormhole SDK dependencies to `1.0.0`
- Moves them out of `dependencies` and into `peerDependencies` (since this is an SDK [plugin](https://blog.bitsrc.io/understanding-peer-dependencies-in-javascript-dbdb4ab5a7be))