### PR TITLE
feat: bump latest sdk + tempo chain

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,18 +51,18 @@
         "typechain": "^8.3.2",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.12.2",
-        "@wormhole-foundation/sdk-definitions": "^4.12.2",
-        "@wormhole-foundation/sdk-evm": "^4.12.2",
-        "@wormhole-foundation/sdk-evm-core": "^4.12.2",
+        "@wormhole-foundation/sdk-base": "^4.16.0",
+        "@wormhole-foundation/sdk-definitions": "^4.16.0",
+        "@wormhole-foundation/sdk-evm": "^4.16.0",
+        "@wormhole-foundation/sdk-evm-core": "^4.16.0",
       },
     },
     "sdk/definitions": {
       "name": "@wormhole-foundation/sdk-definitions-ntt",
       "version": "1.0.0",
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.12.2",
-        "@wormhole-foundation/sdk-definitions": "^4.12.2",
+        "@wormhole-foundation/sdk-base": "^4.16.0",
+        "@wormhole-foundation/sdk-definitions": "^4.16.0",
       },
     },
     "sdk/examples": {
@@ -120,10 +120,10 @@
         "tsx": "^4.7.2",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.12.2",
-        "@wormhole-foundation/sdk-definitions": "^4.12.2",
-        "@wormhole-foundation/sdk-solana": "^4.12.2",
-        "@wormhole-foundation/sdk-solana-core": "^4.12.2",
+        "@wormhole-foundation/sdk-base": "^4.16.0",
+        "@wormhole-foundation/sdk-definitions": "^4.16.0",
+        "@wormhole-foundation/sdk-solana": "^4.16.0",
+        "@wormhole-foundation/sdk-solana-core": "^4.16.0",
       },
     },
     "sui/ts": {
@@ -134,10 +134,10 @@
         "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.12.2",
-        "@wormhole-foundation/sdk-definitions": "^4.12.2",
-        "@wormhole-foundation/sdk-sui": "^4.12.2",
-        "@wormhole-foundation/sdk-sui-core": "^4.12.2",
+        "@wormhole-foundation/sdk-base": "^4.16.0",
+        "@wormhole-foundation/sdk-definitions": "^4.16.0",
+        "@wormhole-foundation/sdk-sui": "^4.16.0",
+        "@wormhole-foundation/sdk-sui-core": "^4.16.0",
       },
     },
     "xrpl/ts": {
@@ -148,9 +148,9 @@
         "xrpl": "^4.6.0",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "4.12.2",
-        "@wormhole-foundation/sdk-definitions": "4.12.2",
-        "@wormhole-foundation/sdk-xrpl": "4.12.2",
+        "@wormhole-foundation/sdk-base": "^4.16.0",
+        "@wormhole-foundation/sdk-definitions": "^4.16.0",
+        "@wormhole-foundation/sdk-xrpl": "^4.16.0",
       },
     },
   },
@@ -750,17 +750,17 @@
 
     "@wormhole-foundation/sdk-stacks-core": ["@wormhole-foundation/sdk-stacks-core@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-stacks": "4.16.0" } }, "sha512-t4HDnS7ThA42nJRfvk6W6nomT7y8Wkys2R5ttwl6wKGC1Dr2kNI8WjaVWi/j8M6bM+wY8Jn3XSpDZeZUvjt46A=="],
 
-    "@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.12.2", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.12.2" } }, "sha512-pVBd2X4JYIET7dPaQQVit99+aPC37x2NvcuECP1aLblFHBZ0v2ZKb3Pg/qwKafRF0qYmB/vwPxRaolA4sHU1rg=="],
+    "@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0" } }, "sha512-toYAx6uhLh1a2fBmBkomPry5RnegxWQ/zB5u7zCpZZ5KigF5f4HV+Kvw1B1wjRdn9QPkIwKyNir2a13iibjEcg=="],
 
     "@wormhole-foundation/sdk-sui-cctp": ["@wormhole-foundation/sdk-sui-cctp@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-sui": "4.16.0" } }, "sha512-0ji1yuK3GTLVGeklzh96/lwQTYBYKCqcG3wTztydQL1tFsVup7u/2TpZHDUQVZKIrazXjQZ5AyVRu6TV+e2ngw=="],
 
-    "@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.12.2", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-sui": "4.12.2" } }, "sha512-2EogRRpSAPfVNvSAL12cg49WW5n5JmTJ7xcTug1nQgIoKA/S164fokCLN5IVP6bb2DHjd3z9QDlAR9qShD/OQg=="],
+    "@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-sui": "4.16.0" } }, "sha512-j4feCkaSNipBifbiq7rI1wu0TNyNk+m+HATh+9/hQ9DvlCToXmBvOJkoGsOQ/DmR0MBbuyZA0VBSdBMzvXv3Jw=="],
 
     "@wormhole-foundation/sdk-sui-ntt": ["@wormhole-foundation/sdk-sui-ntt@workspace:sui/ts"],
 
     "@wormhole-foundation/sdk-sui-tokenbridge": ["@wormhole-foundation/sdk-sui-tokenbridge@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-sui": "4.16.0", "@wormhole-foundation/sdk-sui-core": "4.16.0" } }, "sha512-y4mFxLf/4ctIYR2JxyIMKspEWLi95ZRD69ecdManD0JyX3qzZr5B+DZRsyjnZ/vyo0Oum6sUDnkgs1lxTKfPbw=="],
 
-    "@wormhole-foundation/sdk-xrpl": ["@wormhole-foundation/sdk-xrpl@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.12.2", "xrpl": "^4.2.0" } }, "sha512-ur683trHjv8KYbu2nsU98mBlzHJyUXL7DcCmDxQhp87mm9xWtBu2TuuP0/hWm0PA+b7oyBBP5NKBFQgZACfvIg=="],
+    "@wormhole-foundation/sdk-xrpl": ["@wormhole-foundation/sdk-xrpl@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.16.0", "xrpl": "^4.2.0" } }, "sha512-bPp2WuCe+ZLu9W17faci8vsnzyD0F/39gbRuafBJnq1LYlq9u9Psthe3E7dHMUSWdo7H3N9SDa0Fdc19bf2Jpg=="],
 
     "@wormhole-foundation/sdk-xrpl-ntt": ["@wormhole-foundation/sdk-xrpl-ntt@workspace:xrpl/ts"],
 
@@ -1856,12 +1856,6 @@
 
     "@types/ws/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
 
