### PR TITLE
fix(sdk): deprecate NttAutomaticRoute in favor of NttExecutorRoute

### DIFF
--- a/evm/ts/src/ntt.ts
+++ b/evm/ts/src/ntt.ts
@@ -529,6 +529,7 @@ export class EvmNtt<N extends Network, C extends EvmChains>
         "EvmNtt.quoteDeliveryPrice with automatic: true queries on-chain " +
           "special/standard relayer pricing which is no longer maintained " +
           "and may return inflated fees. " +
+          "Any messages sent via the Standard Relayer will not be automatically delivered to the destination chain past April 1st, 2026. " +
           "For automatic EVM transfers, use nttExecutorRoute and obtain quotes via route.quote() instead."
       );
     }

--- a/evm/ts/src/ntt.ts
+++ b/evm/ts/src/ntt.ts
@@ -524,6 +524,15 @@ export class EvmNtt<N extends Network, C extends EvmChains>
     dstChain: Chain,
     options: Ntt.TransferOptions
   ): Promise<bigint> {
+    if (options.automatic) {
+      console.warn(
+        "EvmNtt.quoteDeliveryPrice with automatic: true queries on-chain " +
+          "special/standard relayer pricing which is no longer maintained " +
+          "and may return inflated fees. " +
+          "For automatic EVM transfers, use nttExecutorRoute and obtain quotes via route.quote() instead."
+      );
+    }
+
     await this.initTransceiverIndices();
 
     // Bypass the manager's quoteDeliveryPrice because it has a bug: it sizes the

--- a/sdk/examples/src/route.ts
+++ b/sdk/examples/src/route.ts
@@ -12,7 +12,7 @@ import "@wormhole-foundation/sdk-evm-ntt";
 import "@wormhole-foundation/sdk-solana-ntt";
 
 import {
-  nttAutomaticRoute,
+  nttExecutorRoute,
   nttManualRoute,
 } from "@wormhole-foundation/sdk-route-ntt";
 import { NttTokens } from "./consts.js";
@@ -29,7 +29,7 @@ import { getSigner } from "./helpers.js";
 
   const resolver = wh.resolver([
     nttManualRoute({ tokens: NttTokens }),
-    nttAutomaticRoute({ tokens: NttTokens }),
+    nttExecutorRoute({ ntt: { tokens: NttTokens } }),
   ]);
 
   const { chain, token } = NttTokens.Test[0]!;

--- a/sdk/route/src/automatic.ts
+++ b/sdk/route/src/automatic.ts
@@ -44,7 +44,8 @@ type R = NttRoute.AutomaticTransferReceipt;
  * @deprecated Use {@link nttExecutorRoute} instead.
  * When the source chain is EVM, this route relies on on-chain special/standard relayer pricing
  * which is no longer maintained. Older EVM transceiver deployments may return stale or inflated
- * delivery quotes.
+ * delivery quotes. Messages sent via the Standard Relayer will not be automatically delivered
+ * to the destination chain past April 1st, 2026.
  */
 export function nttAutomaticRoute(config: NttRoute.Config) {
   class NttRouteImpl<N extends Network> extends NttAutomaticRoute<N> {
@@ -57,7 +58,8 @@ export function nttAutomaticRoute(config: NttRoute.Config) {
  * @deprecated Use {@link NttExecutorRoute} instead.
  * When the source chain is EVM, this route relies on on-chain special/standard relayer pricing
  * which is no longer maintained. Older EVM transceiver deployments may return stale or inflated
- * delivery quotes.
+ * delivery quotes. Messages sent via the Standard Relayer will not be automatically delivered
+ * to the destination chain past April 1st, 2026.
  */
 export class NttAutomaticRoute<N extends Network>
   extends routes.AutomaticRoute<N, Op, Vp, R>

--- a/sdk/route/src/automatic.ts
+++ b/sdk/route/src/automatic.ts
@@ -40,6 +40,12 @@ type Q = routes.Quote<Op, Vp>;
 
 type R = NttRoute.AutomaticTransferReceipt;
 
+/**
+ * @deprecated Use {@link nttExecutorRoute} instead.
+ * When the source chain is EVM, this route relies on on-chain special/standard relayer pricing
+ * which is no longer maintained. Older EVM transceiver deployments may return stale or inflated
+ * delivery quotes.
+ */
 export function nttAutomaticRoute(config: NttRoute.Config) {
   class NttRouteImpl<N extends Network> extends NttAutomaticRoute<N> {
     static override config = config;
@@ -47,6 +53,12 @@ export function nttAutomaticRoute(config: NttRoute.Config) {
   return NttRouteImpl;
 }
 
+/**
+ * @deprecated Use {@link NttExecutorRoute} instead.
+ * When the source chain is EVM, this route relies on on-chain special/standard relayer pricing
+ * which is no longer maintained. Older EVM transceiver deployments may return stale or inflated
+ * delivery quotes.
+ */
 export class NttAutomaticRoute<N extends Network>
   extends routes.AutomaticRoute<N, Op, Vp, R>
   implements routes.StaticRouteMethods<typeof NttAutomaticRoute>


### PR DESCRIPTION
## Summary

- Mark `nttAutomaticRoute` / `NttAutomaticRoute` as `@deprecated` with pointer to `nttExecutorRoute` / `NttExecutorRoute`
- Add runtime `console.warn` in `EvmNtt.quoteDeliveryPrice` when `automatic: true` is passed
- Update `sdk/examples/src/route.ts` to use `nttExecutorRoute`

## Context

The EVM on-chain special/standard relayer pricing was removed from `WormholeTransceiver` in 36570ce4 ("SR removal and CCL"), but older deployed transceivers (v1.0.0/v1.1.0) still have `isSpecialRelayingEnabled` active with stale pricing. This causes `quoteDeliveryPrice` with `automatic: true` to return inflated fees (e.g. 0.6 ETH for an ETH→Solana transfer) via the unmaintained special relayer contract.

The executor route (`NttExecutorRoute`) replaced this path and quotes via an off-chain service, returning correct fees. The Solana automatic relay path (via the on-chain NttQuoter program) is unaffected and still valid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Automatic NTT routing for EVM chains is deprecated; on-chain relayer pricing is no longer maintained and may yield stale or inflated delivery quotes. Migrate to executor-based routing with quote support.
* **Documentation**
  * Deprecated APIs now include deprecation notes and runtime warnings directing users to the executor-based approach.
* **Examples**
  * Sample configurations updated to demonstrate the executor-based routing pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->