### PR TITLE
fix(cli): handle zero-baseFee chains and raise default gasLimit

### DIFF
--- a/cli/src/__tests__/evm-signer.test.ts
+++ b/cli/src/__tests__/evm-signer.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { Signer as EthersSigner, TransactionRequest } from "ethers";
+import { EvmNativeSigner, buildGasOpts } from "../evm/signer";
+
+const HIGH_MAX_FEE = 5_000_000_000n; // 5 gwei (any value > 50_000_000n)
+const LOW_MAX_FEE = 1n; // BSC post-Lorentz shape
+const DEFAULT_FALLBACK_GAS_PRICE = 200_000_000_000n; // module-internal default
+const DEFAULT_FALLBACK_MAX_FEE = 6_000_000_000n;
+const DEFAULT_FALLBACK_PRIO = 1_000_000_000n;
+
+type CapturedTx = TransactionRequest & {
+  gasLimit?: bigint;
+  gasPrice?: bigint;
+  maxFeePerGas?: bigint;
+  maxPriorityFeePerGas?: bigint;
+  type?: number;
+};
+
+function makeFakeSigner(opts?: {
+  feeData?: {
+    gasPrice?: bigint | null;
+    maxFeePerGas?: bigint | null;
+    maxPriorityFeePerGas?: bigint | null;
+  };
+  failGetFeeData?: boolean;
+}) {
+  const captured: CapturedTx[] = [];
+  const getFeeData = mock(async () => {
+    if (opts?.failGetFeeData) throw new Error("RPC down");
+    return {
+      gasPrice: opts?.feeData?.gasPrice ?? null,
+      maxFeePerGas: opts?.feeData?.maxFeePerGas ?? null,
+      maxPriorityFeePerGas: opts?.feeData?.maxPriorityFeePerGas ?? null,
+    };
+  });
+  const signer = {
+    provider: { getFeeData },
+    getNonce: mock(async () => 0),
+    signTransaction: mock(async (t: CapturedTx) => {
+      captured.push(t);
+      return "0xsigned";
+    }),
+  } as unknown as EthersSigner;
+  return { signer, captured, getFeeData };
+}
+
+function makeUnsignedTx(): any {
+  return {
+    transaction: {
+      to: "0x0000000000000000000000000000000000000001",
+      data: "0x",
+    },
+    description: "test",
+    network: "Mainnet",
+    chain: "Ethereum",
+    parallelizable: false,
+  };
+}
+
+describe("buildGasOpts", () => {
+  test("uses EIP-1559 path when maxFeePerGas is above sanity floor", () => {
+    const opts = buildGasOpts(3_000_000n, {
+      gasPrice: 7n,
+      maxFeePerGas: HIGH_MAX_FEE,
+      maxPriorityFeePerGas: 1_000_000_000n,
+    });
+    expect(opts.gasLimit).toBe(3_000_000n);
+    expect(opts.maxFeePerGas).toBe(HIGH_MAX_FEE);
+    expect(opts.maxPriorityFeePerGas).toBe(1_000_000_000n);
+    expect(opts.gasPrice).toBe(7n); // preserved for backward compat
+    expect(opts.type).toBeUndefined();
+  });
+
+  test("falls back to legacy when maxFeePerGas < sanity floor (BSC post-Lorentz)", () => {
+    const opts = buildGasOpts(3_000_000n, {
+      gasPrice: 50_000_000n, // BSC node minimum, below 1 gwei floor
+      maxFeePerGas: LOW_MAX_FEE,
+      maxPriorityFeePerGas: 1n,
+    });
+    expect(opts.type).toBe(0);
+    expect(opts.gasPrice).toBe(1_000_000_000n); // clamped to LEGACY_FALLBACK_GAS_PRICE
+    expect(opts.gasLimit).toBe(3_000_000n);
+    expect(opts.maxFeePerGas).toBeUndefined();
+    expect(opts.maxPriorityFeePerGas).toBeUndefined();
+  });
+
+  test("legacy path preserves provider gasPrice when above the floor", () => {
+    const provider = 5_000_000_000n;
+    const opts = buildGasOpts(3_000_000n, {
+      gasPrice: provider,
+      maxFeePerGas: LOW_MAX_FEE,
+      maxPriorityFeePerGas: 1n,
+    });
+    expect(opts.type).toBe(0);
+    expect(opts.gasPrice).toBe(provider);
+  });
+
+  test("threshold is exclusive: maxFeePerGas == floor stays on EIP-1559 path", () => {
+    const opts = buildGasOpts(3_000_000n, {
+      gasPrice: 1n,
+      maxFeePerGas: 50_000_000n,
+      maxPriorityFeePerGas: 1n,
+    });
+    expect(opts.type).toBeUndefined();
+    expect(opts.maxFeePerGas).toBe(50_000_000n);
+  });
+});
+
+describe("EvmNativeSigner.sign — gas options", () => {
+  test("default chain uses 3M gasLimit", async () => {
+    const { signer, captured } = makeFakeSigner({
+      feeData: {
+        gasPrice: HIGH_MAX_FEE,
+        maxFeePerGas: HIGH_MAX_FEE,
+        maxPriorityFeePerGas: 1_000_000_000n,
+      },
+    });
+    const sut = new EvmNativeSigner("Ethereum", "0xabc", signer);
+    await sut.sign([makeUnsignedTx()]);
+    expect(captured[0].gasLimit).toBe(3_000_000n);
+    expect(captured[0].maxFeePerGas).toBe(HIGH_MAX_FEE);
+    expect(captured[0].type).toBeUndefined();
+  });
+
+  test("opts.maxGasLimit overrides the default on the catch-all branch", async () => {
+    const { signer, captured } = makeFakeSigner({
+      feeData: {
+        gasPrice: HIGH_MAX_FEE,
+        maxFeePerGas: HIGH_MAX_FEE,
+        maxPriorityFeePerGas: 1_000_000_000n,
+      },
+    });
+    const sut = new EvmNativeSigner("Ethereum", "0xabc", signer, {
+      maxGasLimit: 42n,
+    });
+    await sut.sign([makeUnsignedTx()]);
+    expect(captured[0].gasLimit).toBe(42n);
+  });
+
+  test("Mantle and ArbitrumSepolia keep their specialized gasLimits regardless of override", async () => {
+    for (const [chain, expected] of [
+      ["Mantle", 2600_000_000_000n],
+      ["ArbitrumSepolia", 4_000_000n],
+    ] as const) {
+      const { signer, captured } = makeFakeSigner({
+        feeData: {
+          gasPrice: HIGH_MAX_FEE,
+          maxFeePerGas: HIGH_MAX_FEE,
+          maxPriorityFeePerGas: 1n,
+        },
+      });
+      const sut = new EvmNativeSigner(chain, "0xabc", signer, {
+        maxGasLimit: 1n, // ignored on these branches
+      });
+      await sut.sign([makeUnsignedTx()]);
+      expect(captured[0].gasLimit).toBe(expected);
+    }
+  });
+
+  test("BSC-shaped feeData (maxFeePerGas = 1) triggers legacy path with gasPrice floor", async () => {
+    const { signer, captured } = makeFakeSigner({
+      feeData: {
+        gasPrice: 50_000_000n, // BSC node minimum, below 1 gwei floor
+        maxFeePerGas: 1n,
+        maxPriorityFeePerGas: 1n,
+      },
+    });
+    const sut = new EvmNativeSigner("Bsc", "0xabc", signer);
+    await sut.sign([makeUnsignedTx()]);
+    expect(captured[0].type).toBe(0);
+    expect(captured[0].gasPrice).toBe(1_000_000_000n);
+    expect(captured[0].maxFeePerGas).toBeUndefined();
+    expect(captured[0].maxPriorityFeePerGas).toBeUndefined();
+  });
+
+  test("Celo skips getFeeData and uses fallback defaults on the EIP-1559 path", async () => {
+    const { signer, captured, getFeeData } = makeFakeSigner({
+      failGetFeeData: true, // would throw if called
+    });
+    const sut = new EvmNativeSigner("Celo", "0xabc", signer);
+    await sut.sign([makeUnsignedTx()]);
+    expect(getFeeData).not.toHaveBeenCalled();
+    expect(captured[0].gasPrice).toBe(DEFAULT_FALLBACK_GAS_PRICE);
+    expect(captured[0].maxFeePerGas).toBe(DEFAULT_FALLBACK_MAX_FEE);
+    expect(captured[0].maxPriorityFeePerGas).toBe(DEFAULT_FALLBACK_PRIO);
+    expect(captured[0].type).toBeUndefined();
+  });
+
+  test("getFeeData() throwing falls back to literal defaults instead of propagating", async () => {
+    const { signer, captured } = makeFakeSigner({ failGetFeeData: true });
+    const sut = new EvmNativeSigner("Ethereum", "0xabc", signer);
+    await sut.sign([makeUnsignedTx()]);
+    expect(captured[0].gasPrice).toBe(DEFAULT_FALLBACK_GAS_PRICE);
+    expect(captured[0].maxFeePerGas).toBe(DEFAULT_FALLBACK_MAX_FEE);
+    expect(captured[0].gasLimit).toBe(3_000_000n);
+  });
+});