-    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0" } }, "sha512-toYAx6uhLh1a2fBmBkomPry5RnegxWQ/zB5u7zCpZZ5KigF5f4HV+Kvw1B1wjRdn9QPkIwKyNir2a13iibjEcg=="],
-
-    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-sui": "4.16.0" } }, "sha512-j4feCkaSNipBifbiq7rI1wu0TNyNk+m+HATh+9/hQ9DvlCToXmBvOJkoGsOQ/DmR0MBbuyZA0VBSdBMzvXv3Jw=="],
-
-    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-xrpl": ["@wormhole-foundation/sdk-xrpl@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.16.0", "xrpl": "^4.2.0" } }, "sha512-bPp2WuCe+ZLu9W17faci8vsnzyD0F/39gbRuafBJnq1LYlq9u9Psthe3E7dHMUSWdo7H3N9SDa0Fdc19bf2Jpg=="],
-
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
@@ -1881,22 +1875,6 @@
     "@wormhole-foundation/sdk-solana/rpc-websockets": ["rpc-websockets@7.11.2", "", { "dependencies": { "eventemitter3": "^4.0.7", "uuid": "^8.3.2", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" } }, "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ=="],
 
     "@wormhole-foundation/sdk-solana-ntt/@solana/spl-token": ["@solana/spl-token@0.4.0", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-metadata": "^0.1.2", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.89.1" } }, "sha512-jjBIBG9IsclqQVl5Y82npGE6utdCh7Z9VFcF5qgJa5EUq2XgspW3Dt1wujWjH/vQDRnkp9zGO+BqQU/HhX/3wg=="],
-
-    "@wormhole-foundation/sdk-sui/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.12.2", "@wormhole-foundation/sdk-definitions": "4.12.2", "axios": "^1.4.0" } }, "sha512-IAc4qJqxWDUlPszWXCb0etVzWVtz8DFVXzqTOiSSvBMUzX/13OaRNM4B2jPmQb1JZARluT0Q49GpcbrEKttgGw=="],
-
-    "@wormhole-foundation/sdk-sui-cctp/@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0" } }, "sha512-toYAx6uhLh1a2fBmBkomPry5RnegxWQ/zB5u7zCpZZ5KigF5f4HV+Kvw1B1wjRdn9QPkIwKyNir2a13iibjEcg=="],
-
-    "@wormhole-foundation/sdk-sui-core/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.12.2", "@wormhole-foundation/sdk-definitions": "4.12.2", "axios": "^1.4.0" } }, "sha512-IAc4qJqxWDUlPszWXCb0etVzWVtz8DFVXzqTOiSSvBMUzX/13OaRNM4B2jPmQb1JZARluT0Q49GpcbrEKttgGw=="],
-
-    "@wormhole-foundation/sdk-sui-tokenbridge/@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0" } }, "sha512-toYAx6uhLh1a2fBmBkomPry5RnegxWQ/zB5u7zCpZZ5KigF5f4HV+Kvw1B1wjRdn9QPkIwKyNir2a13iibjEcg=="],
-
-    "@wormhole-foundation/sdk-sui-tokenbridge/@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-sui": "4.16.0" } }, "sha512-j4feCkaSNipBifbiq7rI1wu0TNyNk+m+HATh+9/hQ9DvlCToXmBvOJkoGsOQ/DmR0MBbuyZA0VBSdBMzvXv3Jw=="],
-
-    "@wormhole-foundation/sdk-xrpl/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.12.2", "@wormhole-foundation/sdk-definitions": "4.12.2", "axios": "^1.4.0" } }, "sha512-IAc4qJqxWDUlPszWXCb0etVzWVtz8DFVXzqTOiSSvBMUzX/13OaRNM4B2jPmQb1JZARluT0Q49GpcbrEKttgGw=="],
-
-    "@wormhole-foundation/sdk-xrpl-ntt/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.12.2", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-GbCxnsCz8NGBeLB8niTosFPBqozpDKxoafuO2SR3GZcvwYrdkCObFdB6CK210if6ZghpnXLeP3KAJd17GSkL9w=="],
-
-    "@wormhole-foundation/sdk-xrpl-ntt/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.12.2", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.12.2" } }, "sha512-oRZTwZcbSxbBF+/9GyT2AFLvXXRAtKfr2LbGcPIUZH247Qna8KZOUbArdR4bPzjcSyBNY+9q87MoPdTFDcys6w=="],
 
     "@wormhole-foundation/wormchain-sdk/axios": ["axios@0.26.1", "", { "dependencies": { "follow-redirects": "^1.14.8" } }, "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA=="],
 
@@ -2445,18 +2423,6 @@
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
-
-    "@wormhole-foundation/sdk-sui-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.12.2", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-GbCxnsCz8NGBeLB8niTosFPBqozpDKxoafuO2SR3GZcvwYrdkCObFdB6CK210if6ZghpnXLeP3KAJd17GSkL9w=="],
-
-    "@wormhole-foundation/sdk-sui-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.12.2", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.12.2" } }, "sha512-oRZTwZcbSxbBF+/9GyT2AFLvXXRAtKfr2LbGcPIUZH247Qna8KZOUbArdR4bPzjcSyBNY+9q87MoPdTFDcys6w=="],
-
-    "@wormhole-foundation/sdk-sui/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.12.2", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-GbCxnsCz8NGBeLB8niTosFPBqozpDKxoafuO2SR3GZcvwYrdkCObFdB6CK210if6ZghpnXLeP3KAJd17GSkL9w=="],
-
-    "@wormhole-foundation/sdk-sui/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.12.2", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.12.2" } }, "sha512-oRZTwZcbSxbBF+/9GyT2AFLvXXRAtKfr2LbGcPIUZH247Qna8KZOUbArdR4bPzjcSyBNY+9q87MoPdTFDcys6w=="],
-
-    "@wormhole-foundation/sdk-xrpl/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.12.2", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-GbCxnsCz8NGBeLB8niTosFPBqozpDKxoafuO2SR3GZcvwYrdkCObFdB6CK210if6ZghpnXLeP3KAJd17GSkL9w=="],
-
-    "@wormhole-foundation/sdk-xrpl/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.12.2", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.12.2" } }, "sha512-oRZTwZcbSxbBF+/9GyT2AFLvXXRAtKfr2LbGcPIUZH247Qna8KZOUbArdR4bPzjcSyBNY+9q87MoPdTFDcys6w=="],
 
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util": ["jest-util@27.5.1", "", { "dependencies": { "@jest/types": "^27.5.1", "@types/node": "*", "chalk": "^4.0.0", "ci-info": "^3.2.0", "graceful-fs": "^4.2.9", "picomatch": "^2.2.3" } }, "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@solana/web3.js": "^1.95.8",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.2",
-        "@wormhole-foundation/sdk": "4.12.2",
+        "@wormhole-foundation/sdk": "4.16.0",
         "@wormhole-foundation/wormchain-sdk": "^0.0.1",
         "ethers": "^6.5.1",
         "prettier": "3.6.2",
@@ -69,7 +69,7 @@
       "name": "@wormhole-foundation/sdk-examples-ntt",
       "version": "1.0.0",
       "dependencies": {
-        "@wormhole-foundation/sdk": "^4.12.2",
+        "@wormhole-foundation/sdk": "^4.16.0",
         "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
         "@wormhole-foundation/sdk-evm-ntt": "1.0.0",
         "@wormhole-foundation/sdk-route-ntt": "1.0.0",
@@ -97,7 +97,7 @@
         "ts-node": "^10.9.2",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-connect": "^4.12.2",
+        "@wormhole-foundation/sdk-connect": "^4.16.0",
         "axios": "^1.9.0",
       },
     },
@@ -682,83 +682,83 @@
 
     "@wormhole-foundation/ntt-cli": ["@wormhole-foundation/ntt-cli@workspace:cli"],
 
