### PR TITLE
solana sdk: Fix getIsApproved to check inbox item

### DIFF
--- a/solana/ts/sdk/ntt.ts
+++ b/solana/ts/sdk/ntt.ts
@@ -800,7 +800,9 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
   }
 
   async getIsApproved(attestation: Ntt.Attestation): Promise<boolean> {
-    if (attestation.payloadName !== "WormholeTransfer") return false;
+    if (attestation.payloadName !== "WormholeTransfer") {
+      throw new Error(`Invalid payload: ${attestation.payloadName}`);
+    }
     const payload = attestation.payload["nttManagerPayload"];
     try {
       // check that the inbox item was initialized

--- a/solana/ts/sdk/ntt.ts
+++ b/solana/ts/sdk/ntt.ts
@@ -800,14 +800,20 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
   }
 
   async getIsApproved(attestation: Ntt.Attestation): Promise<boolean> {
-    const digest = (attestation as WormholeNttTransceiver.VAA).hash;
-    const vaaAddress = utils.derivePostedVaaKey(
-      this.core.address,
-      Buffer.from(digest)
-    );
-
-    const info = await this.connection.getAccountInfo(vaaAddress);
-    return info !== null;
+    if (attestation.payloadName !== "WormholeTransfer") return false;
+    const payload = attestation.payload["nttManagerPayload"];
+    try {
+      // check that the inbox item was initialized
+      const inboxItem = await this.program.account.inboxItem.fetch(
+        this.pdas.inboxItemAccount(attestation.emitterChain, payload)
+      );
+      return inboxItem.init;
+    } catch (e: any) {
+      if (e.message?.includes("Account does not exist")) {
+        return false;
+      }
+      throw e;
+    }
   }
 
   async *completeInboundQueuedTransfer(


### PR DESCRIPTION
getIsApproved() was returning true when the VAA was posted, causing track() to set the receipt state to DestinationInitiated prematurely. It should check if the inbox item is initialized instead.

Fixes an issue that caused calls to NttAutomaticRoute.complete() to return early and never actually complete the transfer in rare cases (receipt.DestinationInitiated === true and inbox item not created).