--- a/cli/src/evm/signer.ts
+++ b/cli/src/evm/signer.ts
@@ -31,6 +31,56 @@ import type {
 } from "ethers";
 import { NonceManager, Wallet } from "ethers";
 
+// Default gas limit for the catch-all chain branch. Raised from 500k because
+// NttWithExecutor.transfer bundles token escrow + Wormhole message publish +
+// Executor relay instructions in a single transaction, realistically using
+// ~1.2-1.5M gas on mainnet EVM chains. The previous 500k default caused
+// silent out-of-gas reverts in token-transfer flows.
+const DEFAULT_GAS_LIMIT = 3_000_000n;
+
+// gasPrice floor used when the provider's EIP-1559 fee derivation is broken
+// (see EIP1559_FEE_SANITY_FLOOR below). 1 gwei is 20x BSC's 0.05 gwei node
+// minimum and remains inexpensive on every chain that hits this path.
+const LEGACY_FALLBACK_GAS_PRICE = 1_000_000_000n; // 1 gwei
+
+// Threshold (in wei) below which we treat the provider's maxFeePerGas as
+// nonsense and fall back to a legacy (type 0) transaction. The canonical
+// case is BSC post-Lorentz hardfork (mainnet, April 2025) where
+// baseFeePerGas = 0; ethers' getFeeData() then returns maxFeePerGas = 1 wei
+// and the node rejects with:
+//   [private transaction service] require GasPrice=50000000, Provide=1
+// Detecting by content (not by chain name) keeps this forward-compatible
+// with any future chain that exhibits the same shape.
+const EIP1559_FEE_SANITY_FLOOR = 50_000_000n; // 0.05 gwei
+
+type FeeData = {
+  gasPrice: bigint;
+  maxFeePerGas: bigint;
+  maxPriorityFeePerGas: bigint;
+};
+
+export function buildGasOpts(
+  gasLimit: bigint,
+  feeData: FeeData
+): Partial<TransactionRequest> {
+  if (feeData.maxFeePerGas < EIP1559_FEE_SANITY_FLOOR) {
+    return {
+      gasLimit,
+      gasPrice:
+        feeData.gasPrice > LEGACY_FALLBACK_GAS_PRICE
+          ? feeData.gasPrice
+          : LEGACY_FALLBACK_GAS_PRICE,
+      type: 0,
+    };
+  }
+  return {
+    gasLimit,
+    gasPrice: feeData.gasPrice,
+    maxFeePerGas: feeData.maxFeePerGas,
+    maxPriorityFeePerGas: feeData.maxPriorityFeePerGas,
+  };
+}
+
 export async function getEvmSigner(
   rpc: Provider,
   key: string | EthersSigner,
@@ -115,34 +165,37 @@ export class EvmNativeSigner<N extends Network, C extends EvmChains = EvmChains>
         gasLimit = 4_000_000n;
         break;
       default:
-        // default gas limit
-        gasLimit = this.opts?.maxGasLimit ?? 500_000n;
+        gasLimit = this.opts?.maxGasLimit ?? DEFAULT_GAS_LIMIT;
         break;
     }
 