-    "@wormhole-foundation/sdk": ["@wormhole-foundation/sdk@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.12.2", "@wormhole-foundation/sdk-algorand-core": "4.12.2", "@wormhole-foundation/sdk-algorand-tokenbridge": "4.12.2", "@wormhole-foundation/sdk-aptos": "4.12.2", "@wormhole-foundation/sdk-aptos-cctp": "4.12.2", "@wormhole-foundation/sdk-aptos-core": "4.12.2", "@wormhole-foundation/sdk-aptos-tokenbridge": "4.12.2", "@wormhole-foundation/sdk-base": "4.12.2", "@wormhole-foundation/sdk-btc": "4.12.2", "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-cosmwasm": "4.12.2", "@wormhole-foundation/sdk-cosmwasm-core": "4.12.2", "@wormhole-foundation/sdk-cosmwasm-ibc": "4.12.2", "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.12.2", "@wormhole-foundation/sdk-definitions": "4.12.2", "@wormhole-foundation/sdk-evm": "4.12.2", "@wormhole-foundation/sdk-evm-cctp": "4.12.2", "@wormhole-foundation/sdk-evm-core": "4.12.2", "@wormhole-foundation/sdk-evm-portico": "4.12.2", "@wormhole-foundation/sdk-evm-tbtc": "4.12.2", "@wormhole-foundation/sdk-evm-tokenbridge": "4.12.2", "@wormhole-foundation/sdk-solana": "4.12.2", "@wormhole-foundation/sdk-solana-cctp": "4.12.2", "@wormhole-foundation/sdk-solana-core": "4.12.2", "@wormhole-foundation/sdk-solana-tbtc": "4.12.2", "@wormhole-foundation/sdk-solana-tokenbridge": "4.12.2", "@wormhole-foundation/sdk-stacks": "4.12.2", "@wormhole-foundation/sdk-stacks-core": "4.12.2", "@wormhole-foundation/sdk-sui": "4.12.2", "@wormhole-foundation/sdk-sui-cctp": "4.12.2", "@wormhole-foundation/sdk-sui-core": "4.12.2", "@wormhole-foundation/sdk-sui-tokenbridge": "4.12.2", "@wormhole-foundation/sdk-xrpl": "4.12.2" } }, "sha512-q56mDBChBFvcJley8jMDi0vQBu4swkMkTBxyMas/4Za9+bXBH5rU+I5jwZ/5W7QW3vQoATNipjKdU9BTVMucvA=="],
+    "@wormhole-foundation/sdk": ["@wormhole-foundation/sdk@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.16.0", "@wormhole-foundation/sdk-algorand-core": "4.16.0", "@wormhole-foundation/sdk-algorand-tokenbridge": "4.16.0", "@wormhole-foundation/sdk-aptos": "4.16.0", "@wormhole-foundation/sdk-aptos-cctp": "4.16.0", "@wormhole-foundation/sdk-aptos-core": "4.16.0", "@wormhole-foundation/sdk-aptos-tokenbridge": "4.16.0", "@wormhole-foundation/sdk-base": "4.16.0", "@wormhole-foundation/sdk-btc": "4.16.0", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-cosmwasm": "4.16.0", "@wormhole-foundation/sdk-cosmwasm-core": "4.16.0", "@wormhole-foundation/sdk-cosmwasm-ibc": "4.16.0", "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.16.0", "@wormhole-foundation/sdk-definitions": "4.16.0", "@wormhole-foundation/sdk-evm": "4.16.0", "@wormhole-foundation/sdk-evm-cctp": "4.16.0", "@wormhole-foundation/sdk-evm-core": "4.16.0", "@wormhole-foundation/sdk-evm-portico": "4.16.0", "@wormhole-foundation/sdk-evm-tbtc": "4.16.0", "@wormhole-foundation/sdk-evm-tokenbridge": "4.16.0", "@wormhole-foundation/sdk-solana": "4.16.0", "@wormhole-foundation/sdk-solana-cctp": "4.16.0", "@wormhole-foundation/sdk-solana-core": "4.16.0", "@wormhole-foundation/sdk-solana-tbtc": "4.16.0", "@wormhole-foundation/sdk-solana-tokenbridge": "4.16.0", "@wormhole-foundation/sdk-stacks": "4.16.0", "@wormhole-foundation/sdk-stacks-core": "4.16.0", "@wormhole-foundation/sdk-sui": "4.16.0", "@wormhole-foundation/sdk-sui-cctp": "4.16.0", "@wormhole-foundation/sdk-sui-core": "4.16.0", "@wormhole-foundation/sdk-sui-tokenbridge": "4.16.0", "@wormhole-foundation/sdk-xrpl": "4.16.0" } }, "sha512-IU89jiHq7DQAc+Hg32biVyPauFm0j9UhH6Axi/fnGpU2baU49cUb+IV6YSLKy9EPui3UYroDoBp1L5grFxo1dQ=="],
 
-    "@wormhole-foundation/sdk-algorand": ["@wormhole-foundation/sdk-algorand@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.12.2", "algosdk": "2.7.0" } }, "sha512-eEDOy4QHG8o7PtfrlUHSxuXQ8P6a4TaKIros5aX+q49mFnJ6icA/0ZErbUp7fYayyaVVJHF0Sr7WuUaPS8sHjg=="],
+    "@wormhole-foundation/sdk-algorand": ["@wormhole-foundation/sdk-algorand@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.16.0", "algosdk": "2.7.0" } }, "sha512-4ds2rHAn0MPD+iroZ9bPVp2UiKQfb3y1fnAFrMtf/8d52DSz1x0avWscqIwiiLqbtbafgxmBJMUs0tTGziyfmQ=="],
 
-    "@wormhole-foundation/sdk-algorand-core": ["@wormhole-foundation/sdk-algorand-core@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.12.2", "@wormhole-foundation/sdk-connect": "4.12.2" } }, "sha512-y3sV/ln0FHuwnc3BKW0ZrGvgsJ6J45xzGKvSKleQzq++RW6Sbh/dOODx1wYXgFvIhCU8x80xXZdNB4FjSvYukQ=="],
+    "@wormhole-foundation/sdk-algorand-core": ["@wormhole-foundation/sdk-algorand-core@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.16.0", "@wormhole-foundation/sdk-connect": "4.16.0" } }, "sha512-zYeiwRc27c0OCSgCOQY0+Ff84ksAuTtzxMFQaVxByTcA9RPwUSDsQQ1veAJki5xXFPIzhLO5Lj4ZIAzI1vZG9w=="],
 
-    "@wormhole-foundation/sdk-algorand-tokenbridge": ["@wormhole-foundation/sdk-algorand-tokenbridge@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.12.2", "@wormhole-foundation/sdk-algorand-core": "4.12.2", "@wormhole-foundation/sdk-connect": "4.12.2" } }, "sha512-wH3JpEezT7a77DXa3l+st35GPIjda6HduQPwnUPKYZSWt/kM8O8ON1iMKXXNse8kj4Ep5FTEc65OeDFCPLhUEw=="],
+    "@wormhole-foundation/sdk-algorand-tokenbridge": ["@wormhole-foundation/sdk-algorand-tokenbridge@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.16.0", "@wormhole-foundation/sdk-algorand-core": "4.16.0", "@wormhole-foundation/sdk-connect": "4.16.0" } }, "sha512-G56T/QWQ48lnzumaTHoFZhrD8TOkANzI98ENhEOka21XcujaYlSrb4rtxgLA2g1IZFsyZ2F4yxnUPngbofSwyQ=="],
 
