### PR TITLE
feat: set CreditCoin gas limit to 1.5M

### DIFF
--- a/evm/ts/src/nttWithExecutor.ts
+++ b/evm/ts/src/nttWithExecutor.ts
@@ -71,6 +71,7 @@ const gasLimitOverrides: Partial<
 > = {
   Mainnet: {
     Arbitrum: 800_000n,
+    CreditCoin: 1_500_000n,
   },
   Testnet: {
     ArbitrumSepolia: 800_000n,


### PR DESCRIPTION
CreditCoin claims are failing, here's an example claim that used almost 1M gas https://creditcoin.blockscout.com/tx/0xf0117316f09bce151a2f913de0137d8617614d27a56a4e103cc36f01f084b970