-    // TODO: DIFF STARTS HERE
-
-    let gasPrice = 200_000_000_000n; // 200gwei
-    let maxFeePerGas = 6_000_000_000n; // 6gwei
-    let maxPriorityFeePerGas = 1000_000_000n; // 1gwei
+    let feeData: FeeData = {
+      gasPrice: 200_000_000_000n, // 200 gwei
+      maxFeePerGas: 6_000_000_000n, // 6 gwei
+      maxPriorityFeePerGas: 1_000_000_000n, // 1 gwei
+    };
 
     // Celo does not support this call
     if (chain !== "Celo") {
-      const feeData = await this._signer.provider!.getFeeData();
-      gasPrice = feeData.gasPrice ?? gasPrice;
-      maxFeePerGas = feeData.maxFeePerGas ?? maxFeePerGas;
-      maxPriorityFeePerGas =
-        feeData.maxPriorityFeePerGas ?? maxPriorityFeePerGas;
+      try {
+        const fetched = await this._signer.provider!.getFeeData();
+        feeData = {
+          gasPrice: fetched.gasPrice ?? feeData.gasPrice,
+          maxFeePerGas: fetched.maxFeePerGas ?? feeData.maxFeePerGas,
+          maxPriorityFeePerGas:
+            fetched.maxPriorityFeePerGas ?? feeData.maxPriorityFeePerGas,
+        };
+      } catch (e) {
+        if (this.opts?.debug) {
+          console.warn(
+            `getFeeData() failed for ${chain}; using fallback defaults`,
+            e
+          );
+        }
+      }
     }
 