-    "@wormhole-foundation/sdk-aptos": ["@wormhole-foundation/sdk-aptos@4.12.2", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-connect": "4.12.2" } }, "sha512-/P3/q1oPnshatlVdzWGpD/xuMSil67UoheMsQzh/jw/KIWi2RZEW8/LNO88nqhSlsP7/k5aKCBmEiUbNQuIFvQ=="],
+    "@wormhole-foundation/sdk-aptos": ["@wormhole-foundation/sdk-aptos@4.16.0", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-connect": "4.16.0" } }, "sha512-jtIXcOysuweFkqSYPU1w28wJ6cFQWMif6NTlaH2fdaKa974guLDMwwvk2xJfqtSiln6OTy/NYS0qgvIRqiH0vg=="],
 
-    "@wormhole-foundation/sdk-aptos-cctp": ["@wormhole-foundation/sdk-aptos-cctp@4.12.2", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-aptos": "4.12.2", "@wormhole-foundation/sdk-connect": "4.12.2" } }, "sha512-WM4gx2+xoPpcMUV6EdepRCoIE6OZqh7kPP/8MKFV3b1hV09sXy+q6o7b4xhAIUDOo1jv3eH/bql5+5bK2ZMb0g=="],
+    "@wormhole-foundation/sdk-aptos-cctp": ["@wormhole-foundation/sdk-aptos-cctp@4.16.0", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-aptos": "4.16.0", "@wormhole-foundation/sdk-connect": "4.16.0" } }, "sha512-XXWS03hqGCWWkRjBPoRepwviezePUECoOgu9rs5FNiH2esPb8yOe9GnkZTbphrWuCrOUNxFTaKpTG9Des9Nx8w=="],
 
-    "@wormhole-foundation/sdk-aptos-core": ["@wormhole-foundation/sdk-aptos-core@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.12.2", "@wormhole-foundation/sdk-connect": "4.12.2" } }, "sha512-/DhjakJJENQgLpF0yscRWhpPn7qDYl8CcYAb1BOQsgBcOIXPXx66EiMo45cp16JX4t+I/DCSyyYZfxn0y3PKTw=="],
+    "@wormhole-foundation/sdk-aptos-core": ["@wormhole-foundation/sdk-aptos-core@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.16.0", "@wormhole-foundation/sdk-connect": "4.16.0" } }, "sha512-mWfbqOMW7OJE9Yz51/YRjqIz0Q/lXENFmBnUhu8uAq/uWSg3QnRrVzYf3kaT0vbj4/gB3J6wocHtoaGq328bJg=="],
 
-    "@wormhole-foundation/sdk-aptos-tokenbridge": ["@wormhole-foundation/sdk-aptos-tokenbridge@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.12.2", "@wormhole-foundation/sdk-connect": "4.12.2" } }, "sha512-vm4Gn+V3aZ42CwUJmr7L1GdHMlahhdlys4m2teK0K58d4UearOREbN3XgJX3eXK3PQNyzOOyeXA3OeYLixW1qg=="],
+    "@wormhole-foundation/sdk-aptos-tokenbridge": ["@wormhole-foundation/sdk-aptos-tokenbridge@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.16.0", "@wormhole-foundation/sdk-connect": "4.16.0" } }, "sha512-jpzgt//ezDhGQtP9JI/isGnY0OUf6ZEjIdLuBHLLeKxB8Dfnl8SZ81HZaql6KFcjRSPkzHH6eL/x08JwHlqKfA=="],
 
-    "@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.12.2", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-GbCxnsCz8NGBeLB8niTosFPBqozpDKxoafuO2SR3GZcvwYrdkCObFdB6CK210if6ZghpnXLeP3KAJd17GSkL9w=="],
+    "@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.16.0", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-OnsFdLbMfQLZz9Bh6eYto6N3S3/Se7ufUyC9xYqwxkzbT9YSTG1pBTJSjIMkbORQMRkZpLmZgoKm26b+gz3GdQ=="],
 
-    "@wormhole-foundation/sdk-btc": ["@wormhole-foundation/sdk-btc@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.12.2" } }, "sha512-rFpcLWI6eqTFc3e3IzQmS79WdmOu3IoYrGnZ2m3V53hJEEG8V3Dr78MgJNpUhhQPfxqc38YUjQffMHokUbOgnw=="],
+    "@wormhole-foundation/sdk-btc": ["@wormhole-foundation/sdk-btc@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.16.0" } }, "sha512-0yXKeMoPfbmR0G2PURa2rcR6ICmtN07yk71cUly9KZX4GzMzavQ3/S1dp+FftsL+cDent+eLqLxgLmvRYa5icA=="],
 
-    "@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.12.2", "@wormhole-foundation/sdk-definitions": "4.12.2", "axios": "^1.4.0" } }, "sha512-IAc4qJqxWDUlPszWXCb0etVzWVtz8DFVXzqTOiSSvBMUzX/13OaRNM4B2jPmQb1JZARluT0Q49GpcbrEKttgGw=="],
+    "@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.16.0", "@wormhole-foundation/sdk-definitions": "4.16.0", "axios": "^1.4.0" } }, "sha512-CH4PF5MY5B9L8IvNjgRGDO8d14mQmkc7tS2wHP7k7V0YPVSfkqS93Mxbo1mDoxGymjy0d0oKEatUYC6hFGwtoA=="],
 
-    "@wormhole-foundation/sdk-cosmwasm": ["@wormhole-foundation/sdk-cosmwasm@4.12.2", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/proto-signing": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.12.2", "cosmjs-types": "^0.9.0" } }, "sha512-cbbMGC29dr5WN8WFTduZzWyjJH/2BnsA8Oum9Nc2b2lZhx5lUICkYTmBBtrxm7OvXYjde2su95KNdGx+aiBRTQ=="],
+    "@wormhole-foundation/sdk-cosmwasm": ["@wormhole-foundation/sdk-cosmwasm@4.16.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/proto-signing": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.16.0", "cosmjs-types": "^0.9.0" } }, "sha512-h2Qiyusxu7bSWB/rFXVAuOxhcywcE8fkv5ueBHIvUKxLCyuIfAV1xxvhjRrA63nItEeg16nMi3joyEfqivwRGQ=="],
 
-    "@wormhole-foundation/sdk-cosmwasm-core": ["@wormhole-foundation/sdk-cosmwasm-core@4.12.2", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-cosmwasm": "4.12.2" } }, "sha512-Oj0K4DvOPmktuoG4+snrEHVTl9EjvcLwrVeR8AuAHC/i2CttaPd4MBJf8jf0TIO81zzDKgZYEeFR2qI1MAursw=="],
+    "@wormhole-foundation/sdk-cosmwasm-core": ["@wormhole-foundation/sdk-cosmwasm-core@4.16.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-cosmwasm": "4.16.0" } }, "sha512-lWR4t2mZlQK2RgRS5ZQ3IQeiheTKpr1/plk3iz2i6Bi+A+5YKjR+Vt3hkSNTWcbThd3fvdNM3kVUKRnDnLNaaw=="],
 
-    "@wormhole-foundation/sdk-cosmwasm-ibc": ["@wormhole-foundation/sdk-cosmwasm-ibc@4.12.2", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-cosmwasm": "4.12.2", "@wormhole-foundation/sdk-cosmwasm-core": "4.12.2", "cosmjs-types": "^0.9.0" } }, "sha512-vq9im0jSqFIgM0wkpcZQouww/JYH+1dhGlgakdG2HnXCvyC7cmrtINGBlS2fTn5V9HMjzUlvy2Pu9W+5J4FXSA=="],
+    "@wormhole-foundation/sdk-cosmwasm-ibc": ["@wormhole-foundation/sdk-cosmwasm-ibc@4.16.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-cosmwasm": "4.16.0", "@wormhole-foundation/sdk-cosmwasm-core": "4.16.0", "cosmjs-types": "^0.9.0" } }, "sha512-Lc23RA/z5+EpxiIo59vbY4BaMRaADzhoCFNmFYkt6D+uRDQ5cuFA/mM0NayxNAb9BAow6a30Vt8dOAOP8Z45zw=="],
 
-    "@wormhole-foundation/sdk-cosmwasm-tokenbridge": ["@wormhole-foundation/sdk-cosmwasm-tokenbridge@4.12.2", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-cosmwasm": "4.12.2" } }, "sha512-gT04t6ECmoam7yDcsg8UYP0ZEzowQ8tEa5wEn+P2YuTVtTmbN4SgR4JOpBrx1v6FSwB/3HvODQRXsjlm/mOWcw=="],
+    "@wormhole-foundation/sdk-cosmwasm-tokenbridge": ["@wormhole-foundation/sdk-cosmwasm-tokenbridge@4.16.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-cosmwasm": "4.16.0" } }, "sha512-fGTQir8sY1clkja+4Sh1VhIoV69hVrWYqSv3n74mQpAW8VGdESFJ9OF2w56UUobA38Hoa3SbAwx/dtAafkohlQ=="],
 
