### PR TITLE
feat(solana): Make transceiver peers upgradable

### DIFF
--- a/solana/Makefile
+++ b/solana/Makefile
@@ -16,7 +16,7 @@ build: cargo-build anchor-build
 
 
 cargo-build:
-	BPF_OUT_DIR="$(pwd)/target/deploy" cargo build-sbf
+	BPF_OUT_DIR="$(pwd)/target/deploy" cargo build-sbf --features "mainnet"
 
 # After building, remove the generics from the idl file. This is necessary as of anchor 0.29.0,
 # because the javascript library does not support generics yet, and just panics
@@ -75,7 +75,7 @@ cargo-test:
 	cargo build-sbf --features "mainnet"
 	cargo test-sbf -p "example-native-token-transfers" --features "mainnet"
 	cargo test-sbf -p "ntt-transceiver" --features "mainnet,testing"
-	cargo test
+	cargo test --features "mainnet"
 
 anchor-test: idl sdk node_modules
 	anchor test --skip-build
@@ -89,8 +89,8 @@ lint: cargo-lint anchor-lint
 
 cargo-lint:
 	cargo fmt --check --all --manifest-path Cargo.toml
-	cargo check --workspace --tests --manifest-path Cargo.toml
-	cargo clippy --workspace --tests --manifest-path Cargo.toml -- -Dclippy::cast_possible_truncation
+	cargo check --workspace --tests --manifest-path Cargo.toml --features mainnet
+	cargo clippy --workspace --tests --manifest-path Cargo.toml --features mainnet -- -Dclippy::cast_possible_truncation
 
 # Run anchor's linter on all Rust files in the current directory via `anchor idl parse`
 # Results written to /dev/null because we're just calling parse for the linting capabilities and we don't care about

--- a/solana/programs/example-native-token-transfers/tests/admin.rs
+++ b/solana/programs/example-native-token-transfers/tests/admin.rs
@@ -2,18 +2,24 @@
 #![feature(type_changing_struct_update)]
 
 use anchor_lang::{system_program::System, Id};
-use example_native_token_transfers::error::NTTError;
-use ntt_messages::mode::Mode;
+use example_native_token_transfers::{
+    error::NTTError, instructions::SetPeerArgs, peer::NttManagerPeer, queue::inbox::InboxRateLimit,
+};
+use ntt_messages::{chain_id::ChainId, mode::Mode};
 use solana_program_test::*;
 use solana_sdk::{instruction::InstructionError, signer::Signer, transaction::TransactionError};
 use test_utils::{
-    common::submit::Submittable,
+    common::{
+        fixtures::{ANOTHER_MANAGER, INBOUND_LIMIT, OTHER_CHAIN, OTHER_MANAGER},
+        query::GetAccountDataAnchor,
+        submit::Submittable,
+    },
     helpers::{assert_threshold, assert_transceiver_id, setup},
     sdk::{
-        accounts::good_ntt,
+        accounts::{good_ntt, NTTAccounts},
         instructions::admin::{
-            deregister_transceiver, register_transceiver, set_threshold, DeregisterTransceiver,
-            RegisterTransceiver, SetThreshold,
+            deregister_transceiver, register_transceiver, set_peer, set_threshold,
+            DeregisterTransceiver, RegisterTransceiver, SetPeer, SetThreshold,
         },
         transceivers::accounts::{good_ntt_transceiver, NTTTransceiverAccounts},
     },
@@ -248,4 +254,50 @@ async fn test_threshold_too_high() {
             InstructionError::Custom(NTTError::ThresholdTooHigh.into())
         )
     );