-    const gasOpts = {
-      gasPrice,
-      maxFeePerGas,
-      maxPriorityFeePerGas,
-      gasLimit,
-    };
-
-    // TODO: DIFF ENDS HERE
+    const gasOpts = buildGasOpts(gasLimit, feeData);
 
     for (const txn of tx) {
       const { transaction, description } = txn;


### PR DESCRIPTION
## Summary

Two latent bugs in `cli/src/evm/signer.ts` (`EvmNativeSigner.sign`) reproduced during a Mainnet NTT v2.0.0 deployment on Monad ↔ BSC.

1. **Default catch-all `gasLimit` was too small for `NttWithExecutor.transfer`.** The flow bundles token escrow + Wormhole message publish + Executor relay instructions in a single transaction and realistically uses ~1.2–1.5M gas on mainnet EVM chains. The previous 500_000 default caused silent out-of-gas reverts on every token transfer.
2. **EIP-1559 fee derivation is broken on chains where `baseFeePerGas = 0`** (BSC post-Lorentz, April 2025). Ethers' `getFeeData()` returns `maxFeePerGas = 1 wei` and the BSC private-tx-service rejects with:
   ```
   [private transaction service] require GasPrice=50000000, Provide=1
   ```

## Fix

### Default gasLimit: 500_000n → 3_000_000n

Catch-all branch only. The `Mantle` (2.6T) and `ArbitrumSepolia` (4M) special cases are preserved. The `opts.maxGasLimit` override is preserved; callers passing an explicit value continue to get exactly that value.

### Content-based legacy-tx fallback (not chain-name)

Instead of hard-coding `chain === "Bsc"`, the broken EIP-1559 shape is detected by content:

```ts
if (feeData.maxFeePerGas < EIP1559_FEE_SANITY_FLOOR /* 50_000_000n = 0.05 gwei */) {
  // legacy (type 0) tx with gasPrice floor of 1 gwei
}
```

This auto-covers any future chain (or buggy provider response) exhibiting the same shape — fixed-fee chains, Linea-style quirks, future zero-baseFee L2s, etc. The 1 gwei floor is 20× BSC's 0.05 gwei minimum and remains inexpensive everywhere it applies.

### Other changes in this diff

- Hoist `DEFAULT_GAS_LIMIT`, `LEGACY_FALLBACK_GAS_PRICE`, `EIP1559_FEE_SANITY_FLOOR` to module scope (matches the existing convention used elsewhere in the CLI).
- Extract a small `buildGasOpts(gasLimit, feeData): Partial<TransactionRequest>` helper — typed (the previous `gasOpts` was implicitly `any`) and unit-testable in isolation.
- Wrap `getFeeData()` in `try/catch`. A transient RPC failure no longer fails the whole `sign()` call; it falls back to the literal defaults already defined in the function.
- Remove the stale `// TODO: DIFF STARTS HERE / DIFF ENDS HERE` markers (they wrapped the previous local divergence and no longer match the current shape).
- Fix bigint underscore inconsistency (`1000_000_000n` → `1_000_000_000n`).

## Repro (without this PR)

```bash
ntt token-transfer --network Mainnet \
  --source-chain Monad --destination-chain Bsc \
  --amount 1 --destination-address 0xRECIPIENT \
  --deployment-path ./deployment.json
```

Symptoms:
- Source-chain tx reverts with `gasUsed == 500000`, `status == 0`, no logs (out-of-gas).
- BSC-side ops (`ntt push` limit application, `set-outbound-limit`, `transfer-ownership`, etc.) fail at submission with the BSC private-tx-service error above.

> _Tx hashes from the live deployment available on request — happy to attach._

## Test plan

New file: `cli/src/__tests__/evm-signer.test.ts` (10 cases, `bun:test`).

`buildGasOpts` (pure):
- [x] EIP-1559 path when `maxFeePerGas` ≥ sanity floor — preserves all three fee fields, `type` undefined.
- [x] Legacy fallback when `maxFeePerGas < 50_000_000n` — `type: 0`, `maxFeePerGas`/`maxPriorityFeePerGas` absent.
- [x] Legacy path clamps low provider `gasPrice` up to `1_000_000_000n`.
- [x] Legacy path preserves provider `gasPrice` when above the floor.
- [x] Threshold is exclusive (`maxFeePerGas == floor` stays on EIP-1559 path).

`EvmNativeSigner.sign` (mocked end-to-end):
- [x] Default Ethereum-class chain → `gasLimit = 3_000_000n`, EIP-1559 fields, no `type`.
- [x] `opts.maxGasLimit = 42n` → captured `gasLimit === 42n`.
- [x] `Mantle` and `ArbitrumSepolia` keep their specialized `gasLimit` regardless of override.
- [x] BSC-shape feeData (`maxFeePerGas: 1n`) → `type: 0`, `gasPrice: 1_000_000_000n`, no 1559 fields.
- [x] `Celo` skips `getFeeData()` and uses fallback defaults.
- [x] `getFeeData()` throwing falls back to literal defaults instead of propagating.

Local validation:
- `bun run typecheck:cli` → exit 0
- `cd cli && bun test src/ __tests__/` → 166 pass, 2 skip, 0 fail across 15 files
- `prettier --check src/evm/signer.ts src/__tests__/evm-signer.test.ts` → clean

## Alternatives considered

- **`estimateGas + 20% buffer`** — arguably the root-cause fix. The block is already written and commented out in `signer.ts` (lines ~218–229) since 2024-06-27. Reviving it would remove the need for a static `gasLimit` default entirely. Out of scope here because of the larger blast radius; left as a follow-up.
- **`NttWithExecutor`'s own `gasLimitOverrides` map** (`evm/ts/src/nttWithExecutor.ts:80`) — those values describe the relayer's quoted gas (paid to the executor), which is orthogonal to the source-chain tx's `gasLimit`. Not applicable.
- **Hard-coded `chain === "Bsc"` check** — initial draft. Rejected because chain-name policy in a generic signer doesn't generalize; any other zero-baseFee chain (or buggy provider response) silently regresses. Content-based detection is one fewer code path per future chain.
- **Retry-on-underprice loop** — would catch the BSC error at submission and bump fees. Rejected because BSC's floor is deterministic post-Lorentz; an upfront floor is simpler and avoids an extra round-trip.
- **Env-var override (`NTT_DEFAULT_GAS_LIMIT`)** — added complexity for a knob no current caller exercises (`cli/src/signers/getSigner.ts:96` passes only `{ debug: true }`). The existing `opts.maxGasLimit` plumbing is the right place; threading it through belongs in a follow-up.

## Backwards compatibility

- The CLI is published with `bin: ntt` only — no `main`/`exports` in `cli/package.json`, so `EvmNativeSigner` / `getEvmSigner` are not part of any external API surface.
- Callers passing an explicit `opts.maxGasLimit` continue to get exactly that value.
- BSC receipts now have `type: 0` instead of `type: 2`. Anything outside this repo parsing `effectiveGasPrice` / `maxFeePerGas` from BSC receipts produced by the CLI would see legacy-shaped receipts; no such consumer exists in `cli/`.

## Follow-ups (intentionally out of scope)

- Re-enable `estimateGas + 20% buffer` (`cli/src/evm/signer.ts:218`); the static 3M default is symptom suppression and the underlying issue is that the signer doesn't estimate.
- Plumb `opts.maxGasLimit` through `cli/src/signers/getSigner.ts:96` (it currently passes only `{ debug: true }`, so the override has no CLI surface). Renaming to `defaultGasLimit` or making it a true upper-bound ceiling would also be useful.
- Add a per-chain `MAX_GAS_PRICE` ceiling so a malicious or misconfigured RPC returning an absurd `gasPrice` cannot cause silent operator overpayment.
- Per the long-standing TODO at `cli/src/evm/signer.ts:9`, this whole local copy of the SDK signer can likely be replaced by upstream `@wormhole-foundation/sdk-evm` after wormhole-sdk-ts PR #583. Worth a separate cleanup pass.

---

## Files in this PR

- `cli/src/evm/signer.ts` — refactor + fix.
- `cli/src/__tests__/evm-signer.test.ts` — new, 10 cases.

Diff stat: 2 files changed, 270 insertions(+), 20 deletions(-).