-    "@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.12.2", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.12.2" } }, "sha512-oRZTwZcbSxbBF+/9GyT2AFLvXXRAtKfr2LbGcPIUZH247Qna8KZOUbArdR4bPzjcSyBNY+9q87MoPdTFDcys6w=="],
+    "@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.16.0", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.16.0" } }, "sha512-cAl4jK2PnLABITWt4wCLJziqiIjprueHFj+DtycZRrpaEp2PkqWmV+VPpFL9r1OJKNsEV5Zk12yNt5m1PsoAww=="],
 
     "@wormhole-foundation/sdk-definitions-ntt": ["@wormhole-foundation/sdk-definitions-ntt@workspace:sdk/definitions"],
 
-    "@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.12.2", "ethers": "^6.5.1" } }, "sha512-mWciRvxmd5hy+bWc/+owuo4/1IFwhFaGcbvRXbiYlNQnHYgztojtC/Iu1TKiKbo/DkWJmmRnqlymMjRbQdQvwQ=="],
+    "@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.16.0", "ethers": "^6.5.1" } }, "sha512-tcztVpyHbQXTjRSS/UwQ0O9XnQcl501QJA9JlBhpmgu8abQep59qQ6JS8LMCTAfPxJ8bmVqnxdE6M5sp6PLPwA=="],
 
-    "@wormhole-foundation/sdk-evm-cctp": ["@wormhole-foundation/sdk-evm-cctp@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-evm": "4.12.2", "@wormhole-foundation/sdk-evm-core": "4.12.2", "ethers": "^6.5.1" } }, "sha512-etF7AtCR3r+MZRxyJUpxIAdFsnZHTPUFDZW1nC2N4fAMb4Rpa+7vvgV4zAKcL9qd3/ZGVOWG8DvFNcI03md/Pw=="],
+    "@wormhole-foundation/sdk-evm-cctp": ["@wormhole-foundation/sdk-evm-cctp@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-evm": "4.16.0", "@wormhole-foundation/sdk-evm-core": "4.16.0", "ethers": "^6.5.1" } }, "sha512-Xo9INYljvzLpTCh7fdQnlBHKweBc+3USEDh7LHfyNT0nu77bRMYiZNvLOOut+swhQzGL/hcR8M1KAF/sZcgtqw=="],
 
-    "@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-evm": "4.12.2", "ethers": "^6.5.1" } }, "sha512-nAXzPqtnMGqZeu1J2l0zcnCeuUEjuW9+Kc5BRm1SjYIAof3XWcizu37k+pF3XEfmNuuyXi1Ee/+WnCjsqUj9tg=="],
+    "@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-evm": "4.16.0", "ethers": "^6.5.1" } }, "sha512-LjDpKYHGyAbcjWR1kUa398yIPBT5Xt8DIeU8nGXpznY9j84rvdDtaN7k7QUT6JydKvE5aRSEjV1mZbL8V8uzxQ=="],
 
     "@wormhole-foundation/sdk-evm-ntt": ["@wormhole-foundation/sdk-evm-ntt@workspace:evm/ts"],
 
-    "@wormhole-foundation/sdk-evm-portico": ["@wormhole-foundation/sdk-evm-portico@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-evm": "4.12.2", "@wormhole-foundation/sdk-evm-core": "4.12.2", "@wormhole-foundation/sdk-evm-tokenbridge": "4.12.2", "ethers": "^6.5.1" } }, "sha512-eEh1WHX2f4xe8COXpQvqP5JGpHQfIuB2v5iKeNOLh0v0JsE2YzsdO79XFEgjFcWdBlILvrkSp4lynFGDnNbO3g=="],
+    "@wormhole-foundation/sdk-evm-portico": ["@wormhole-foundation/sdk-evm-portico@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-evm": "4.16.0", "@wormhole-foundation/sdk-evm-core": "4.16.0", "@wormhole-foundation/sdk-evm-tokenbridge": "4.16.0", "ethers": "^6.5.1" } }, "sha512-Z1kkikV5JiK2lPWXtJqxCgqjMv4bCE3jR8YlTXst4dMzpuOEe4QIjEYcyC3qKWxIvxU+TMdg0pyk7n7GBvxWFQ=="],
 
-    "@wormhole-foundation/sdk-evm-tbtc": ["@wormhole-foundation/sdk-evm-tbtc@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-evm": "4.12.2", "@wormhole-foundation/sdk-evm-core": "4.12.2", "ethers": "^6.5.1" } }, "sha512-lDh8XaZrf0II/KQEyUp/tceuE5rLXQnGtnj4vNcHiDDMMY6tSEw1egXPYmvNXhVUKLvv4TqLZFHrTDfzYqSfXA=="],
+    "@wormhole-foundation/sdk-evm-tbtc": ["@wormhole-foundation/sdk-evm-tbtc@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-evm": "4.16.0", "@wormhole-foundation/sdk-evm-core": "4.16.0", "ethers": "^6.5.1" } }, "sha512-Rrok/b16Fp5gmos6UYCJNsMTgJ2o/pL9L9L7xIo79v3KeoJTWOm5CpVtlEJtriF8rm7wkuilRwoqi6r/HbVYQg=="],
 
-    "@wormhole-foundation/sdk-evm-tokenbridge": ["@wormhole-foundation/sdk-evm-tokenbridge@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-evm": "4.12.2", "@wormhole-foundation/sdk-evm-core": "4.12.2", "ethers": "^6.5.1" } }, "sha512-yKg4dKo5koOJMXWbPj1AT1LEDMxqajsAEyLKMP+4s2eQhCp42b+BhTgoqFAvsjRbnC96nr+/6Ggrf/njK679cQ=="],
+    "@wormhole-foundation/sdk-evm-tokenbridge": ["@wormhole-foundation/sdk-evm-tokenbridge@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-evm": "4.16.0", "@wormhole-foundation/sdk-evm-core": "4.16.0", "ethers": "^6.5.1" } }, "sha512-SrxMjP1N5/MMe/2HnpTWF9VqnBY6qW0LAFqZ1il+B2onpCVzYwRxosCMh7uIpp1MtqAkEFS5M/3LYSytJItD+Q=="],
 
     "@wormhole-foundation/sdk-examples-ntt": ["@wormhole-foundation/sdk-examples-ntt@workspace:sdk/examples"],
 
     "@wormhole-foundation/sdk-route-ntt": ["@wormhole-foundation/sdk-route-ntt@workspace:sdk/route"],
 
-    "@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.12.2", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.12.2", "rpc-websockets": "^7.10.0" } }, "sha512-x6KMaMmsyowfavTbX0xFk0YipVbQY6mLR70phc0Vel9hmFzabskO6pD8Dy9S0eTsGE5mhAXUm9tkPaIBMG0BQw=="],
+    "@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.16.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.16.0", "rpc-websockets": "^7.10.0" } }, "sha512-dbEuRkDoJht7JfiRzQDqv5ay3LgDfGzDJSkkj4zinVTGDr7eKE7xrqBbAaAYLpo1ad9YI2vS98+FKquweW3PvA=="],
 
