### PR TITLE
evm: Remove redundant threshold setting in script

### DIFF
--- a/evm/script/helpers/DeployWormholeNttBase.sol
+++ b/evm/script/helpers/DeployWormholeNttBase.sol
@@ -91,10 +91,6 @@ contract DeployWormholeNttBase is ParseNttConfig {
             INttManager(nttManager).setOutboundLimit(outboundLimit);
             console2.log("Outbound rate limit set on NttManager: ", outboundLimit);
         }
-
-        // Hardcoded to one since these scripts handle Wormhole-only deployments.
-        INttManager(nttManager).setThreshold(1);
-        console2.log("Threshold set on NttManager: %d", uint256(1));
     }
 
     function _readEnvVariables() internal view returns (DeploymentParams memory params) {


### PR DESCRIPTION
This PR removes an explicit call to `INttManager.setThreshold(1)` that is not needed given that the threshold was already set to 1 in a previous call to `IManagerBase(nttManager).setTransceiver(transceiver);` when the first transceiver was added.

https://github.com/wormhole-foundation/native-token-transfers/blob/404c0aa411fded30d04328716fcba928de4c25a4/evm/src/NttManager/ManagerBase.sol#L353-L379