### PR TITLE
cli: remove unnecessary sui package dependency

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -18,8 +18,6 @@
     "ntt": "src/index.ts"
   },
   "dependencies": {
-    "@mysten/sui": "1.37.2",
-    "@wormhole-foundation/sdk-sui-ntt": "^2.0.3",
     "chalk": "^5.3.0",
     "yargs": "^17.7.2"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,8 +37,6 @@
       "name": "@wormhole-foundation/ntt-cli",
       "version": "1.5.0",
       "dependencies": {
-        "@mysten/sui": "1.37.2",
-        "@wormhole-foundation/sdk-sui-ntt": "^2.0.3",
         "chalk": "^5.3.0",
         "yargs": "^17.7.2"
       },
@@ -51,86 +49,6 @@
       },
       "peerDependencies": {
         "typescript": "^5.0.0"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-base": {
-      "version": "2.5.0",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@scure/base": "^1.1.3",
-        "binary-layout": "^1.0.3"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "2.5.0",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@wormhole-foundation/sdk-base": "2.5.0",
-        "@wormhole-foundation/sdk-definitions": "2.5.0",
-        "axios": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "2.5.0",
-      "peer": true,
-      "dependencies": {
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "2.5.0"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-definitions-ntt": {
-      "version": "2.0.3",
-      "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^2.4.0",
-        "@wormhole-foundation/sdk-definitions": "^2.4.0"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "2.5.0",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "2.5.0",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "2.5.0",
-        "@wormhole-foundation/sdk-sui": "2.5.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "cli/node_modules/@wormhole-foundation/sdk-sui-ntt": {
-      "version": "2.0.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mysten/sui": "1.37.2",
-        "@wormhole-foundation/sdk-definitions-ntt": "2.0.3"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^2.4.0",
-        "@wormhole-foundation/sdk-definitions": "^2.4.0",
-        "@wormhole-foundation/sdk-sui": "^2.4.0",
-        "@wormhole-foundation/sdk-sui-core": "^2.4.0"
       }
     },
     "evm/ts": {


### PR DESCRIPTION
We just override it anyway so this is not needed and causes problems with the sui ntt protocol not getting registered.