-    "@wormhole-foundation/sdk-solana-cctp": ["@wormhole-foundation/sdk-solana-cctp@4.12.2", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-solana": "4.12.2" } }, "sha512-KOy4BA+1LFOJOgVaID61jheUhgJQhirtTC6GBuXA11WKbRsvtLOqwZpKaM/I0viMfxi1lUbVA9blblfMKw4LeQ=="],
+    "@wormhole-foundation/sdk-solana-cctp": ["@wormhole-foundation/sdk-solana-cctp@4.16.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-solana": "4.16.0" } }, "sha512-7Yf9QeYsIEEJEnRhdTr0trcL8R1E37koqSAWU7RlufAgdQ1u7YxI76Ph8VIEtN+N1I8L8XDSB042eRDJZ2S6nA=="],
 
-    "@wormhole-foundation/sdk-solana-core": ["@wormhole-foundation/sdk-solana-core@4.12.2", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-solana": "4.12.2" } }, "sha512-wx90bpv+ntZbu5xPBo70KXwPGHFOQWN+/8+MxoDjTYb2PVPx2zPcwu+G/9pjD8IqLwXViSGduUTOhwBrKP6WIg=="],
+    "@wormhole-foundation/sdk-solana-core": ["@wormhole-foundation/sdk-solana-core@4.16.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-solana": "4.16.0" } }, "sha512-e069yWvZbLWf7qKjftmLV3LYfRnntDCj29aDxenduUN9EhwkehO/UMILCu7BxRieSOoLAIQep2+7tikfp1MUTQ=="],
 
     "@wormhole-foundation/sdk-solana-ntt": ["@wormhole-foundation/sdk-solana-ntt@workspace:solana"],
 
-    "@wormhole-foundation/sdk-solana-tbtc": ["@wormhole-foundation/sdk-solana-tbtc@4.12.2", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-solana": "4.12.2", "@wormhole-foundation/sdk-solana-core": "4.12.2", "@wormhole-foundation/sdk-solana-tokenbridge": "4.12.2" } }, "sha512-1IEzinA5FdXKl4C3/GAF9tFWHjl2aHmGlkw5/CFcvVnwph3CHIpL0VHIr5y7UsSjxnc89eqHEGtogJaKHOqwuA=="],
+    "@wormhole-foundation/sdk-solana-tbtc": ["@wormhole-foundation/sdk-solana-tbtc@4.16.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-solana": "4.16.0", "@wormhole-foundation/sdk-solana-core": "4.16.0", "@wormhole-foundation/sdk-solana-tokenbridge": "4.16.0" } }, "sha512-NvPyDXp9gRRCQ9F/WLn5ULk/BxWOysdLFhRhXVKd7BfWnUdqFiniprJhP2qkg7L6V7v0Y/F30J14kCg682kv4Q=="],
 
-    "@wormhole-foundation/sdk-solana-tokenbridge": ["@wormhole-foundation/sdk-solana-tokenbridge@4.12.2", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-solana": "4.12.2", "@wormhole-foundation/sdk-solana-core": "4.12.2" } }, "sha512-0h3eFNhx9p0KFa8SPFNrsn7KiOhs9XdpFHzbVpin5/fl8jpHHVcVG3vXifsNpkzh3AmhBT7fc4ja1NaBmjiOmg=="],
+    "@wormhole-foundation/sdk-solana-tokenbridge": ["@wormhole-foundation/sdk-solana-tokenbridge@4.16.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-solana": "4.16.0", "@wormhole-foundation/sdk-solana-core": "4.16.0" } }, "sha512-vX2ze0Mu4DPpOGdJZCLdeEHdYqiIQFxIK0FHxuedX/GXkLELGWSntkByD1L+/FVyXo1PBLexg5uwHu8yxqjekw=="],
 
-    "@wormhole-foundation/sdk-stacks": ["@wormhole-foundation/sdk-stacks@4.12.2", "", { "dependencies": { "@stacks/network": "^7.0.2", "@stacks/transactions": "^7.1.0", "@wormhole-foundation/sdk-connect": "4.12.2" } }, "sha512-vlBwbDcuhlNEIDpHRyxsaZojcU+US6B55ZIPVYXMGUggqva4SEZAZcRbiUfaumZRMutTSwsYqa137th2vbmImw=="],
+    "@wormhole-foundation/sdk-stacks": ["@wormhole-foundation/sdk-stacks@4.16.0", "", { "dependencies": { "@stacks/network": "^7.0.2", "@stacks/transactions": "^7.1.0", "@wormhole-foundation/sdk-connect": "4.16.0" } }, "sha512-cQn/P4e9Aep6W2vEYVc9T3b/2ynVqvY/A7HsyMtJx7i9vn3TVXOTd9xgDzoHN159//LMtEn/+pzX/ePrKt7n6w=="],
 
-    "@wormhole-foundation/sdk-stacks-core": ["@wormhole-foundation/sdk-stacks-core@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-stacks": "4.12.2" } }, "sha512-RlkdLYkyqO8GWTkPg+oEgMs7TYzaMNzCu6JSxDJbhMlxnyXaVIcbOzLJWQ3L2zoII0sK7Fevt5cGAAcFAqBKjQ=="],
+    "@wormhole-foundation/sdk-stacks-core": ["@wormhole-foundation/sdk-stacks-core@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-stacks": "4.16.0" } }, "sha512-t4HDnS7ThA42nJRfvk6W6nomT7y8Wkys2R5ttwl6wKGC1Dr2kNI8WjaVWi/j8M6bM+wY8Jn3XSpDZeZUvjt46A=="],
 
     "@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.12.2", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.12.2" } }, "sha512-pVBd2X4JYIET7dPaQQVit99+aPC37x2NvcuECP1aLblFHBZ0v2ZKb3Pg/qwKafRF0qYmB/vwPxRaolA4sHU1rg=="],
 
-    "@wormhole-foundation/sdk-sui-cctp": ["@wormhole-foundation/sdk-sui-cctp@4.12.2", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-sui": "4.12.2" } }, "sha512-iKw0NCOvCCSDLA4eOC3FT6WizLyfa8YuU5r62Ch16jxPLIKEEQR48nTz8q+c6LvhIcphKw7MR2YXOHd5Cx9rqQ=="],
+    "@wormhole-foundation/sdk-sui-cctp": ["@wormhole-foundation/sdk-sui-cctp@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-sui": "4.16.0" } }, "sha512-0ji1yuK3GTLVGeklzh96/lwQTYBYKCqcG3wTztydQL1tFsVup7u/2TpZHDUQVZKIrazXjQZ5AyVRu6TV+e2ngw=="],
 
     "@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.12.2", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-sui": "4.12.2" } }, "sha512-2EogRRpSAPfVNvSAL12cg49WW5n5JmTJ7xcTug1nQgIoKA/S164fokCLN5IVP6bb2DHjd3z9QDlAR9qShD/OQg=="],
 
     "@wormhole-foundation/sdk-sui-ntt": ["@wormhole-foundation/sdk-sui-ntt@workspace:sui/ts"],
 
