### PR TITLE
[pipeline fix] Change test from chainId 6 to chainId 14

### DIFF
--- a/evm/test/IntegrationRelayer.t.sol
+++ b/evm/test/IntegrationRelayer.t.sol
@@ -36,7 +36,7 @@ contract TestEndToEndRelayer is IntegrationHelpers, IRateLimiterEvents, Wormhole
     using TrimmedAmountLib for TrimmedAmount;
 
     uint16 constant chainId1 = 4;
-    uint16 constant chainId2 = 6;
+    uint16 constant chainId2 = 14;
     uint8 constant FAST_CONSISTENCY_LEVEL = 200;
     uint256 constant GAS_LIMIT = 500000;
 


### PR DESCRIPTION
* For some reason, AVAX (used in a CI test) is quoting sending messages as 80+ ETH, which makes a test fail because we're `vm.deal`ing 1 ETH. Could solve it by dealing more ETH but thought we could just move to another chain just in case
* Changed `chainId` from 6 to 14 as other chains still use Ankr (deprecated) RPCs that are coming from the Solidity SDK (we should migrate to post `0.1.0` when it's ready though 