### PR TITLE
dockerfile: pin bun for cli

### DIFF
--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: v1.3.6
 
       - name: Run Forge build
         run: |
@@ -61,7 +61,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.3.6
 
       - name: Run Forge build
         run: |

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -15,7 +15,7 @@ RUN apt install -y unzip
 RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.2.23"
 
 RUN curl -L https://foundry.paradigm.xyz | bash
-RUN bash -ci "foundryup"
+RUN bash -ci "foundryup --install v1.3.6"
 
 RUN apt install -y jq
 


### PR DESCRIPTION
I'm not sure why this started failing with bun v1.3.0, but let's pin for now.

Oh Foundry / forge v1.4.0 and v1.4.1 break something in the imports as well as introducing new lints. I attempted to fix or bypass all the warnings and ignore all the notes via the toml, but that simply revealed the import errors. For now I'm pinning the foundry version. 🤞 