-    "@wormhole-foundation/sdk-sui-tokenbridge": ["@wormhole-foundation/sdk-sui-tokenbridge@4.12.2", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.12.2", "@wormhole-foundation/sdk-sui": "4.12.2", "@wormhole-foundation/sdk-sui-core": "4.12.2" } }, "sha512-aMWcqzkN3Ijm7XI1vluEKUJN0WW8uGX8Gm6P6d3ZVmMdBUXbGHXM+oLfTWXJGfB5pBVu5bRTmPETdguXFizb4Q=="],
+    "@wormhole-foundation/sdk-sui-tokenbridge": ["@wormhole-foundation/sdk-sui-tokenbridge@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-sui": "4.16.0", "@wormhole-foundation/sdk-sui-core": "4.16.0" } }, "sha512-y4mFxLf/4ctIYR2JxyIMKspEWLi95ZRD69ecdManD0JyX3qzZr5B+DZRsyjnZ/vyo0Oum6sUDnkgs1lxTKfPbw=="],
 
     "@wormhole-foundation/sdk-xrpl": ["@wormhole-foundation/sdk-xrpl@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.12.2", "xrpl": "^4.2.0" } }, "sha512-ur683trHjv8KYbu2nsU98mBlzHJyUXL7DcCmDxQhp87mm9xWtBu2TuuP0/hWm0PA+b7oyBBP5NKBFQgZACfvIg=="],
 
@@ -1856,6 +1856,12 @@
 
     "@types/ws/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
 
+    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0" } }, "sha512-toYAx6uhLh1a2fBmBkomPry5RnegxWQ/zB5u7zCpZZ5KigF5f4HV+Kvw1B1wjRdn9QPkIwKyNir2a13iibjEcg=="],
+
+    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-sui": "4.16.0" } }, "sha512-j4feCkaSNipBifbiq7rI1wu0TNyNk+m+HATh+9/hQ9DvlCToXmBvOJkoGsOQ/DmR0MBbuyZA0VBSdBMzvXv3Jw=="],
+
+    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-xrpl": ["@wormhole-foundation/sdk-xrpl@4.16.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.16.0", "xrpl": "^4.2.0" } }, "sha512-bPp2WuCe+ZLu9W17faci8vsnzyD0F/39gbRuafBJnq1LYlq9u9Psthe3E7dHMUSWdo7H3N9SDa0Fdc19bf2Jpg=="],
+
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
@@ -1875,6 +1881,22 @@
     "@wormhole-foundation/sdk-solana/rpc-websockets": ["rpc-websockets@7.11.2", "", { "dependencies": { "eventemitter3": "^4.0.7", "uuid": "^8.3.2", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" } }, "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ=="],
 
     "@wormhole-foundation/sdk-solana-ntt/@solana/spl-token": ["@solana/spl-token@0.4.0", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-metadata": "^0.1.2", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.89.1" } }, "sha512-jjBIBG9IsclqQVl5Y82npGE6utdCh7Z9VFcF5qgJa5EUq2XgspW3Dt1wujWjH/vQDRnkp9zGO+BqQU/HhX/3wg=="],
+
+    "@wormhole-foundation/sdk-sui/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.12.2", "@wormhole-foundation/sdk-definitions": "4.12.2", "axios": "^1.4.0" } }, "sha512-IAc4qJqxWDUlPszWXCb0etVzWVtz8DFVXzqTOiSSvBMUzX/13OaRNM4B2jPmQb1JZARluT0Q49GpcbrEKttgGw=="],
+
+    "@wormhole-foundation/sdk-sui-cctp/@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0" } }, "sha512-toYAx6uhLh1a2fBmBkomPry5RnegxWQ/zB5u7zCpZZ5KigF5f4HV+Kvw1B1wjRdn9QPkIwKyNir2a13iibjEcg=="],
+
+    "@wormhole-foundation/sdk-sui-core/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.12.2", "@wormhole-foundation/sdk-definitions": "4.12.2", "axios": "^1.4.0" } }, "sha512-IAc4qJqxWDUlPszWXCb0etVzWVtz8DFVXzqTOiSSvBMUzX/13OaRNM4B2jPmQb1JZARluT0Q49GpcbrEKttgGw=="],
+
+    "@wormhole-foundation/sdk-sui-tokenbridge/@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0" } }, "sha512-toYAx6uhLh1a2fBmBkomPry5RnegxWQ/zB5u7zCpZZ5KigF5f4HV+Kvw1B1wjRdn9QPkIwKyNir2a13iibjEcg=="],
+
+    "@wormhole-foundation/sdk-sui-tokenbridge/@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.16.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.16.0", "@wormhole-foundation/sdk-sui": "4.16.0" } }, "sha512-j4feCkaSNipBifbiq7rI1wu0TNyNk+m+HATh+9/hQ9DvlCToXmBvOJkoGsOQ/DmR0MBbuyZA0VBSdBMzvXv3Jw=="],
+
+    "@wormhole-foundation/sdk-xrpl/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.12.2", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.12.2", "@wormhole-foundation/sdk-definitions": "4.12.2", "axios": "^1.4.0" } }, "sha512-IAc4qJqxWDUlPszWXCb0etVzWVtz8DFVXzqTOiSSvBMUzX/13OaRNM4B2jPmQb1JZARluT0Q49GpcbrEKttgGw=="],
+
+    "@wormhole-foundation/sdk-xrpl-ntt/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.12.2", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-GbCxnsCz8NGBeLB8niTosFPBqozpDKxoafuO2SR3GZcvwYrdkCObFdB6CK210if6ZghpnXLeP3KAJd17GSkL9w=="],
+
+    "@wormhole-foundation/sdk-xrpl-ntt/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.12.2", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.12.2" } }, "sha512-oRZTwZcbSxbBF+/9GyT2AFLvXXRAtKfr2LbGcPIUZH247Qna8KZOUbArdR4bPzjcSyBNY+9q87MoPdTFDcys6w=="],
 
     "@wormhole-foundation/wormchain-sdk/axios": ["axios@0.26.1", "", { "dependencies": { "follow-redirects": "^1.14.8" } }, "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA=="],
 
@@ -2423,6 +2445,18 @@
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
+
+    "@wormhole-foundation/sdk-sui-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.12.2", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-GbCxnsCz8NGBeLB8niTosFPBqozpDKxoafuO2SR3GZcvwYrdkCObFdB6CK210if6ZghpnXLeP3KAJd17GSkL9w=="],
+
+    "@wormhole-foundation/sdk-sui-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.12.2", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.12.2" } }, "sha512-oRZTwZcbSxbBF+/9GyT2AFLvXXRAtKfr2LbGcPIUZH247Qna8KZOUbArdR4bPzjcSyBNY+9q87MoPdTFDcys6w=="],
+
+    "@wormhole-foundation/sdk-sui/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.12.2", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-GbCxnsCz8NGBeLB8niTosFPBqozpDKxoafuO2SR3GZcvwYrdkCObFdB6CK210if6ZghpnXLeP3KAJd17GSkL9w=="],
+
+    "@wormhole-foundation/sdk-sui/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.12.2", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.12.2" } }, "sha512-oRZTwZcbSxbBF+/9GyT2AFLvXXRAtKfr2LbGcPIUZH247Qna8KZOUbArdR4bPzjcSyBNY+9q87MoPdTFDcys6w=="],
+
+    "@wormhole-foundation/sdk-xrpl/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.12.2", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-GbCxnsCz8NGBeLB8niTosFPBqozpDKxoafuO2SR3GZcvwYrdkCObFdB6CK210if6ZghpnXLeP3KAJd17GSkL9w=="],
+
+    "@wormhole-foundation/sdk-xrpl/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.12.2", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.12.2" } }, "sha512-oRZTwZcbSxbBF+/9GyT2AFLvXXRAtKfr2LbGcPIUZH247Qna8KZOUbArdR4bPzjcSyBNY+9q87MoPdTFDcys6w=="],
 
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util": ["jest-util@27.5.1", "", { "dependencies": { "@jest/types": "^27.5.1", "@types/node": "*", "chalk": "^4.0.0", "ci-info": "^3.2.0", "graceful-fs": "^4.2.9", "picomatch": "^2.2.3" } }, "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -24,14 +24,14 @@
     "yargs": "18.0.0"
   },
   "overrides": {
-    "@wormhole-foundation/sdk-base": "^4.12.2",
-    "@wormhole-foundation/sdk-definitions": "^4.12.2",
-    "@wormhole-foundation/sdk-evm": "^4.12.2",
-    "@wormhole-foundation/sdk-evm-core": "^4.12.2",
-    "@wormhole-foundation/sdk-connect": "^4.12.2",
-    "@wormhole-foundation/sdk-solana": "^4.12.2",
-    "@wormhole-foundation/sdk-solana-core": "^4.12.2",
-    "@wormhole-foundation/sdk-sui": "^4.12.2",
-    "@wormhole-foundation/sdk-sui-core": "^4.12.2"
+    "@wormhole-foundation/sdk-base": "^4.16.0",
+    "@wormhole-foundation/sdk-definitions": "^4.16.0",
+    "@wormhole-foundation/sdk-evm": "^4.16.0",
+    "@wormhole-foundation/sdk-evm-core": "^4.16.0",
+    "@wormhole-foundation/sdk-connect": "^4.16.0",
+    "@wormhole-foundation/sdk-solana": "^4.16.0",
+    "@wormhole-foundation/sdk-solana-core": "^4.16.0",
+    "@wormhole-foundation/sdk-sui": "^4.16.0",
+    "@wormhole-foundation/sdk-sui-core": "^4.16.0"
   }
 }

