### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -11,11 +11,11 @@ jobs:
   test-evm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - run: docker build -f Dockerfile.cli --target cli-local-test . --progress=plain
 
   test-solana:
     runs-on: tilt-kube-public
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - run: docker build -f Dockerfile.cli --target cli-local-test-solana . --progress=plain

--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -22,7 +22,7 @@ jobs:
     name: forge test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -54,7 +54,7 @@ jobs:
     name: echidna
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v3
         with:
           node-version: 20

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v3
         with:
           node-version: 20

--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       RUSTFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Get rust toolchain version
         id: toolchain
@@ -88,7 +88,7 @@ jobs:
     name: Check version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - run: ./scripts/sync-versions --check
         shell: bash
@@ -101,7 +101,7 @@ jobs:
       solana-cli-version: "1.18.26"
       anchor-version: "0.29.0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/setup-anchor
         with:

--- a/.github/workflows/tilt.yml
+++ b/.github/workflows/tilt.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Clear repository
         run: |
           rm -rf $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Expand for link to Tilt dashboard (only available during build)


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0