+}
+
+#[tokio::test]
+async fn test_update_peer() {
+    let (mut ctx, test_data) = setup(Mode::Locking).await;
+
+    // verify initial setup values
+    let peer: NttManagerPeer = ctx
+        .get_account_data_anchor(good_ntt.peer(OTHER_CHAIN))
+        .await;
+    assert_eq!(peer.address, OTHER_MANAGER);
+    assert_eq!(peer.token_decimals, 7);
+    let inbox_rate_limit: InboxRateLimit = ctx
+        .get_account_data_anchor(good_ntt.inbox_rate_limit(OTHER_CHAIN))
+        .await;
+    assert_eq!(inbox_rate_limit.limit, INBOUND_LIMIT);
+
+    // update peer for the same chain to a different address, decimals, and limit
+    set_peer(
+        &good_ntt,
+        SetPeer {
+            payer: ctx.payer.pubkey(),
+            owner: test_data.program_owner.pubkey(),
+        },
+        SetPeerArgs {
+            chain_id: ChainId { id: OTHER_CHAIN },
+            address: ANOTHER_MANAGER,
+            limit: 0,
+            token_decimals: 9,
+        },
+    )
+    .submit_with_signers(&[&test_data.program_owner], &mut ctx)
+    .await
+    .unwrap();
+
+    // verify peer address, decimals, and limit were updated
+    let peer: NttManagerPeer = ctx
+        .get_account_data_anchor(good_ntt.peer(OTHER_CHAIN))
+        .await;
+    assert_eq!(peer.address, ANOTHER_MANAGER);
+    assert_eq!(peer.token_decimals, 9);
+    let inbox_rate_limit: InboxRateLimit = ctx
+        .get_account_data_anchor(good_ntt.inbox_rate_limit(OTHER_CHAIN))
+        .await;
+    assert_eq!(inbox_rate_limit.limit, 0);
+    assert_eq!(inbox_rate_limit.capacity_at_last_tx, 0);
 }

--- a/solana/programs/ntt-transceiver/Cargo.toml
+++ b/solana/programs/ntt-transceiver/Cargo.toml
@@ -38,7 +38,7 @@ tilt-devnet2 = [ "wormhole-transceiver", "tilt-devnet", "wormhole-svm-definition
 workspace = true
 
 [dependencies]
-anchor-lang.workspace = true
+anchor-lang = { workspace = true, features = ["init-if-needed"] }
 anchor-spl.workspace = true
 cfg-if.workspace = true
 solana-program.workspace = true

--- a/solana/programs/ntt-transceiver/src/wormhole/instructions/admin.rs
+++ b/solana/programs/ntt-transceiver/src/wormhole/instructions/admin.rs
@@ -17,7 +17,7 @@ pub struct SetTransceiverPeer<'info> {
     pub payer: Signer<'info>,
 
     #[account(
-        init,
+        init_if_needed,
         space = 8 + TransceiverPeer::INIT_SPACE,
         payer = payer,
         seeds = [TransceiverPeer::SEED_PREFIX, args.chain_id.id.to_be_bytes().as_ref()],

--- a/solana/programs/ntt-transceiver/tests/admin.rs
+++ b/solana/programs/ntt-transceiver/tests/admin.rs
@@ -3,11 +3,16 @@
 
 use anchor_lang::{system_program::System, Id};
 use example_native_token_transfers::error::NTTError;
-use ntt_messages::mode::Mode;
+use ntt_messages::{chain_id::ChainId, mode::Mode};
+use ntt_transceiver::peer::TransceiverPeer;
 use solana_program_test::*;
 use solana_sdk::{instruction::InstructionError, signer::Signer, transaction::TransactionError};
 use test_utils::{
-    common::submit::Submittable,
+    common::{
+        fixtures::{ANOTHER_TRANSCEIVER, OTHER_CHAIN, OTHER_TRANSCEIVER},
+        query::GetAccountDataAnchor,
+        submit::Submittable,
+    },
     helpers::{assert_threshold, assert_transceiver_id, setup},
     sdk::{
         accounts::good_ntt,
@@ -15,7 +20,12 @@ use test_utils::{
             deregister_transceiver, register_transceiver, set_threshold, DeregisterTransceiver,
             RegisterTransceiver, SetThreshold,
         },
-        transceivers::accounts::{good_ntt_transceiver, NTTTransceiverAccounts},
+        transceivers::{
+            accounts::{good_ntt_transceiver, NTTTransceiverAccounts},
+            instructions::admin::{
+                set_transceiver_peer, SetTransceiverPeer, SetTransceiverPeerArgs,
+            },
+        },
     },
 };
 use wormhole_svm_definitions::solana::{POST_MESSAGE_SHIM_PROGRAM_ID, VERIFY_VAA_SHIM_PROGRAM_ID};
@@ -205,4 +215,38 @@ async fn test_deregister_last_enabled_transceiver() {
             InstructionError::Custom(NTTError::ZeroThreshold.into())
         )
     );