--- a/cli/src/__tests__/evm-helpers.test.ts
+++ b/cli/src/__tests__/evm-helpers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { getSlowFlag, getGasMultiplier } from "../evm/helpers";
 
 describe("getSlowFlag", () => {
-  const slowChains = ["Mezo", "HyperEVM", "XRPLEVM", "CreditCoin"] as const;
+  const slowChains = ["Mezo", "HyperEVM", "XRPLEVM", "CreditCoin", "Tempo"] as const;
   const normalChains = ["Ethereum", "Sepolia", "Base", "Arbitrum"] as const;
 
   test("returns --slow for known slow chains", () => {

--- a/cli/src/__tests__/evm-helpers.test.ts
+++ b/cli/src/__tests__/evm-helpers.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { getSlowFlag, getGasMultiplier } from "../evm/helpers";
 
 describe("getSlowFlag", () => {
-  const slowChains = ["Mezo", "HyperEVM", "XRPLEVM", "CreditCoin", "Tempo"] as const;
+  const slowChains = [
+    "Mezo",
+    "HyperEVM",
+    "XRPLEVM",
+    "CreditCoin",
+    "Tempo",
+  ] as const;
   const normalChains = ["Ethereum", "Sepolia", "Base", "Arbitrum"] as const;
 
   test("returns --slow for known slow chains", () => {

--- a/cli/src/evm/helpers.ts
+++ b/cli/src/evm/helpers.ts
@@ -141,7 +141,8 @@ export function getSlowFlag(chain: Chain): string {
   return chain === "Mezo" ||
     chain === "HyperEVM" ||
     chain == "XRPLEVM" ||
-    chain === "CreditCoin"
+    chain === "CreditCoin" ||
+    chain === "Tempo"
     ? "--slow"
     : "";
 }

--- a/evm/ts/package.json
+++ b/evm/ts/package.json
@@ -68,9 +68,9 @@
     }
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "^4.12.2",
-    "@wormhole-foundation/sdk-definitions": "^4.12.2",
-    "@wormhole-foundation/sdk-evm": "^4.12.2",
-    "@wormhole-foundation/sdk-evm-core": "^4.12.2"
+    "@wormhole-foundation/sdk-base": "^4.16.0",
+    "@wormhole-foundation/sdk-definitions": "^4.16.0",
+    "@wormhole-foundation/sdk-evm": "^4.16.0",
+    "@wormhole-foundation/sdk-evm-core": "^4.16.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@solana/web3.js": "^1.95.8",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.2",
-    "@wormhole-foundation/sdk": "4.12.2",
+    "@wormhole-foundation/sdk": "4.16.0",
     "@wormhole-foundation/wormchain-sdk": "^0.0.1",
     "ethers": "^6.5.1",
     "prettier": "3.6.2",

--- a/sdk/definitions/package.json
+++ b/sdk/definitions/package.json
@@ -51,7 +51,7 @@
   },
   "type": "module",
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "^4.12.2",
-    "@wormhole-foundation/sdk-definitions": "^4.12.2"
+    "@wormhole-foundation/sdk-base": "^4.16.0",
+    "@wormhole-foundation/sdk-definitions": "^4.16.0"
   }
 }

--- a/sdk/examples/package.json
+++ b/sdk/examples/package.json
@@ -34,7 +34,7 @@
     "tsx": "^4.7.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "^4.12.2",
+    "@wormhole-foundation/sdk": "^4.16.0",
     "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
     "@wormhole-foundation/sdk-evm-ntt": "1.0.0",
     "@wormhole-foundation/sdk-route-ntt": "1.0.0",

--- a/sdk/route/package.json
+++ b/sdk/route/package.json
@@ -51,7 +51,7 @@
     "@wormhole-foundation/sdk-solana-ntt": "1.0.0"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-connect": "^4.12.2",
+    "@wormhole-foundation/sdk-connect": "^4.16.0",
     "axios": "^1.9.0"
   },
   "type": "module",

--- a/solana/package.json
+++ b/solana/package.json
@@ -71,9 +71,9 @@
     }
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "^4.12.2",
-    "@wormhole-foundation/sdk-definitions": "^4.12.2",
-    "@wormhole-foundation/sdk-solana": "^4.12.2",
-    "@wormhole-foundation/sdk-solana-core": "^4.12.2"
+    "@wormhole-foundation/sdk-base": "^4.16.0",
+    "@wormhole-foundation/sdk-definitions": "^4.16.0",
+    "@wormhole-foundation/sdk-solana": "^4.16.0",
+    "@wormhole-foundation/sdk-solana-core": "^4.16.0"
   }
 }

--- a/sui/ts/package.json
+++ b/sui/ts/package.json
@@ -58,9 +58,9 @@
     }
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "^4.12.2",
-    "@wormhole-foundation/sdk-definitions": "^4.12.2",
-    "@wormhole-foundation/sdk-sui": "^4.12.2",
-    "@wormhole-foundation/sdk-sui-core": "^4.12.2"
+    "@wormhole-foundation/sdk-base": "^4.16.0",
+    "@wormhole-foundation/sdk-definitions": "^4.16.0",
+    "@wormhole-foundation/sdk-sui": "^4.16.0",
+    "@wormhole-foundation/sdk-sui-core": "^4.16.0"
   }
 }

--- a/xrpl/ts/package.json
+++ b/xrpl/ts/package.json
@@ -58,8 +58,8 @@
     }
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "4.12.2",
-    "@wormhole-foundation/sdk-definitions": "4.12.2",
-    "@wormhole-foundation/sdk-xrpl": "4.12.2"
+    "@wormhole-foundation/sdk-base": "^4.16.0",
+    "@wormhole-foundation/sdk-definitions": "^4.16.0",
+    "@wormhole-foundation/sdk-xrpl": "^4.16.0"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Wormhole Foundation SDK and SDK-Connect dependency ranges to 4.16.0 across CLI, core, examples, and route packages for compatibility.

* **Bug Fixes**
  * Added Tempo to slow-flag handling so transactions on Tempo use the --slow option.

* **Tests**
  * Improved end-to-end test robustness: increased Anvil startup timeout, capture stderr, and detect early Anvil failures during readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->