### PR TITLE
fix: use u64::MAX as default Solana outbound limit

### DIFF
--- a/cli/src/constants.ts
+++ b/cli/src/constants.ts
@@ -1,0 +1,2 @@
+/** u64::MAX -- effectively unlimited, consistent with EVM and Sui defaults. */
+export const U64_MAX = 2n ** 64n - 1n;

--- a/cli/src/solana/deploy.ts
+++ b/cli/src/solana/deploy.ts
@@ -19,6 +19,7 @@ import type { SolanaChains } from "@wormhole-foundation/sdk-solana";
 import { NTT, SolanaNtt } from "@wormhole-foundation/sdk-solana-ntt";
 
 import { getSigner, type SignerType } from "../signers/getSigner";
+import { U64_MAX } from "../constants.js";
 import { handleDeploymentError } from "../error";
 import { ensureNttRoot } from "../validation";
 import { askForConfirmation } from "../prompts.js";
@@ -446,7 +447,7 @@ export async function deploySvm<N extends Network, C extends SolanaChains>(
       {
         mint: new PublicKey(token),
         mode,
-        outboundLimit: 100000000n,
+        outboundLimit: U64_MAX,
         ...(mode === "burning" &&
           !mint.mintAuthority!.equals(tokenAuthority) && {
             multisigTokenAuthority: mint.mintAuthority!,


### PR DESCRIPTION
Sets limits on solana/svm to match that of evm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated outbound limit configuration to use the maximum 64-bit unsigned integer value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->