+}
+
+#[tokio::test]
+async fn test_update_transceiver_peer() {
+    let (mut ctx, test_data) = setup(Mode::Locking).await;
+
+    // verify initial setup values
+    let peer: TransceiverPeer = ctx
+        .get_account_data_anchor(good_ntt_transceiver.transceiver_peer(OTHER_CHAIN))
+        .await;
+    assert_eq!(peer.address, OTHER_TRANSCEIVER);
+
+    // update peer for the same chain to a different address
+    set_transceiver_peer(
+        &good_ntt,
+        &good_ntt_transceiver,
+        SetTransceiverPeer {
+            payer: ctx.payer.pubkey(),
+            owner: test_data.program_owner.pubkey(),
+        },
+        SetTransceiverPeerArgs {
+            chain_id: ChainId { id: OTHER_CHAIN },
+            address: ANOTHER_TRANSCEIVER,
+        },
+    )
+    .submit_with_signers(&[&test_data.program_owner], &mut ctx)
+    .await
+    .unwrap();
+
+    // verify peer address was updated
+    let peer: TransceiverPeer = ctx
+        .get_account_data_anchor(good_ntt_transceiver.transceiver_peer(OTHER_CHAIN))
+        .await;
+    assert_eq!(peer.address, ANOTHER_TRANSCEIVER);
 }

--- a/solana/tests/anchor/anchor.test.ts
+++ b/solana/tests/anchor/anchor.test.ts
@@ -14,7 +14,10 @@ import {
   serialize,
   serializePayload,
 } from "@wormhole-foundation/sdk";
-import { Ntt } from "@wormhole-foundation/sdk-definitions-ntt";
+import {
+  Ntt,
+  register as registerDefinitions,
+} from "@wormhole-foundation/sdk-definitions-ntt";
 import * as testing from "@wormhole-foundation/sdk-definitions/testing";
 import {
   SolanaAddress,
@@ -25,7 +28,12 @@ import {
   SolanaWormholeCore,
   utils,
 } from "@wormhole-foundation/sdk-solana-core";
-import { IdlVersion, NTT, getTransceiverProgram } from "../../ts/index.js";
+import {
+  IdlVersion,
+  NTT,
+  getTransceiverProgram,
+  register as registerSolana,
+} from "../../ts/index.js";
 import { SolanaNtt } from "../../ts/sdk/index.js";
 import {
   TestDummyTransferHook,
@@ -35,6 +43,9 @@ import {
   assert,
   signSendWait,
 } from "./utils/helpers.js";
+
+registerDefinitions();
+registerSolana();
 
 /**
  * Test Config Constants


### PR DESCRIPTION
Currently, the `set_transceiver_peer` instruction can only be called once since it uses `init`. This means if the transceiver peer needs to be modified, then the transceiver needs to be redeployed. This PR changes the `set_transceiver_peer` instruction to be `init_if_needed` so that we can update previously set transceiver peers.

This also adds unit tests for `update_peer` and `update_transceiver_peer`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for peer configuration updates and transceiver peer address updates
  * Enhanced test infrastructure and initialization to ensure on-chain account verification and registrations run during test startup

* **Chores**
  * Enabled mainnet feature flag in build, test, and lint targets
  * Adjusted dependency/configuration to allow conditional account initialization during operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->