### PR TITLE
feat(cli): support precompile token deployment + Tempo gas limit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,25 +51,25 @@
         "typechain": "^8.3.2",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.17.0",
-        "@wormhole-foundation/sdk-definitions": "^4.17.0",
-        "@wormhole-foundation/sdk-evm": "^4.17.0",
-        "@wormhole-foundation/sdk-evm-core": "^4.17.0",
+        "@wormhole-foundation/sdk-base": "^4.17.1",
+        "@wormhole-foundation/sdk-definitions": "^4.17.1",
+        "@wormhole-foundation/sdk-evm": "^4.17.1",
+        "@wormhole-foundation/sdk-evm-core": "^4.17.1",
       },
     },
     "sdk/definitions": {
       "name": "@wormhole-foundation/sdk-definitions-ntt",
       "version": "1.0.0",
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.17.0",
-        "@wormhole-foundation/sdk-definitions": "^4.17.0",
+        "@wormhole-foundation/sdk-base": "^4.17.1",
+        "@wormhole-foundation/sdk-definitions": "^4.17.1",
       },
     },
     "sdk/examples": {
       "name": "@wormhole-foundation/sdk-examples-ntt",
       "version": "1.0.0",
       "dependencies": {
-        "@wormhole-foundation/sdk": "^4.17.0",
+        "@wormhole-foundation/sdk": "^4.17.1",
         "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
         "@wormhole-foundation/sdk-evm-ntt": "1.0.0",
         "@wormhole-foundation/sdk-route-ntt": "1.0.0",
@@ -97,7 +97,7 @@
         "ts-node": "^10.9.2",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-connect": "^4.17.0",
+        "@wormhole-foundation/sdk-connect": "^4.17.1",
         "axios": "^1.9.0",
       },
     },
@@ -120,10 +120,10 @@
         "tsx": "^4.7.2",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.17.0",
-        "@wormhole-foundation/sdk-definitions": "^4.17.0",
-        "@wormhole-foundation/sdk-solana": "^4.17.0",
-        "@wormhole-foundation/sdk-solana-core": "^4.17.0",
+        "@wormhole-foundation/sdk-base": "^4.17.1",
+        "@wormhole-foundation/sdk-definitions": "^4.17.1",
+        "@wormhole-foundation/sdk-solana": "^4.17.1",
+        "@wormhole-foundation/sdk-solana-core": "^4.17.1",
       },
     },
     "sui/ts": {
@@ -134,10 +134,10 @@
         "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.17.0",
-        "@wormhole-foundation/sdk-definitions": "^4.17.0",
-        "@wormhole-foundation/sdk-sui": "^4.17.0",
-        "@wormhole-foundation/sdk-sui-core": "^4.17.0",
+        "@wormhole-foundation/sdk-base": "^4.17.1",
+        "@wormhole-foundation/sdk-definitions": "^4.17.1",
+        "@wormhole-foundation/sdk-sui": "^4.17.1",
+        "@wormhole-foundation/sdk-sui-core": "^4.17.1",
       },
     },
     "xrpl/ts": {
@@ -148,9 +148,9 @@
         "xrpl": "^4.6.0",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.17.0",
-        "@wormhole-foundation/sdk-definitions": "^4.17.0",
-        "@wormhole-foundation/sdk-xrpl": "^4.17.0",
+        "@wormhole-foundation/sdk-base": "^4.17.1",
+        "@wormhole-foundation/sdk-definitions": "^4.17.1",
+        "@wormhole-foundation/sdk-xrpl": "^4.17.1",
       },
     },
   },
@@ -698,11 +698,11 @@
 
     "@wormhole-foundation/sdk-aptos-tokenbridge": ["@wormhole-foundation/sdk-aptos-tokenbridge@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.17.1", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-mNY+XGummeZYVqr+LHpBMkRaocosf3QjIrj9Co1wJ57P9F4PSaOnrWc0WE7I0Ox3GayDi5cglGyf2yHAypetvQ=="],
 
-    "@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.0", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-c+dnUJWLk67wnnAhJluS+G5H/76oQ2RpGmx0JcFIU0LR3FooMeS9swS3kJglqw7dutjIkIGUv/K9J13/+0SKqA=="],
+    "@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
 
     "@wormhole-foundation/sdk-btc": ["@wormhole-foundation/sdk-btc@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-x17Yjy2ofowbEqx0I2yhmy8gmu2yQGSrcS98rfNxRHrGvngkLVwQQd/QeJdP+rdKYi73lIekt0LSMMSALFg8GA=="],
 
-    "@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.0", "@wormhole-foundation/sdk-definitions": "4.17.0", "axios": "^1.4.0" } }, "sha512-mERYuazxyF3f+70oNInd3jwno9LJH+TzIURZQBwLMMMK7v7kqyBDXjamoNTdks5Hd+ctQ1BhQI95FLgjc2SBiw=="],
+    "@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
 
     "@wormhole-foundation/sdk-cosmwasm": ["@wormhole-foundation/sdk-cosmwasm@4.17.1", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/proto-signing": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.1", "cosmjs-types": "^0.9.0" } }, "sha512-+AYKTE/Q/8GiH1F6Mx5XBMH7Qg5pK2ODxpKbZ+jk/50n07shS/sJunS0v5Z/WzVZKgFkbZ5usiJ+V/3Anu2a/Q=="],
 
@@ -712,15 +712,15 @@
 
     "@wormhole-foundation/sdk-cosmwasm-tokenbridge": ["@wormhole-foundation/sdk-cosmwasm-tokenbridge@4.17.1", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-cosmwasm": "4.17.1" } }, "sha512-5JgWwAGI5KdRqAbWfhnIFFb/2cGkMY/86aSbD/YOYcpeLF+Cy9p6oCM0Sywo9qGJ6o9XWUql/y+cfGrfAAtPjA=="],
 
-    "@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.0", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.0" } }, "sha512-GqzHCar6BemFA17y7JEPWoaYCOBtI9XGiuFhuib+3zuc6T4w59BXYi5mIJE/Ci+IesQM0JIukdlBlEg9jWHKQg=="],
+    "@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
 
     "@wormhole-foundation/sdk-definitions-ntt": ["@wormhole-foundation/sdk-definitions-ntt@workspace:sdk/definitions"],
 
-    "@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "ethers": "^6.5.1" } }, "sha512-ewYYruUkp7Ou6BRyhUnfAPSNdw3ToOpVDBQWtAZmjBE2AmZaxhMI1W9OkFd85S0NSKjFfNC3VqRFOq5Lx2pHgg=="],
+    "@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "ethers": "^6.5.1" } }, "sha512-cfJD2oAYyWauN6QdgDnSogTq+BOjc11mBM8liET/rJwhvkpJS8PCO8NIzljS/6zsZoTcPMDhKle2CXtx/CSd8w=="],
 
     "@wormhole-foundation/sdk-evm-cctp": ["@wormhole-foundation/sdk-evm-cctp@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "@wormhole-foundation/sdk-evm-core": "4.17.1", "ethers": "^6.5.1" } }, "sha512-TbU44du4hJ13vUDqz4yBZvbq5v7Aj7TfkiR+SL795YzrLnDbfL2+qKBu5tbzgbFU90H2xeOLd0lHyM09G+hCQA=="],
 
-    "@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-evm": "4.17.0", "ethers": "^6.5.1" } }, "sha512-9bGqvr3SUSZd4KKeVG+moNOjKhLsW72zambhNIdGlfYgKSVCOsocYIBryaeShe1/tDLTJJneGLw36LQSjpnWcQ=="],
+    "@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "ethers": "^6.5.1" } }, "sha512-VdE3fi219iF5qmJFxA3SVZre9PijWJ89jR7x4X+wAeI5HISzWCDVdst3JaGxeXW9GqAFTXyufG4ITn2XJSrq+g=="],
 
     "@wormhole-foundation/sdk-evm-ntt": ["@wormhole-foundation/sdk-evm-ntt@workspace:evm/ts"],
 
@@ -734,11 +734,11 @@
 
     "@wormhole-foundation/sdk-route-ntt": ["@wormhole-foundation/sdk-route-ntt@workspace:sdk/route"],
 
-    "@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.17.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.0", "rpc-websockets": "^7.10.0" } }, "sha512-KakINbLBFVVQLKdSxePmNA54BQ7GMsCCaKwQmhPEt9aCtL5KaSWSnhAdyENUfK2ZeTMDQPzuQ4nlLUk1vQ3WKQ=="],
+    "@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "rpc-websockets": "^7.10.0" } }, "sha512-o8a9/IZ4++4niD0WVzhjvwz9hJF/T+EVzpqbixJ/ZujYHusVrvIU0yzzsBvL4wz8aM2y3374xz1WWTZ2OTyAsw=="],
 
     "@wormhole-foundation/sdk-solana-cctp": ["@wormhole-foundation/sdk-solana-cctp@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1" } }, "sha512-XnHnrvHEBCfM8bbMTVLcd8xc0FrhpZfcwnMXlv3RYIqwy8r5fO/DWyLHIcfCroC5Twljyxg1KEUtwfSrYVXanA=="],
 
-    "@wormhole-foundation/sdk-solana-core": ["@wormhole-foundation/sdk-solana-core@4.17.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-solana": "4.17.0" } }, "sha512-FmkLcDTTneGzjqcY8XCizONVWTLTVsDxFX1OnlMP6/8cJzn19hM+G2r/yDyO75mozr9ldxRVEux8GJ9vRI5Lbg=="],
+    "@wormhole-foundation/sdk-solana-core": ["@wormhole-foundation/sdk-solana-core@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1" } }, "sha512-mTTXro17kxFr7cxI44+SCcvhSZjzpI/3PMwK7x+tGl0U3NIpvepMDwsMa6tMGijdUKc1h47eXF+xRQlwpPjhnA=="],
 
     "@wormhole-foundation/sdk-solana-ntt": ["@wormhole-foundation/sdk-solana-ntt@workspace:solana"],
 
@@ -750,17 +750,17 @@
 
     "@wormhole-foundation/sdk-stacks-core": ["@wormhole-foundation/sdk-stacks-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-stacks": "4.17.1" } }, "sha512-aJAhdqNx4uUG7np4QdYAlLH169dSmQk7xCtG86/IIgYn2CWlw+AYCtr26+krseqj5W3494XaQ97JjDsZkfePLQ=="],
 
-    "@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.17.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-J539CELeOkxxMpBkhnMNPytiOBnsvIQznr5PoRLIlXF+Fit0Tn+IrdT/ok5O1ZwtRopd+rz5giblp4NLWtCkrg=="],
+    "@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-8w4BCSK6SdnucfZVjyiOSR4k82xL4l4ZGJFpePvtUZoA4wsg6Uai/F9yEqPnUI0QAe3zuTXju51AfDJP7TzKMg=="],
 
     "@wormhole-foundation/sdk-sui-cctp": ["@wormhole-foundation/sdk-sui-cctp@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-sui": "4.17.1" } }, "sha512-+mnj9ZTqMUDs/9u8JYPDiF/jKAGVmn0D+khsPAKgZRUKDYwBGTDeLH3mCXTl4dzbmOU4tsWglik0nEh67HQiAQ=="],
 
-    "@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.17.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-sui": "4.17.0" } }, "sha512-WXAPAw/jPFiyLtaSpeOQWqHnIx5teJlmlx0RFp+peU2cyHtavFpSziycVi2m4pHrhPce+t6V70mjt3jTtw+1wA=="],
+    "@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-sui": "4.17.1" } }, "sha512-3U64Men/4UVHZAru/xTZXTL0FbiU9JGL0d6EC6Fh5lMdo5EpGLmdlOAdwnr0UqEIHcWcBGdP3QNbzuWLHx2tFg=="],
 
     "@wormhole-foundation/sdk-sui-ntt": ["@wormhole-foundation/sdk-sui-ntt@workspace:sui/ts"],
 
     "@wormhole-foundation/sdk-sui-tokenbridge": ["@wormhole-foundation/sdk-sui-tokenbridge@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-sui": "4.17.1", "@wormhole-foundation/sdk-sui-core": "4.17.1" } }, "sha512-L4iR7kz03uA2VMemxMKi+ZgSqUBwkDD2fcHdSWRQpPIeWx6jfCFeckkfHLO1LpZdQ1Rrf680KdfzOuzICvAXpg=="],
 
-    "@wormhole-foundation/sdk-xrpl": ["@wormhole-foundation/sdk-xrpl@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "xrpl": "^4.2.0" } }, "sha512-id1rkqwZyrUbrJP9OOltXiUkyZSAHMbulZQUewhTelV+IWIj4ZoU7ErCnFUNfWZEmDRTfhmvKjSSDoIMm+31CA=="],
+    "@wormhole-foundation/sdk-xrpl": ["@wormhole-foundation/sdk-xrpl@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "xrpl": "^4.2.0" } }, "sha512-NniKnBFMrrvdBG0NqhQLu3r5pY3QyHvvb7TYuoOhAQTrRdzF9S+2S+yocmuKM3CFAvhIcs/VbGtI6nS9whu0lw=="],
 
     "@wormhole-foundation/sdk-xrpl-ntt": ["@wormhole-foundation/sdk-xrpl-ntt@workspace:xrpl/ts"],
 
@@ -1856,125 +1856,25 @@
 
     "@types/ws/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
 
-    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "ethers": "^6.5.1" } }, "sha512-cfJD2oAYyWauN6QdgDnSogTq+BOjc11mBM8liET/rJwhvkpJS8PCO8NIzljS/6zsZoTcPMDhKle2CXtx/CSd8w=="],
-
-    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "ethers": "^6.5.1" } }, "sha512-VdE3fi219iF5qmJFxA3SVZre9PijWJ89jR7x4X+wAeI5HISzWCDVdst3JaGxeXW9GqAFTXyufG4ITn2XJSrq+g=="],
-
-    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "rpc-websockets": "^7.10.0" } }, "sha512-o8a9/IZ4++4niD0WVzhjvwz9hJF/T+EVzpqbixJ/ZujYHusVrvIU0yzzsBvL4wz8aM2y3374xz1WWTZ2OTyAsw=="],
-
-    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-solana-core": ["@wormhole-foundation/sdk-solana-core@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1" } }, "sha512-mTTXro17kxFr7cxI44+SCcvhSZjzpI/3PMwK7x+tGl0U3NIpvepMDwsMa6tMGijdUKc1h47eXF+xRQlwpPjhnA=="],
-
-    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-8w4BCSK6SdnucfZVjyiOSR4k82xL4l4ZGJFpePvtUZoA4wsg6Uai/F9yEqPnUI0QAe3zuTXju51AfDJP7TzKMg=="],
-
-    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-sui": "4.17.1" } }, "sha512-3U64Men/4UVHZAru/xTZXTL0FbiU9JGL0d6EC6Fh5lMdo5EpGLmdlOAdwnr0UqEIHcWcBGdP3QNbzuWLHx2tFg=="],
-
-    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-xrpl": ["@wormhole-foundation/sdk-xrpl@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "xrpl": "^4.2.0" } }, "sha512-NniKnBFMrrvdBG0NqhQLu3r5pY3QyHvvb7TYuoOhAQTrRdzF9S+2S+yocmuKM3CFAvhIcs/VbGtI6nS9whu0lw=="],
-
-    "@wormhole-foundation/sdk-algorand/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-algorand-core/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-algorand-tokenbridge/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-aptos/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-aptos-cctp/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-aptos-core/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-aptos-tokenbridge/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-btc/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate": ["@cosmjs/stargate@0.32.4", "", { "dependencies": { "@confio/ics23": "^0.6.8", "@cosmjs/amino": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "xstream": "^11.14.0" } }, "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ=="],
 
-    "@wormhole-foundation/sdk-cosmwasm/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
     "@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
 
     "@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate": ["@cosmjs/stargate@0.32.4", "", { "dependencies": { "@confio/ics23": "^0.6.8", "@cosmjs/amino": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "xstream": "^11.14.0" } }, "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ=="],
-
-    "@wormhole-foundation/sdk-cosmwasm-core/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
 
     "@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
 
     "@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate": ["@cosmjs/stargate@0.32.4", "", { "dependencies": { "@confio/ics23": "^0.6.8", "@cosmjs/amino": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "xstream": "^11.14.0" } }, "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ=="],
 
-    "@wormhole-foundation/sdk-cosmwasm-ibc/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
     "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
-
-    "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-evm-cctp/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-evm-cctp/@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "ethers": "^6.5.1" } }, "sha512-cfJD2oAYyWauN6QdgDnSogTq+BOjc11mBM8liET/rJwhvkpJS8PCO8NIzljS/6zsZoTcPMDhKle2CXtx/CSd8w=="],
-
-    "@wormhole-foundation/sdk-evm-cctp/@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "ethers": "^6.5.1" } }, "sha512-VdE3fi219iF5qmJFxA3SVZre9PijWJ89jR7x4X+wAeI5HISzWCDVdst3JaGxeXW9GqAFTXyufG4ITn2XJSrq+g=="],
-
-    "@wormhole-foundation/sdk-evm-portico/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-evm-portico/@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "ethers": "^6.5.1" } }, "sha512-cfJD2oAYyWauN6QdgDnSogTq+BOjc11mBM8liET/rJwhvkpJS8PCO8NIzljS/6zsZoTcPMDhKle2CXtx/CSd8w=="],
-
-    "@wormhole-foundation/sdk-evm-portico/@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "ethers": "^6.5.1" } }, "sha512-VdE3fi219iF5qmJFxA3SVZre9PijWJ89jR7x4X+wAeI5HISzWCDVdst3JaGxeXW9GqAFTXyufG4ITn2XJSrq+g=="],
-
-    "@wormhole-foundation/sdk-evm-tbtc/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-evm-tbtc/@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "ethers": "^6.5.1" } }, "sha512-cfJD2oAYyWauN6QdgDnSogTq+BOjc11mBM8liET/rJwhvkpJS8PCO8NIzljS/6zsZoTcPMDhKle2CXtx/CSd8w=="],
-
-    "@wormhole-foundation/sdk-evm-tbtc/@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "ethers": "^6.5.1" } }, "sha512-VdE3fi219iF5qmJFxA3SVZre9PijWJ89jR7x4X+wAeI5HISzWCDVdst3JaGxeXW9GqAFTXyufG4ITn2XJSrq+g=="],
-
-    "@wormhole-foundation/sdk-evm-tokenbridge/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-evm-tokenbridge/@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "ethers": "^6.5.1" } }, "sha512-cfJD2oAYyWauN6QdgDnSogTq+BOjc11mBM8liET/rJwhvkpJS8PCO8NIzljS/6zsZoTcPMDhKle2CXtx/CSd8w=="],
-
-    "@wormhole-foundation/sdk-evm-tokenbridge/@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "ethers": "^6.5.1" } }, "sha512-VdE3fi219iF5qmJFxA3SVZre9PijWJ89jR7x4X+wAeI5HISzWCDVdst3JaGxeXW9GqAFTXyufG4ITn2XJSrq+g=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk": ["@wormhole-foundation/sdk@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.17.0", "@wormhole-foundation/sdk-algorand-core": "4.17.0", "@wormhole-foundation/sdk-algorand-tokenbridge": "4.17.0", "@wormhole-foundation/sdk-aptos": "4.17.0", "@wormhole-foundation/sdk-aptos-cctp": "4.17.0", "@wormhole-foundation/sdk-aptos-core": "4.17.0", "@wormhole-foundation/sdk-aptos-tokenbridge": "4.17.0", "@wormhole-foundation/sdk-base": "4.17.0", "@wormhole-foundation/sdk-btc": "4.17.0", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-cosmwasm": "4.17.0", "@wormhole-foundation/sdk-cosmwasm-core": "4.17.0", "@wormhole-foundation/sdk-cosmwasm-ibc": "4.17.0", "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.17.0", "@wormhole-foundation/sdk-definitions": "4.17.0", "@wormhole-foundation/sdk-evm": "4.17.0", "@wormhole-foundation/sdk-evm-cctp": "4.17.0", "@wormhole-foundation/sdk-evm-core": "4.17.0", "@wormhole-foundation/sdk-evm-portico": "4.17.0", "@wormhole-foundation/sdk-evm-tbtc": "4.17.0", "@wormhole-foundation/sdk-evm-tokenbridge": "4.17.0", "@wormhole-foundation/sdk-solana": "4.17.0", "@wormhole-foundation/sdk-solana-cctp": "4.17.0", "@wormhole-foundation/sdk-solana-core": "4.17.0", "@wormhole-foundation/sdk-solana-tbtc": "4.17.0", "@wormhole-foundation/sdk-solana-tokenbridge": "4.17.0", "@wormhole-foundation/sdk-stacks": "4.17.0", "@wormhole-foundation/sdk-stacks-core": "4.17.0", "@wormhole-foundation/sdk-sui": "4.17.0", "@wormhole-foundation/sdk-sui-cctp": "4.17.0", "@wormhole-foundation/sdk-sui-core": "4.17.0", "@wormhole-foundation/sdk-sui-tokenbridge": "4.17.0", "@wormhole-foundation/sdk-xrpl": "4.17.0" } }, "sha512-lnthynllsCnDdCK17VTn638Ykt5VTN3BbsfrRn0U5C+ZPO27x3MNgOwZum/6ExLJ7cKtN9jo/8qunMB/q6C+HA=="],
 
     "@wormhole-foundation/sdk-solana/rpc-websockets": ["rpc-websockets@7.11.2", "", { "dependencies": { "eventemitter3": "^4.0.7", "uuid": "^8.3.2", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" } }, "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ=="],
 
-    "@wormhole-foundation/sdk-solana-cctp/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-solana-cctp/@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "rpc-websockets": "^7.10.0" } }, "sha512-o8a9/IZ4++4niD0WVzhjvwz9hJF/T+EVzpqbixJ/ZujYHusVrvIU0yzzsBvL4wz8aM2y3374xz1WWTZ2OTyAsw=="],
-
     "@wormhole-foundation/sdk-solana-ntt/@solana/spl-token": ["@solana/spl-token@0.4.0", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-metadata": "^0.1.2", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.89.1" } }, "sha512-jjBIBG9IsclqQVl5Y82npGE6utdCh7Z9VFcF5qgJa5EUq2XgspW3Dt1wujWjH/vQDRnkp9zGO+BqQU/HhX/3wg=="],
-
-    "@wormhole-foundation/sdk-solana-tbtc/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-solana-tbtc/@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "rpc-websockets": "^7.10.0" } }, "sha512-o8a9/IZ4++4niD0WVzhjvwz9hJF/T+EVzpqbixJ/ZujYHusVrvIU0yzzsBvL4wz8aM2y3374xz1WWTZ2OTyAsw=="],
-
-    "@wormhole-foundation/sdk-solana-tbtc/@wormhole-foundation/sdk-solana-core": ["@wormhole-foundation/sdk-solana-core@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1" } }, "sha512-mTTXro17kxFr7cxI44+SCcvhSZjzpI/3PMwK7x+tGl0U3NIpvepMDwsMa6tMGijdUKc1h47eXF+xRQlwpPjhnA=="],
-
-    "@wormhole-foundation/sdk-solana-tokenbridge/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-solana-tokenbridge/@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "rpc-websockets": "^7.10.0" } }, "sha512-o8a9/IZ4++4niD0WVzhjvwz9hJF/T+EVzpqbixJ/ZujYHusVrvIU0yzzsBvL4wz8aM2y3374xz1WWTZ2OTyAsw=="],
-
-    "@wormhole-foundation/sdk-solana-tokenbridge/@wormhole-foundation/sdk-solana-core": ["@wormhole-foundation/sdk-solana-core@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1" } }, "sha512-mTTXro17kxFr7cxI44+SCcvhSZjzpI/3PMwK7x+tGl0U3NIpvepMDwsMa6tMGijdUKc1h47eXF+xRQlwpPjhnA=="],
-
-    "@wormhole-foundation/sdk-stacks/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-stacks-core/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-sui-cctp/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-sui-cctp/@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-8w4BCSK6SdnucfZVjyiOSR4k82xL4l4ZGJFpePvtUZoA4wsg6Uai/F9yEqPnUI0QAe3zuTXju51AfDJP7TzKMg=="],
-
-    "@wormhole-foundation/sdk-sui-tokenbridge/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
-
-    "@wormhole-foundation/sdk-sui-tokenbridge/@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-8w4BCSK6SdnucfZVjyiOSR4k82xL4l4ZGJFpePvtUZoA4wsg6Uai/F9yEqPnUI0QAe3zuTXju51AfDJP7TzKMg=="],
-
-    "@wormhole-foundation/sdk-sui-tokenbridge/@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-sui": "4.17.1" } }, "sha512-3U64Men/4UVHZAru/xTZXTL0FbiU9JGL0d6EC6Fh5lMdo5EpGLmdlOAdwnr0UqEIHcWcBGdP3QNbzuWLHx2tFg=="],
 
     "@wormhole-foundation/wormchain-sdk/axios": ["axios@0.26.1", "", { "dependencies": { "follow-redirects": "^1.14.8" } }, "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA=="],
 
@@ -2418,38 +2318,6 @@
 
     "@types/ws/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
-    "@wormhole-foundation/sdk-algorand-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-algorand-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-algorand-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-algorand-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-algorand/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-algorand/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-aptos-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-aptos-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-aptos-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-aptos-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-aptos-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-aptos-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-aptos/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-aptos/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-btc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-btc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
     "@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
 
     "@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
@@ -2477,10 +2345,6 @@
     "@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
 
     "@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
-
-    "@wormhole-foundation/sdk-cosmwasm-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-cosmwasm-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
 
     "@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
 
@@ -2510,10 +2374,6 @@
 
     "@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
 
-    "@wormhole-foundation/sdk-cosmwasm-ibc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-cosmwasm-ibc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
     "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
 
     "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
@@ -2529,10 +2389,6 @@
     "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
 
     "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
-
-    "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
 
@@ -2567,108 +2423,6 @@
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
-
-    "@wormhole-foundation/sdk-cosmwasm/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-cosmwasm/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-evm-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-evm-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-evm-portico/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-evm-portico/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-evm-tbtc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-evm-tbtc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-evm-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-evm-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-algorand": ["@wormhole-foundation/sdk-algorand@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "algosdk": "2.7.0" } }, "sha512-RpILx+UbR3fwjPavnAEfCan11JVamrx5Ovwk+mZALf76wXXhd3k3O+GbYrst07Og9fRbBWnopoRbukvyTe2mRg=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-algorand-core": ["@wormhole-foundation/sdk-algorand-core@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.17.0", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-G+NecSL90mQoZgRZWf0KVYWnZJJLzEwbV+mxp/NFn6gT5GVJnicaxsC0Cti/u60PfCJOkZlT3Tl0EQs0VPkLbQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-algorand-tokenbridge": ["@wormhole-foundation/sdk-algorand-tokenbridge@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.17.0", "@wormhole-foundation/sdk-algorand-core": "4.17.0", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-7ZPu3KzH7YijYs9PW9tPu8yd3y5X7LvjYPmh9zrPmnTIiULNrIqG+2VwxECwlUFpd13LTJMFi70P+TBVf3CAmg=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-aptos": ["@wormhole-foundation/sdk-aptos@4.17.0", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-bofhj/nkFMj/xp+j3vzUaHPfUGqRfq698CMS0RuIUD2uOee/m4O+zncfUYt8shN9XeFjFJSqSlATFRCL2XMh1Q=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-aptos-cctp": ["@wormhole-foundation/sdk-aptos-cctp@4.17.0", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-aptos": "4.17.0", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-yGktFYehLV/drUsTIt7ZT1EPCHboH8/9ab3WzvaGhrluBHfkIPaiklewNlniOH9JXmTDGo0/WXLZLdDIWfpzlg=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-aptos-core": ["@wormhole-foundation/sdk-aptos-core@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.17.0", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-MUb0tPm1p/JPC+qcPcb+vuaft6/piWH1HRv/GcFi+mdRLiGLBt6cR3N62k8yLEFHq9TcCaGz/QRxeGKc1j+mAA=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-aptos-tokenbridge": ["@wormhole-foundation/sdk-aptos-tokenbridge@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.17.0", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-JQMq1F88NtNo4cRDcklVzVTfF0GzgJaEIyN9eMopAzvByAHCLp7Ecypy3VNGvPp+Rw1YWyy404Bkyh2hyBgGXQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-btc": ["@wormhole-foundation/sdk-btc@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-/I5vQ2OLgMoOwE60t8FsAcTldjnztgKnM5BMa5OcF+akJCyE2Y6OTBSA+NcLTo4pmRY4rgP3GXKvp/4UX1HqTg=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm": ["@wormhole-foundation/sdk-cosmwasm@4.17.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/proto-signing": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.0", "cosmjs-types": "^0.9.0" } }, "sha512-My2niQQjr7BARQB0Hc2f947xYnR8NdpIrsnFir1k8/2XpOdiyFAkLvxadGjPKvETsodneQkLk1ve9Smjb5c/OQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core": ["@wormhole-foundation/sdk-cosmwasm-core@4.17.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-cosmwasm": "4.17.0" } }, "sha512-qykTmBtoIYwHiD/HsfMMmraiK7I+HEZJPC8oHWN88c1ptFwZ5CFqh8pEPks6xoS10TnsR+14VhBpg4sSnj7fWA=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc": ["@wormhole-foundation/sdk-cosmwasm-ibc@4.17.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-cosmwasm": "4.17.0", "@wormhole-foundation/sdk-cosmwasm-core": "4.17.0", "cosmjs-types": "^0.9.0" } }, "sha512-6XrCXLd8F/QjH97iYjEtQV6Rmn5nWGLQP/KTma3Gi1cuHimRu/9byH5nu63H/zw9UYEgmxn8HPCEG5bCqJT0sA=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge": ["@wormhole-foundation/sdk-cosmwasm-tokenbridge@4.17.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-cosmwasm": "4.17.0" } }, "sha512-nX3iJR9gEzpkbNd5Nu6TpnZ2Wul3NWbep1uGv5o5ujvJYm/pgYB4oMS/sA7ee+ExozO8E3aEFvfzMAnYbHJlzA=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-evm-cctp": ["@wormhole-foundation/sdk-evm-cctp@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-evm": "4.17.0", "@wormhole-foundation/sdk-evm-core": "4.17.0", "ethers": "^6.5.1" } }, "sha512-7fqeVdl6OwcMe7ht7BedFEj/M9V9Lwj9fjC8p/13BDUWD3dFOWENO8nSj2moPGGQ1+tEInivJr9QU81Qa2MiUQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-evm-portico": ["@wormhole-foundation/sdk-evm-portico@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-evm": "4.17.0", "@wormhole-foundation/sdk-evm-core": "4.17.0", "@wormhole-foundation/sdk-evm-tokenbridge": "4.17.0", "ethers": "^6.5.1" } }, "sha512-c/Fk3aAp4YjE8WT/9DSY7ERgpQegbNNxtHyB1iISB8BE2mCdFrsZREHdNsQ88S85IS7kEiv7sEFu7B3yiHGPDg=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-evm-tbtc": ["@wormhole-foundation/sdk-evm-tbtc@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-evm": "4.17.0", "@wormhole-foundation/sdk-evm-core": "4.17.0", "ethers": "^6.5.1" } }, "sha512-4Q4sbVAY7fdcptau5zqIB6lfslr7eLgW9X+21bUxS0hK8ogcFGYpUE0ZGKGiK8cjsB1EuYcdw8BGml8Ynw7SlA=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-evm-tokenbridge": ["@wormhole-foundation/sdk-evm-tokenbridge@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-evm": "4.17.0", "@wormhole-foundation/sdk-evm-core": "4.17.0", "ethers": "^6.5.1" } }, "sha512-gt/vfEYH1fTPC83qpHiCunUAvfG+jk82gOnbJOaASXZx7GWy0M0o0vYqOKjcJPFp/G6rcQ4CvAjzGCTtvC/E1A=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-solana-cctp": ["@wormhole-foundation/sdk-solana-cctp@4.17.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-solana": "4.17.0" } }, "sha512-LdikEgiDPBAcaFC2MArsuAiOrFgkLtXc5jGEPDnrCdCIlThEZg39cZit7USg86RcEnPWV/DvbUmAr2lj1Exbhw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-solana-tbtc": ["@wormhole-foundation/sdk-solana-tbtc@4.17.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-solana": "4.17.0", "@wormhole-foundation/sdk-solana-core": "4.17.0", "@wormhole-foundation/sdk-solana-tokenbridge": "4.17.0" } }, "sha512-fI9MXQgdizpfqQyKepyEM7K3rb+UMh8m5VnGLV1Z1GoWsowLSRH0/TYKuui5f9Fb1bf100lxn67f7bBmJIdUVA=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-solana-tokenbridge": ["@wormhole-foundation/sdk-solana-tokenbridge@4.17.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-solana": "4.17.0", "@wormhole-foundation/sdk-solana-core": "4.17.0" } }, "sha512-CRLuZbT9QmtOdwx4K5wxsfO6LBuWDGGSppDtNuXi72xPCfXHzkd6CMrmB7g9M+xyMOZyP3qkUnz41LVcGp8ZBw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-stacks": ["@wormhole-foundation/sdk-stacks@4.17.0", "", { "dependencies": { "@stacks/network": "^7.0.2", "@stacks/transactions": "^7.1.0", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-NPICjnjurNW8HiH0citA7qFFxRmXD+ISGZPSb8PwgXGojY1lbNlgBfXV5Vl58a8iOFgypQvIMgTqbxd+817n0A=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-stacks-core": ["@wormhole-foundation/sdk-stacks-core@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-stacks": "4.17.0" } }, "sha512-LvEMmGtbhFNNjTyBxTQVDSvMaBqQXyoD6JUPIbKm7vsYgLZWFvybQTunGBOn5oj2lBlHgH4QeFMUQydGIZdHeg=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-sui-cctp": ["@wormhole-foundation/sdk-sui-cctp@4.17.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-sui": "4.17.0" } }, "sha512-q2fNRvmldY+l6l5c95fDrCSGUNRwVKk00IpKt0I7fVg+/psPJ0vPCSx/K1lgXnkgDxCO9TOfd6Y+Y4IRO+UJyg=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-sui-tokenbridge": ["@wormhole-foundation/sdk-sui-tokenbridge@4.17.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-sui": "4.17.0", "@wormhole-foundation/sdk-sui-core": "4.17.0" } }, "sha512-v7EEhxqXWj4j2cgw90fCiaI7HWEpn7GgvDPtGWF7/KpZ/4bnRcDHJQfe8KbfRPVdgE6WMeUdMt7B8Wh8FKGtiA=="],
-
-    "@wormhole-foundation/sdk-solana-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-solana-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-solana-cctp/@wormhole-foundation/sdk-solana/rpc-websockets": ["rpc-websockets@7.11.2", "", { "dependencies": { "eventemitter3": "^4.0.7", "uuid": "^8.3.2", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" } }, "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ=="],
-
-    "@wormhole-foundation/sdk-solana-tbtc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-solana-tbtc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-solana-tbtc/@wormhole-foundation/sdk-solana/rpc-websockets": ["rpc-websockets@7.11.2", "", { "dependencies": { "eventemitter3": "^4.0.7", "uuid": "^8.3.2", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" } }, "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ=="],
-
-    "@wormhole-foundation/sdk-solana-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-solana-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-solana-tokenbridge/@wormhole-foundation/sdk-solana/rpc-websockets": ["rpc-websockets@7.11.2", "", { "dependencies": { "eventemitter3": "^4.0.7", "uuid": "^8.3.2", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" } }, "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ=="],
-
-    "@wormhole-foundation/sdk-stacks-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-stacks-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-stacks/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-stacks/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-sui-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-sui-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk-sui-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
-
-    "@wormhole-foundation/sdk-sui-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
-
-    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-solana/rpc-websockets": ["rpc-websockets@7.11.2", "", { "dependencies": { "eventemitter3": "^4.0.7", "uuid": "^8.3.2", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" } }, "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ=="],
 
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util": ["jest-util@27.5.1", "", { "dependencies": { "@jest/types": "^27.5.1", "@types/node": "*", "chalk": "^4.0.0", "ci-info": "^3.2.0", "graceful-fs": "^4.2.9", "picomatch": "^2.2.3" } }, "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw=="],
 
@@ -3088,22 +2842,6 @@
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
 
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate": ["@cosmjs/stargate@0.32.4", "", { "dependencies": { "@confio/ics23": "^0.6.8", "@cosmjs/amino": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "xstream": "^11.14.0" } }, "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate": ["@cosmjs/stargate@0.32.4", "", { "dependencies": { "@confio/ics23": "^0.6.8", "@cosmjs/amino": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "xstream": "^11.14.0" } }, "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate": ["@cosmjs/stargate@0.32.4", "", { "dependencies": { "@confio/ics23": "^0.6.8", "@cosmjs/amino": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "xstream": "^11.14.0" } }, "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
-
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util/@jest/types": ["@jest/types@27.5.1", "", { "dependencies": { "@types/istanbul-lib-coverage": "^2.0.0", "@types/istanbul-reports": "^3.0.0", "@types/node": "*", "@types/yargs": "^16.0.0", "chalk": "^4.0.0" } }, "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw=="],
 
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
@@ -3324,112 +3062,6 @@
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/stargate": ["@cosmjs/stargate@0.32.4", "", { "dependencies": { "@confio/ics23": "^0.6.8", "@cosmjs/amino": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "xstream": "^11.14.0" } }, "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
-
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util/@jest/types/@types/yargs": ["@types/yargs@16.0.11", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-sbtvk8wDN+JvEdabmZExoW/HNr1cB7D/j4LT08rMiuikfA7m/JNJg7ATQcgzs34zHnoScDkY0ZRSl29Fkmk36g=="],
 
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
@@ -3520,102 +3152,6 @@
 
     "@jest/fake-timers/jest-util/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/json-rpc": ["@cosmjs/json-rpc@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "xstream": "^11.14.0" } }, "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/amino/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/proto-signing/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/json-rpc": ["@cosmjs/json-rpc@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "xstream": "^11.14.0" } }, "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/json-rpc": ["@cosmjs/json-rpc@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "xstream": "^11.14.0" } }, "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/amino/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/proto-signing/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/json-rpc": ["@cosmjs/json-rpc@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "xstream": "^11.14.0" } }, "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/stargate/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/json-rpc": ["@cosmjs/json-rpc@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "xstream": "^11.14.0" } }, "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/json-rpc": ["@cosmjs/json-rpc@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "xstream": "^11.14.0" } }, "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/amino/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/json-rpc": ["@cosmjs/json-rpc@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "xstream": "^11.14.0" } }, "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
-
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -3637,36 +3173,6 @@
     "@jest/expect/expect/jest-message-util/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "@jest/expect/expect/jest-util/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/amino/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/proto-signing/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/amino/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/proto-signing/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/amino/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@solana/web3.js": "^1.95.8",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.2",
-        "@wormhole-foundation/sdk": "4.17.1",
+        "@wormhole-foundation/sdk": "4.20.0",
         "@wormhole-foundation/wormchain-sdk": "^0.0.1",
         "ethers": "^6.5.1",
         "prettier": "3.6.2",
@@ -51,25 +51,25 @@
         "typechain": "^8.3.2",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.17.1",
-        "@wormhole-foundation/sdk-definitions": "^4.17.1",
-        "@wormhole-foundation/sdk-evm": "^4.17.1",
-        "@wormhole-foundation/sdk-evm-core": "^4.17.1",
+        "@wormhole-foundation/sdk-base": "^4.20.0",
+        "@wormhole-foundation/sdk-definitions": "^4.20.0",
+        "@wormhole-foundation/sdk-evm": "^4.20.0",
+        "@wormhole-foundation/sdk-evm-core": "^4.20.0",
       },
     },
     "sdk/definitions": {
       "name": "@wormhole-foundation/sdk-definitions-ntt",
       "version": "1.0.0",
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.17.1",
-        "@wormhole-foundation/sdk-definitions": "^4.17.1",
+        "@wormhole-foundation/sdk-base": "^4.20.0",
+        "@wormhole-foundation/sdk-definitions": "^4.20.0",
       },
     },
     "sdk/examples": {
       "name": "@wormhole-foundation/sdk-examples-ntt",
       "version": "1.0.0",
       "dependencies": {
-        "@wormhole-foundation/sdk": "^4.17.1",
+        "@wormhole-foundation/sdk": "^4.20.0",
         "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
         "@wormhole-foundation/sdk-evm-ntt": "1.0.0",
         "@wormhole-foundation/sdk-route-ntt": "1.0.0",
@@ -97,7 +97,7 @@
         "ts-node": "^10.9.2",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-connect": "^4.17.1",
+        "@wormhole-foundation/sdk-connect": "^4.20.0",
         "axios": "^1.9.0",
       },
     },
@@ -120,24 +120,24 @@
         "tsx": "^4.7.2",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.17.1",
-        "@wormhole-foundation/sdk-definitions": "^4.17.1",
-        "@wormhole-foundation/sdk-solana": "^4.17.1",
-        "@wormhole-foundation/sdk-solana-core": "^4.17.1",
+        "@wormhole-foundation/sdk-base": "^4.20.0",
+        "@wormhole-foundation/sdk-definitions": "^4.20.0",
+        "@wormhole-foundation/sdk-solana": "^4.20.0",
+        "@wormhole-foundation/sdk-solana-core": "^4.20.0",
       },
     },
     "sui/ts": {
       "name": "@wormhole-foundation/sdk-sui-ntt",
-      "version": "0.5.0",
+      "version": "1.0.0",
       "dependencies": {
         "@mysten/sui": "1.37.2",
         "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.17.1",
-        "@wormhole-foundation/sdk-definitions": "^4.17.1",
-        "@wormhole-foundation/sdk-sui": "^4.17.1",
-        "@wormhole-foundation/sdk-sui-core": "^4.17.1",
+        "@wormhole-foundation/sdk-base": "^4.20.0",
+        "@wormhole-foundation/sdk-definitions": "^4.20.0",
+        "@wormhole-foundation/sdk-sui": "^4.20.0",
+        "@wormhole-foundation/sdk-sui-core": "^4.20.0",
       },
     },
     "xrpl/ts": {
@@ -148,9 +148,9 @@
         "xrpl": "^4.6.0",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.17.1",
-        "@wormhole-foundation/sdk-definitions": "^4.17.1",
-        "@wormhole-foundation/sdk-xrpl": "^4.17.1",
+        "@wormhole-foundation/sdk-base": "^4.20.0",
+        "@wormhole-foundation/sdk-definitions": "^4.20.0",
+        "@wormhole-foundation/sdk-xrpl": "^4.20.0",
       },
     },
   },
@@ -682,85 +682,85 @@
 
     "@wormhole-foundation/ntt-cli": ["@wormhole-foundation/ntt-cli@workspace:cli"],
 
-    "@wormhole-foundation/sdk": ["@wormhole-foundation/sdk@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.17.1", "@wormhole-foundation/sdk-algorand-core": "4.17.1", "@wormhole-foundation/sdk-algorand-tokenbridge": "4.17.1", "@wormhole-foundation/sdk-aptos": "4.17.1", "@wormhole-foundation/sdk-aptos-cctp": "4.17.1", "@wormhole-foundation/sdk-aptos-core": "4.17.1", "@wormhole-foundation/sdk-aptos-tokenbridge": "4.17.1", "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-btc": "4.17.1", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-cosmwasm": "4.17.1", "@wormhole-foundation/sdk-cosmwasm-core": "4.17.1", "@wormhole-foundation/sdk-cosmwasm-ibc": "4.17.1", "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "@wormhole-foundation/sdk-evm-cctp": "4.17.1", "@wormhole-foundation/sdk-evm-core": "4.17.1", "@wormhole-foundation/sdk-evm-portico": "4.17.1", "@wormhole-foundation/sdk-evm-tbtc": "4.17.1", "@wormhole-foundation/sdk-evm-tokenbridge": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1", "@wormhole-foundation/sdk-solana-cctp": "4.17.1", "@wormhole-foundation/sdk-solana-core": "4.17.1", "@wormhole-foundation/sdk-solana-tbtc": "4.17.1", "@wormhole-foundation/sdk-solana-tokenbridge": "4.17.1", "@wormhole-foundation/sdk-stacks": "4.17.1", "@wormhole-foundation/sdk-stacks-core": "4.17.1", "@wormhole-foundation/sdk-sui": "4.17.1", "@wormhole-foundation/sdk-sui-cctp": "4.17.1", "@wormhole-foundation/sdk-sui-core": "4.17.1", "@wormhole-foundation/sdk-sui-tokenbridge": "4.17.1", "@wormhole-foundation/sdk-xrpl": "4.17.1" } }, "sha512-EruG+PNGwynp8lOraVYkqIdvOlYW3iTacgEf7dpQgA3EamZEAOMaLA84VsNDaZ3RjOLZMROZ+a+F+kpZhX0JHQ=="],
+    "@wormhole-foundation/sdk": ["@wormhole-foundation/sdk@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.20.0", "@wormhole-foundation/sdk-algorand-core": "4.20.0", "@wormhole-foundation/sdk-algorand-tokenbridge": "4.20.0", "@wormhole-foundation/sdk-aptos": "4.20.0", "@wormhole-foundation/sdk-aptos-cctp": "4.20.0", "@wormhole-foundation/sdk-aptos-core": "4.20.0", "@wormhole-foundation/sdk-aptos-tokenbridge": "4.20.0", "@wormhole-foundation/sdk-base": "4.20.0", "@wormhole-foundation/sdk-btc": "4.20.0", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-cosmwasm": "4.20.0", "@wormhole-foundation/sdk-cosmwasm-core": "4.20.0", "@wormhole-foundation/sdk-cosmwasm-ibc": "4.20.0", "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.20.0", "@wormhole-foundation/sdk-definitions": "4.20.0", "@wormhole-foundation/sdk-evm": "4.20.0", "@wormhole-foundation/sdk-evm-cctp": "4.20.0", "@wormhole-foundation/sdk-evm-core": "4.20.0", "@wormhole-foundation/sdk-evm-portico": "4.20.0", "@wormhole-foundation/sdk-evm-tbtc": "4.20.0", "@wormhole-foundation/sdk-evm-tokenbridge": "4.20.0", "@wormhole-foundation/sdk-solana": "4.20.0", "@wormhole-foundation/sdk-solana-cctp": "4.20.0", "@wormhole-foundation/sdk-solana-core": "4.20.0", "@wormhole-foundation/sdk-solana-tbtc": "4.20.0", "@wormhole-foundation/sdk-solana-tokenbridge": "4.20.0", "@wormhole-foundation/sdk-stacks": "4.20.0", "@wormhole-foundation/sdk-stacks-core": "4.20.0", "@wormhole-foundation/sdk-sui": "4.20.0", "@wormhole-foundation/sdk-sui-cctp": "4.20.0", "@wormhole-foundation/sdk-sui-core": "4.20.0", "@wormhole-foundation/sdk-sui-tokenbridge": "4.20.0", "@wormhole-foundation/sdk-xrpl": "4.20.0" } }, "sha512-FLPbTbKN7BAMMs+qrSccij9+vuAthAJgXF4RvKZ0uo9QP8D6DY54ehA7sVYH+1/cuWU+Edn6iWTVgQRSmivsbg=="],
 
-    "@wormhole-foundation/sdk-algorand": ["@wormhole-foundation/sdk-algorand@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "algosdk": "2.7.0" } }, "sha512-8vaHroIpqrlh549KSAIN0JkqVQfB85ZHqbnWDr083pp/z2Uj1mlrmMfUsZiuEc1RohkyNESfN04jm0oNPW3ZyA=="],
+    "@wormhole-foundation/sdk-algorand": ["@wormhole-foundation/sdk-algorand@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "algosdk": "2.7.0" } }, "sha512-6JhlH7oTy1G5i3kpiNezfBKjcsK+dJzuhq/b3uqD6r5X90ICQO0vLb7uW8K7rqKnccnEFA3JXB63sr/lhEej9g=="],
 
-    "@wormhole-foundation/sdk-algorand-core": ["@wormhole-foundation/sdk-algorand-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.17.1", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-5yRHwpWWv0YZdHKg9Rh7e6dtZVP7nLIVFtTG9xHbjfiKn1gRzEcVJQrGepoeRvKvNhDIC/dODR/fhTQtc9S4nA=="],
+    "@wormhole-foundation/sdk-algorand-core": ["@wormhole-foundation/sdk-algorand-core@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.20.0", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-X235Vt6Gk/HV51Iz4PQp1C6KIQET8e4xsw+CwVQdcQdg+/odNOgyc5z1ia/WK/g/Trmrg+bNXJFtpE8SxIOpCA=="],
 
-    "@wormhole-foundation/sdk-algorand-tokenbridge": ["@wormhole-foundation/sdk-algorand-tokenbridge@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.17.1", "@wormhole-foundation/sdk-algorand-core": "4.17.1", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-XYog5i713RfGgBl9mbNA4en6l4d+Nc4ArxE8ipP/dTtSLQgjzCBMvGRI5WDZlPTgAxWIKthNRo+8Ur7Rw937QA=="],
+    "@wormhole-foundation/sdk-algorand-tokenbridge": ["@wormhole-foundation/sdk-algorand-tokenbridge@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.20.0", "@wormhole-foundation/sdk-algorand-core": "4.20.0", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-R8XZoxovsTDdubLCj0Gecw42UMXZQZ/4+eWkNWTKjfbfju4daMz+7fJOPaJ/NQlfivlLJGoIe7o2yZopDAMLrw=="],
 
-    "@wormhole-foundation/sdk-aptos": ["@wormhole-foundation/sdk-aptos@4.17.1", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-SB8sRzD7M1m9+Xabq4omJ9fpAu7KqPOUTQAfkTQ1wJ0S8G+8/5PXIZtWaGpX3WD89N0E4s5jRU+Mff7yG3wvgw=="],
+    "@wormhole-foundation/sdk-aptos": ["@wormhole-foundation/sdk-aptos@4.20.0", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-fiL38eLFjUn2CFhvMGPpfK5X6ZciwdxVubQFaO8HWiWIelsfI2x4KRq0+SXTDdX4u2HKpJVLzu3ISC2Q44di5g=="],
 
-    "@wormhole-foundation/sdk-aptos-cctp": ["@wormhole-foundation/sdk-aptos-cctp@4.17.1", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-aptos": "4.17.1", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-udKu3zXR+oYMvehjg6NpB4lyYBGVDjLP97SBlqS2sPyu2j17f7Ozhgd+l0YD5VJWcvLkLSotRrlTv5cj31U/Ow=="],
+    "@wormhole-foundation/sdk-aptos-cctp": ["@wormhole-foundation/sdk-aptos-cctp@4.20.0", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-aptos": "4.20.0", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-Zf5/pnNkBKbJG5vDqEnASezdqVbO+7NWv4KuhAzL4twXvDXijiDdv3AkhxeAtGdBrQiJx3/qlfK6TKOhQb6BrQ=="],
 
-    "@wormhole-foundation/sdk-aptos-core": ["@wormhole-foundation/sdk-aptos-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.17.1", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-dSWMWF72x/VyWpvLQtxdoJkhVdQEuDN+To3CJSdMIuVq9/Gea7wdmaUpyqsAAHrFiyJ+vTAtv8Fxy8+awA8eTg=="],
+    "@wormhole-foundation/sdk-aptos-core": ["@wormhole-foundation/sdk-aptos-core@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.20.0", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-2OD8WJztnm7P2iQtw6w90tQgBjX/UQOj2/GxPJFdtIHim+uk9xfZU9+IKKzGDfZ7+KcIk+Qody9KNNROqaRGmg=="],
 
-    "@wormhole-foundation/sdk-aptos-tokenbridge": ["@wormhole-foundation/sdk-aptos-tokenbridge@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.17.1", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-mNY+XGummeZYVqr+LHpBMkRaocosf3QjIrj9Co1wJ57P9F4PSaOnrWc0WE7I0Ox3GayDi5cglGyf2yHAypetvQ=="],
+    "@wormhole-foundation/sdk-aptos-tokenbridge": ["@wormhole-foundation/sdk-aptos-tokenbridge@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.20.0", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-hBM8GmDklEbWbAlZ4mmX7Q0w5GLEq9fH4GPiKUeaUlLLMAkSxMiJ2lEOn+FxjgaqKZN2FHGTyrNN2e8LwZoHqQ=="],
 
-    "@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+    "@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.20.0", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-+uWmqEJ5n+3BjBHTM1PXpEYNHZTA1J+5uR50qADHJNwKbXu6Sg7X2ZJUC+2b5ZKeyVmmev1irksMhdl9UIZl/w=="],
 
-    "@wormhole-foundation/sdk-btc": ["@wormhole-foundation/sdk-btc@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-x17Yjy2ofowbEqx0I2yhmy8gmu2yQGSrcS98rfNxRHrGvngkLVwQQd/QeJdP+rdKYi73lIekt0LSMMSALFg8GA=="],
+    "@wormhole-foundation/sdk-btc": ["@wormhole-foundation/sdk-btc@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-sciOrzATiTaMgRMp+3f2hTp9VDd5eesRAIL3IJSIb2VTVVSA3X5RNv+GgQO1mLZYvWTdeTTe5DmRqD0A0VPJDw=="],
 
-    "@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+    "@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.20.0", "@wormhole-foundation/sdk-definitions": "4.20.0", "axios": "^1.4.0" } }, "sha512-SYfiDGtKp9zNRMEndvLzPpGXa7RQoqdCYL2T1jHN+KiVgMVDABtUVA76ma1iNxlw+jM0H1LnAMHPm9WvstQ75A=="],
 
-    "@wormhole-foundation/sdk-cosmwasm": ["@wormhole-foundation/sdk-cosmwasm@4.17.1", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/proto-signing": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.1", "cosmjs-types": "^0.9.0" } }, "sha512-+AYKTE/Q/8GiH1F6Mx5XBMH7Qg5pK2ODxpKbZ+jk/50n07shS/sJunS0v5Z/WzVZKgFkbZ5usiJ+V/3Anu2a/Q=="],
+    "@wormhole-foundation/sdk-cosmwasm": ["@wormhole-foundation/sdk-cosmwasm@4.20.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/proto-signing": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.20.0", "cosmjs-types": "^0.9.0" } }, "sha512-lDzs6dWmfUQFh8OGMV58WKwJgHPqvQ4A9xkqC55Ukh1TzbZggx2Id9YHRNauOEuuONUSrPQO1K8yfFssCw5wJA=="],
 
-    "@wormhole-foundation/sdk-cosmwasm-core": ["@wormhole-foundation/sdk-cosmwasm-core@4.17.1", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-cosmwasm": "4.17.1" } }, "sha512-az2qc9YrYhbmb4QBIOQnoU+YR9sHHxmVUqOrPG5Rjcr7LKK9Iueie2Hlf1lpoAXXnyqCX4MeC5+mKWM5/U7I/w=="],
+    "@wormhole-foundation/sdk-cosmwasm-core": ["@wormhole-foundation/sdk-cosmwasm-core@4.20.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-cosmwasm": "4.20.0" } }, "sha512-qXV6NVxAQpzo0I9UEYvKNYvlvCN/CD0YVd9gEDiu9krXo1iFgaBynnvWJKFRMldb0K/GyqiOsTBmgp6Xx48V9g=="],
 
-    "@wormhole-foundation/sdk-cosmwasm-ibc": ["@wormhole-foundation/sdk-cosmwasm-ibc@4.17.1", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-cosmwasm": "4.17.1", "@wormhole-foundation/sdk-cosmwasm-core": "4.17.1", "cosmjs-types": "^0.9.0" } }, "sha512-cBPinYDR3CZ0D2m4SxRlxX4Eik7g1mbSGwxbnynQKtcODQsluphbPDCYhmfHOOI/EYAsImy1vM9tueRrwRC+EQ=="],
+    "@wormhole-foundation/sdk-cosmwasm-ibc": ["@wormhole-foundation/sdk-cosmwasm-ibc@4.20.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-cosmwasm": "4.20.0", "@wormhole-foundation/sdk-cosmwasm-core": "4.20.0", "cosmjs-types": "^0.9.0" } }, "sha512-O9oj9Hj75x9Okj5YmLMogqH1PP4Lo+Lx3e3vU3HgHwZhyJXj+cQ4alGlic0LcA9N5QniaBB2aDkEVbplM9qhbA=="],
 
-    "@wormhole-foundation/sdk-cosmwasm-tokenbridge": ["@wormhole-foundation/sdk-cosmwasm-tokenbridge@4.17.1", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-cosmwasm": "4.17.1" } }, "sha512-5JgWwAGI5KdRqAbWfhnIFFb/2cGkMY/86aSbD/YOYcpeLF+Cy9p6oCM0Sywo9qGJ6o9XWUql/y+cfGrfAAtPjA=="],
+    "@wormhole-foundation/sdk-cosmwasm-tokenbridge": ["@wormhole-foundation/sdk-cosmwasm-tokenbridge@4.20.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-cosmwasm": "4.20.0" } }, "sha512-tvjLtAQnl6pwgG6Mp54Mvb8IaJs4xEJv4J6JiPz6//thDjgibw8Aw/QRZvPyXEcuwn8h3+f07bHp0JZfbGqYaw=="],
 
-    "@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+    "@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.20.0", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.20.0" } }, "sha512-Ht/lTI8PKdGTN+ghlUeve6I6oMiWgZnMK6h8VGyyA9mZYsCzRgZ7OlpaxKFHK2WEgUAeO1ITmBjnLxCoUpdb+w=="],
 
     "@wormhole-foundation/sdk-definitions-ntt": ["@wormhole-foundation/sdk-definitions-ntt@workspace:sdk/definitions"],
 
-    "@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "ethers": "^6.5.1" } }, "sha512-cfJD2oAYyWauN6QdgDnSogTq+BOjc11mBM8liET/rJwhvkpJS8PCO8NIzljS/6zsZoTcPMDhKle2CXtx/CSd8w=="],
+    "@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "ethers": "^6.5.1" } }, "sha512-OxpQ+yiANm3hpITD4w/sLzLwMZkFb0MDW+y+TJl3Ll8Fau1Xg0aGCypNnvXsoWlLmd0QOVr+V+SVM167BRuJMw=="],
 
-    "@wormhole-foundation/sdk-evm-cctp": ["@wormhole-foundation/sdk-evm-cctp@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "@wormhole-foundation/sdk-evm-core": "4.17.1", "ethers": "^6.5.1" } }, "sha512-TbU44du4hJ13vUDqz4yBZvbq5v7Aj7TfkiR+SL795YzrLnDbfL2+qKBu5tbzgbFU90H2xeOLd0lHyM09G+hCQA=="],
+    "@wormhole-foundation/sdk-evm-cctp": ["@wormhole-foundation/sdk-evm-cctp@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-evm": "4.20.0", "@wormhole-foundation/sdk-evm-core": "4.20.0", "ethers": "^6.5.1" } }, "sha512-n3tD/rLcaJCODN/TObgKZfJFWNnu6gCObJVU3Ozr/FOSxxkgUvPmp33h5BNrKmGYWJAIs/hA6SC6EuEWZebr+Q=="],
 
-    "@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "ethers": "^6.5.1" } }, "sha512-VdE3fi219iF5qmJFxA3SVZre9PijWJ89jR7x4X+wAeI5HISzWCDVdst3JaGxeXW9GqAFTXyufG4ITn2XJSrq+g=="],
+    "@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-evm": "4.20.0", "ethers": "^6.5.1" } }, "sha512-9PV7lkB8+buNBfsPVLWSVPSXYBYc92R431984zbuaD7dR3hf47MaPVe7VYoMlsd/nrIK3eKE3+jXSWavZ8vWTg=="],
 
     "@wormhole-foundation/sdk-evm-ntt": ["@wormhole-foundation/sdk-evm-ntt@workspace:evm/ts"],
 
-    "@wormhole-foundation/sdk-evm-portico": ["@wormhole-foundation/sdk-evm-portico@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "@wormhole-foundation/sdk-evm-core": "4.17.1", "@wormhole-foundation/sdk-evm-tokenbridge": "4.17.1", "ethers": "^6.5.1" } }, "sha512-e5kEH/qSk/ET8RKBTZYP5Ir0lfcSYqGwZ6nTJ4iO7EXIB6ECAP8jH/gzDyQ4GqXaZcrErowyvxgQPNT8DuicOg=="],
+    "@wormhole-foundation/sdk-evm-portico": ["@wormhole-foundation/sdk-evm-portico@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-evm": "4.20.0", "@wormhole-foundation/sdk-evm-core": "4.20.0", "@wormhole-foundation/sdk-evm-tokenbridge": "4.20.0", "ethers": "^6.5.1" } }, "sha512-H0P2iKc+XUO64ymv52tnm1bD0/efdcULEMTiRQpaeWECUN/IV1G2GygjEl46LNc2VBIMFc8bH9q8mA4dfPIJ7A=="],
 
-    "@wormhole-foundation/sdk-evm-tbtc": ["@wormhole-foundation/sdk-evm-tbtc@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "@wormhole-foundation/sdk-evm-core": "4.17.1", "ethers": "^6.5.1" } }, "sha512-ERfHGDf1TiRDXYcM7w26PfaV1Ei6UlhdTc60fOCQyJynqiVMMQoKByVjj1iwCo5aSu8p8edCxV2gQ0QfiTG1TQ=="],
+    "@wormhole-foundation/sdk-evm-tbtc": ["@wormhole-foundation/sdk-evm-tbtc@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-evm": "4.20.0", "@wormhole-foundation/sdk-evm-core": "4.20.0", "ethers": "^6.5.1" } }, "sha512-bxi//wxW22LGpd12eK//WxNp4T1yFHW5LENPC5ESd5Wap4yc8HGob9IQBC3gaMwjMxAr4DzKzQN6QVUaCKKaSQ=="],
 
-    "@wormhole-foundation/sdk-evm-tokenbridge": ["@wormhole-foundation/sdk-evm-tokenbridge@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "@wormhole-foundation/sdk-evm-core": "4.17.1", "ethers": "^6.5.1" } }, "sha512-fECKLJzeD/xquD69pT5Ll01D+SNLTdWgtzsbyJMXS8y1qs5Tn8/CT0BsIkfCERsKCA1QStUGi54jGCO3Z9pRHw=="],
+    "@wormhole-foundation/sdk-evm-tokenbridge": ["@wormhole-foundation/sdk-evm-tokenbridge@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-evm": "4.20.0", "@wormhole-foundation/sdk-evm-core": "4.20.0", "ethers": "^6.5.1" } }, "sha512-C+05OF8ufb4ox91BIVad0rSH7va2vMkP5oqDviG7jOj3R6g1w4h2VR2B2okmI720Dr0Rvn0056MyTMfo4E7z0Q=="],
 
     "@wormhole-foundation/sdk-examples-ntt": ["@wormhole-foundation/sdk-examples-ntt@workspace:sdk/examples"],
 
     "@wormhole-foundation/sdk-route-ntt": ["@wormhole-foundation/sdk-route-ntt@workspace:sdk/route"],
 
-    "@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "rpc-websockets": "^7.10.0" } }, "sha512-o8a9/IZ4++4niD0WVzhjvwz9hJF/T+EVzpqbixJ/ZujYHusVrvIU0yzzsBvL4wz8aM2y3374xz1WWTZ2OTyAsw=="],
+    "@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.20.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.20.0", "rpc-websockets": "^7.10.0" } }, "sha512-12ycRHBa810sCLp2XtPpjgG8LS9wGc3E4W6ClqosJ8slxeC8yCr7yH27XtsoX1waGc/N5uAH7VY7/OJB/0k7cA=="],
 
-    "@wormhole-foundation/sdk-solana-cctp": ["@wormhole-foundation/sdk-solana-cctp@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1" } }, "sha512-XnHnrvHEBCfM8bbMTVLcd8xc0FrhpZfcwnMXlv3RYIqwy8r5fO/DWyLHIcfCroC5Twljyxg1KEUtwfSrYVXanA=="],
+    "@wormhole-foundation/sdk-solana-cctp": ["@wormhole-foundation/sdk-solana-cctp@4.20.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-solana": "4.20.0" } }, "sha512-qZpThjhIe69YZKcDimzyEEAXZzb2V3TgZbZnL9/MY9rlZG+/NdnBGwGPoqHAy68UagL3XJzWILnudTz4fdzDHg=="],
 
-    "@wormhole-foundation/sdk-solana-core": ["@wormhole-foundation/sdk-solana-core@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1" } }, "sha512-mTTXro17kxFr7cxI44+SCcvhSZjzpI/3PMwK7x+tGl0U3NIpvepMDwsMa6tMGijdUKc1h47eXF+xRQlwpPjhnA=="],
+    "@wormhole-foundation/sdk-solana-core": ["@wormhole-foundation/sdk-solana-core@4.20.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-solana": "4.20.0" } }, "sha512-EHNlJ+rTWdYr6HK3D6cZoEhLP7A2BD9O+jwXEaxbWdOcstij6GA091n8Bv6pesH1f/4xx2UEwWZzpCS5G+EPiQ=="],
 
     "@wormhole-foundation/sdk-solana-ntt": ["@wormhole-foundation/sdk-solana-ntt@workspace:solana"],
 
-    "@wormhole-foundation/sdk-solana-tbtc": ["@wormhole-foundation/sdk-solana-tbtc@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1", "@wormhole-foundation/sdk-solana-core": "4.17.1", "@wormhole-foundation/sdk-solana-tokenbridge": "4.17.1" } }, "sha512-oxUddjwHi34/2Wr9mUYENqZ+I2d5NOzSU2IAtzYgOtwkKq4FWfeEaTx5Vr1B5VabfZ7uyWfG5BcciExdIIKXqg=="],
+    "@wormhole-foundation/sdk-solana-tbtc": ["@wormhole-foundation/sdk-solana-tbtc@4.20.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-solana": "4.20.0", "@wormhole-foundation/sdk-solana-core": "4.20.0", "@wormhole-foundation/sdk-solana-tokenbridge": "4.20.0" } }, "sha512-9lGOs+q1h00v8/75eUnbYDzWYvpSlTcfGjvuTfmPZR1zs8w9H5EF9Tpuik8MdcpzVZIEtkHJEXK5I8KIvmvZaA=="],
 
-    "@wormhole-foundation/sdk-solana-tokenbridge": ["@wormhole-foundation/sdk-solana-tokenbridge@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1", "@wormhole-foundation/sdk-solana-core": "4.17.1" } }, "sha512-RXYMdMXP2buF3focVpNNuXoGWQzC9V9XLp6FB8GhFX+Vhr6c/gNb6L5P6G5FOnogAb0eRqGt3XDNLGBqtn0amg=="],
+    "@wormhole-foundation/sdk-solana-tokenbridge": ["@wormhole-foundation/sdk-solana-tokenbridge@4.20.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-solana": "4.20.0", "@wormhole-foundation/sdk-solana-core": "4.20.0" } }, "sha512-Dh2aaSpvppTMkGmPxk1qdr50yuO65jM1Mf2d8Gs+zXjNQnzAf/8hh9j1yGrG3BbYDq36EqOlXCQv+gAA8BHMDw=="],
 
-    "@wormhole-foundation/sdk-stacks": ["@wormhole-foundation/sdk-stacks@4.17.1", "", { "dependencies": { "@stacks/network": "^7.0.2", "@stacks/transactions": "^7.1.0", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-wa+41YD9fEmXVAs4MzGCEIMESxUFXLDnQ2IdYxamD6zXae1In/NOJ5Yj//dyPoe4mC9byTtpAuOiGZ+tx+NI8w=="],
+    "@wormhole-foundation/sdk-stacks": ["@wormhole-foundation/sdk-stacks@4.20.0", "", { "dependencies": { "@stacks/network": "^7.0.2", "@stacks/transactions": "^7.1.0", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-mZTVSZbeTqgHI+ivZ7rYMVs1EvR92BnLOprccHG7J/yWjfRRFovYMUp0klzw8ho9hjlLY4+aJ8ufRqtWAhEsEg=="],
 
-    "@wormhole-foundation/sdk-stacks-core": ["@wormhole-foundation/sdk-stacks-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-stacks": "4.17.1" } }, "sha512-aJAhdqNx4uUG7np4QdYAlLH169dSmQk7xCtG86/IIgYn2CWlw+AYCtr26+krseqj5W3494XaQ97JjDsZkfePLQ=="],
+    "@wormhole-foundation/sdk-stacks-core": ["@wormhole-foundation/sdk-stacks-core@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-stacks": "4.20.0" } }, "sha512-vPlCPt/uq/7mo1yZ/RZ1DygsxFldaj1rwL3SHOlE3st+t4YRI/gQ86Jqsru+Z1eUNhM3+Cz7Ijj3jq86uTaPpg=="],
 
-    "@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-8w4BCSK6SdnucfZVjyiOSR4k82xL4l4ZGJFpePvtUZoA4wsg6Uai/F9yEqPnUI0QAe3zuTXju51AfDJP7TzKMg=="],
+    "@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.20.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-EigJnxS23PywPzlN0n3ZO8vUA0zZUjA5mDfsC6Wq86p7hA53sASk+pQsjIBvD9sHn1yBLNM0+rvT1esT77Z22g=="],
 
-    "@wormhole-foundation/sdk-sui-cctp": ["@wormhole-foundation/sdk-sui-cctp@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-sui": "4.17.1" } }, "sha512-+mnj9ZTqMUDs/9u8JYPDiF/jKAGVmn0D+khsPAKgZRUKDYwBGTDeLH3mCXTl4dzbmOU4tsWglik0nEh67HQiAQ=="],
+    "@wormhole-foundation/sdk-sui-cctp": ["@wormhole-foundation/sdk-sui-cctp@4.20.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-sui": "4.20.0" } }, "sha512-v5qxlkZX3PUtVdYM1OsHEa9eedFaMzt4RFjhjY5Wex6z/W4UP0MuO95M/TigC/G5zOWxCfJSf80jr38V6x0FNQ=="],
 
-    "@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-sui": "4.17.1" } }, "sha512-3U64Men/4UVHZAru/xTZXTL0FbiU9JGL0d6EC6Fh5lMdo5EpGLmdlOAdwnr0UqEIHcWcBGdP3QNbzuWLHx2tFg=="],
+    "@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.20.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-sui": "4.20.0" } }, "sha512-vYemQAIyK0ou8JuCzVWB2l6oUU85giXWlX6KgIG+2dIdd01TKYL5OfAMvmqL8T2CDp27rmPZ81ZHPgujcA0j7g=="],
 
     "@wormhole-foundation/sdk-sui-ntt": ["@wormhole-foundation/sdk-sui-ntt@workspace:sui/ts"],
 
-    "@wormhole-foundation/sdk-sui-tokenbridge": ["@wormhole-foundation/sdk-sui-tokenbridge@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-sui": "4.17.1", "@wormhole-foundation/sdk-sui-core": "4.17.1" } }, "sha512-L4iR7kz03uA2VMemxMKi+ZgSqUBwkDD2fcHdSWRQpPIeWx6jfCFeckkfHLO1LpZdQ1Rrf680KdfzOuzICvAXpg=="],
+    "@wormhole-foundation/sdk-sui-tokenbridge": ["@wormhole-foundation/sdk-sui-tokenbridge@4.20.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-sui": "4.20.0", "@wormhole-foundation/sdk-sui-core": "4.20.0" } }, "sha512-KrlgtPNSu1+ykBCl93OMP0ThM8IX51TRCp7D5bBvjwPFzPuoiYZzUtknqQizTQdLzPGsJJx1bpnm6eMFLNoVyA=="],
 
-    "@wormhole-foundation/sdk-xrpl": ["@wormhole-foundation/sdk-xrpl@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "xrpl": "^4.2.0" } }, "sha512-NniKnBFMrrvdBG0NqhQLu3r5pY3QyHvvb7TYuoOhAQTrRdzF9S+2S+yocmuKM3CFAvhIcs/VbGtI6nS9whu0lw=="],
+    "@wormhole-foundation/sdk-xrpl": ["@wormhole-foundation/sdk-xrpl@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "xrpl": "^4.2.0" } }, "sha512-EpNT7aev+k8M0pZxLUgTNkc0wJG5eR2DfBp6Gb1zvywnbvsaMnjpoT0+12dhYguYytUXcvkMpc0XtRsWquTYjQ=="],
 
     "@wormhole-foundation/sdk-xrpl-ntt": ["@wormhole-foundation/sdk-xrpl-ntt@workspace:xrpl/ts"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@solana/web3.js": "^1.95.8",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.2",
-        "@wormhole-foundation/sdk": "4.20.0",
+        "@wormhole-foundation/sdk": "4.17.1",
         "@wormhole-foundation/wormchain-sdk": "^0.0.1",
         "ethers": "^6.5.1",
         "prettier": "3.6.2",
@@ -51,25 +51,25 @@
         "typechain": "^8.3.2",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.20.0",
-        "@wormhole-foundation/sdk-definitions": "^4.20.0",
-        "@wormhole-foundation/sdk-evm": "^4.20.0",
-        "@wormhole-foundation/sdk-evm-core": "^4.20.0",
+        "@wormhole-foundation/sdk-base": "^4.17.0",
+        "@wormhole-foundation/sdk-definitions": "^4.17.0",
+        "@wormhole-foundation/sdk-evm": "^4.17.0",
+        "@wormhole-foundation/sdk-evm-core": "^4.17.0",
       },
     },
     "sdk/definitions": {
       "name": "@wormhole-foundation/sdk-definitions-ntt",
       "version": "1.0.0",
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.20.0",
-        "@wormhole-foundation/sdk-definitions": "^4.20.0",
+        "@wormhole-foundation/sdk-base": "^4.17.0",
+        "@wormhole-foundation/sdk-definitions": "^4.17.0",
       },
     },
     "sdk/examples": {
       "name": "@wormhole-foundation/sdk-examples-ntt",
       "version": "1.0.0",
       "dependencies": {
-        "@wormhole-foundation/sdk": "^4.20.0",
+        "@wormhole-foundation/sdk": "^4.17.0",
         "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
         "@wormhole-foundation/sdk-evm-ntt": "1.0.0",
         "@wormhole-foundation/sdk-route-ntt": "1.0.0",
@@ -97,7 +97,7 @@
         "ts-node": "^10.9.2",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-connect": "^4.20.0",
+        "@wormhole-foundation/sdk-connect": "^4.17.0",
         "axios": "^1.9.0",
       },
     },
@@ -120,24 +120,24 @@
         "tsx": "^4.7.2",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.20.0",
-        "@wormhole-foundation/sdk-definitions": "^4.20.0",
-        "@wormhole-foundation/sdk-solana": "^4.20.0",
-        "@wormhole-foundation/sdk-solana-core": "^4.20.0",
+        "@wormhole-foundation/sdk-base": "^4.17.0",
+        "@wormhole-foundation/sdk-definitions": "^4.17.0",
+        "@wormhole-foundation/sdk-solana": "^4.17.0",
+        "@wormhole-foundation/sdk-solana-core": "^4.17.0",
       },
     },
     "sui/ts": {
       "name": "@wormhole-foundation/sdk-sui-ntt",
-      "version": "1.0.0",
+      "version": "0.5.0",
       "dependencies": {
         "@mysten/sui": "1.37.2",
         "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.20.0",
-        "@wormhole-foundation/sdk-definitions": "^4.20.0",
-        "@wormhole-foundation/sdk-sui": "^4.20.0",
-        "@wormhole-foundation/sdk-sui-core": "^4.20.0",
+        "@wormhole-foundation/sdk-base": "^4.17.0",
+        "@wormhole-foundation/sdk-definitions": "^4.17.0",
+        "@wormhole-foundation/sdk-sui": "^4.17.0",
+        "@wormhole-foundation/sdk-sui-core": "^4.17.0",
       },
     },
     "xrpl/ts": {
@@ -148,9 +148,9 @@
         "xrpl": "^4.6.0",
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^4.20.0",
-        "@wormhole-foundation/sdk-definitions": "^4.20.0",
-        "@wormhole-foundation/sdk-xrpl": "^4.20.0",
+        "@wormhole-foundation/sdk-base": "^4.17.0",
+        "@wormhole-foundation/sdk-definitions": "^4.17.0",
+        "@wormhole-foundation/sdk-xrpl": "^4.17.0",
       },
     },
   },
@@ -682,85 +682,85 @@
 
     "@wormhole-foundation/ntt-cli": ["@wormhole-foundation/ntt-cli@workspace:cli"],
 
-    "@wormhole-foundation/sdk": ["@wormhole-foundation/sdk@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.20.0", "@wormhole-foundation/sdk-algorand-core": "4.20.0", "@wormhole-foundation/sdk-algorand-tokenbridge": "4.20.0", "@wormhole-foundation/sdk-aptos": "4.20.0", "@wormhole-foundation/sdk-aptos-cctp": "4.20.0", "@wormhole-foundation/sdk-aptos-core": "4.20.0", "@wormhole-foundation/sdk-aptos-tokenbridge": "4.20.0", "@wormhole-foundation/sdk-base": "4.20.0", "@wormhole-foundation/sdk-btc": "4.20.0", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-cosmwasm": "4.20.0", "@wormhole-foundation/sdk-cosmwasm-core": "4.20.0", "@wormhole-foundation/sdk-cosmwasm-ibc": "4.20.0", "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.20.0", "@wormhole-foundation/sdk-definitions": "4.20.0", "@wormhole-foundation/sdk-evm": "4.20.0", "@wormhole-foundation/sdk-evm-cctp": "4.20.0", "@wormhole-foundation/sdk-evm-core": "4.20.0", "@wormhole-foundation/sdk-evm-portico": "4.20.0", "@wormhole-foundation/sdk-evm-tbtc": "4.20.0", "@wormhole-foundation/sdk-evm-tokenbridge": "4.20.0", "@wormhole-foundation/sdk-solana": "4.20.0", "@wormhole-foundation/sdk-solana-cctp": "4.20.0", "@wormhole-foundation/sdk-solana-core": "4.20.0", "@wormhole-foundation/sdk-solana-tbtc": "4.20.0", "@wormhole-foundation/sdk-solana-tokenbridge": "4.20.0", "@wormhole-foundation/sdk-stacks": "4.20.0", "@wormhole-foundation/sdk-stacks-core": "4.20.0", "@wormhole-foundation/sdk-sui": "4.20.0", "@wormhole-foundation/sdk-sui-cctp": "4.20.0", "@wormhole-foundation/sdk-sui-core": "4.20.0", "@wormhole-foundation/sdk-sui-tokenbridge": "4.20.0", "@wormhole-foundation/sdk-xrpl": "4.20.0" } }, "sha512-FLPbTbKN7BAMMs+qrSccij9+vuAthAJgXF4RvKZ0uo9QP8D6DY54ehA7sVYH+1/cuWU+Edn6iWTVgQRSmivsbg=="],
+    "@wormhole-foundation/sdk": ["@wormhole-foundation/sdk@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.17.1", "@wormhole-foundation/sdk-algorand-core": "4.17.1", "@wormhole-foundation/sdk-algorand-tokenbridge": "4.17.1", "@wormhole-foundation/sdk-aptos": "4.17.1", "@wormhole-foundation/sdk-aptos-cctp": "4.17.1", "@wormhole-foundation/sdk-aptos-core": "4.17.1", "@wormhole-foundation/sdk-aptos-tokenbridge": "4.17.1", "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-btc": "4.17.1", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-cosmwasm": "4.17.1", "@wormhole-foundation/sdk-cosmwasm-core": "4.17.1", "@wormhole-foundation/sdk-cosmwasm-ibc": "4.17.1", "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "@wormhole-foundation/sdk-evm-cctp": "4.17.1", "@wormhole-foundation/sdk-evm-core": "4.17.1", "@wormhole-foundation/sdk-evm-portico": "4.17.1", "@wormhole-foundation/sdk-evm-tbtc": "4.17.1", "@wormhole-foundation/sdk-evm-tokenbridge": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1", "@wormhole-foundation/sdk-solana-cctp": "4.17.1", "@wormhole-foundation/sdk-solana-core": "4.17.1", "@wormhole-foundation/sdk-solana-tbtc": "4.17.1", "@wormhole-foundation/sdk-solana-tokenbridge": "4.17.1", "@wormhole-foundation/sdk-stacks": "4.17.1", "@wormhole-foundation/sdk-stacks-core": "4.17.1", "@wormhole-foundation/sdk-sui": "4.17.1", "@wormhole-foundation/sdk-sui-cctp": "4.17.1", "@wormhole-foundation/sdk-sui-core": "4.17.1", "@wormhole-foundation/sdk-sui-tokenbridge": "4.17.1", "@wormhole-foundation/sdk-xrpl": "4.17.1" } }, "sha512-EruG+PNGwynp8lOraVYkqIdvOlYW3iTacgEf7dpQgA3EamZEAOMaLA84VsNDaZ3RjOLZMROZ+a+F+kpZhX0JHQ=="],
 
-    "@wormhole-foundation/sdk-algorand": ["@wormhole-foundation/sdk-algorand@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "algosdk": "2.7.0" } }, "sha512-6JhlH7oTy1G5i3kpiNezfBKjcsK+dJzuhq/b3uqD6r5X90ICQO0vLb7uW8K7rqKnccnEFA3JXB63sr/lhEej9g=="],
+    "@wormhole-foundation/sdk-algorand": ["@wormhole-foundation/sdk-algorand@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "algosdk": "2.7.0" } }, "sha512-8vaHroIpqrlh549KSAIN0JkqVQfB85ZHqbnWDr083pp/z2Uj1mlrmMfUsZiuEc1RohkyNESfN04jm0oNPW3ZyA=="],
 
-    "@wormhole-foundation/sdk-algorand-core": ["@wormhole-foundation/sdk-algorand-core@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.20.0", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-X235Vt6Gk/HV51Iz4PQp1C6KIQET8e4xsw+CwVQdcQdg+/odNOgyc5z1ia/WK/g/Trmrg+bNXJFtpE8SxIOpCA=="],
+    "@wormhole-foundation/sdk-algorand-core": ["@wormhole-foundation/sdk-algorand-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.17.1", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-5yRHwpWWv0YZdHKg9Rh7e6dtZVP7nLIVFtTG9xHbjfiKn1gRzEcVJQrGepoeRvKvNhDIC/dODR/fhTQtc9S4nA=="],
 
-    "@wormhole-foundation/sdk-algorand-tokenbridge": ["@wormhole-foundation/sdk-algorand-tokenbridge@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.20.0", "@wormhole-foundation/sdk-algorand-core": "4.20.0", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-R8XZoxovsTDdubLCj0Gecw42UMXZQZ/4+eWkNWTKjfbfju4daMz+7fJOPaJ/NQlfivlLJGoIe7o2yZopDAMLrw=="],
+    "@wormhole-foundation/sdk-algorand-tokenbridge": ["@wormhole-foundation/sdk-algorand-tokenbridge@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.17.1", "@wormhole-foundation/sdk-algorand-core": "4.17.1", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-XYog5i713RfGgBl9mbNA4en6l4d+Nc4ArxE8ipP/dTtSLQgjzCBMvGRI5WDZlPTgAxWIKthNRo+8Ur7Rw937QA=="],
 
-    "@wormhole-foundation/sdk-aptos": ["@wormhole-foundation/sdk-aptos@4.20.0", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-fiL38eLFjUn2CFhvMGPpfK5X6ZciwdxVubQFaO8HWiWIelsfI2x4KRq0+SXTDdX4u2HKpJVLzu3ISC2Q44di5g=="],
+    "@wormhole-foundation/sdk-aptos": ["@wormhole-foundation/sdk-aptos@4.17.1", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-SB8sRzD7M1m9+Xabq4omJ9fpAu7KqPOUTQAfkTQ1wJ0S8G+8/5PXIZtWaGpX3WD89N0E4s5jRU+Mff7yG3wvgw=="],
 
-    "@wormhole-foundation/sdk-aptos-cctp": ["@wormhole-foundation/sdk-aptos-cctp@4.20.0", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-aptos": "4.20.0", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-Zf5/pnNkBKbJG5vDqEnASezdqVbO+7NWv4KuhAzL4twXvDXijiDdv3AkhxeAtGdBrQiJx3/qlfK6TKOhQb6BrQ=="],
+    "@wormhole-foundation/sdk-aptos-cctp": ["@wormhole-foundation/sdk-aptos-cctp@4.17.1", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-aptos": "4.17.1", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-udKu3zXR+oYMvehjg6NpB4lyYBGVDjLP97SBlqS2sPyu2j17f7Ozhgd+l0YD5VJWcvLkLSotRrlTv5cj31U/Ow=="],
 
-    "@wormhole-foundation/sdk-aptos-core": ["@wormhole-foundation/sdk-aptos-core@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.20.0", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-2OD8WJztnm7P2iQtw6w90tQgBjX/UQOj2/GxPJFdtIHim+uk9xfZU9+IKKzGDfZ7+KcIk+Qody9KNNROqaRGmg=="],
+    "@wormhole-foundation/sdk-aptos-core": ["@wormhole-foundation/sdk-aptos-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.17.1", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-dSWMWF72x/VyWpvLQtxdoJkhVdQEuDN+To3CJSdMIuVq9/Gea7wdmaUpyqsAAHrFiyJ+vTAtv8Fxy8+awA8eTg=="],
 
-    "@wormhole-foundation/sdk-aptos-tokenbridge": ["@wormhole-foundation/sdk-aptos-tokenbridge@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.20.0", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-hBM8GmDklEbWbAlZ4mmX7Q0w5GLEq9fH4GPiKUeaUlLLMAkSxMiJ2lEOn+FxjgaqKZN2FHGTyrNN2e8LwZoHqQ=="],
+    "@wormhole-foundation/sdk-aptos-tokenbridge": ["@wormhole-foundation/sdk-aptos-tokenbridge@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.17.1", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-mNY+XGummeZYVqr+LHpBMkRaocosf3QjIrj9Co1wJ57P9F4PSaOnrWc0WE7I0Ox3GayDi5cglGyf2yHAypetvQ=="],
 
-    "@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.20.0", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-+uWmqEJ5n+3BjBHTM1PXpEYNHZTA1J+5uR50qADHJNwKbXu6Sg7X2ZJUC+2b5ZKeyVmmev1irksMhdl9UIZl/w=="],
+    "@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.0", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-c+dnUJWLk67wnnAhJluS+G5H/76oQ2RpGmx0JcFIU0LR3FooMeS9swS3kJglqw7dutjIkIGUv/K9J13/+0SKqA=="],
 
-    "@wormhole-foundation/sdk-btc": ["@wormhole-foundation/sdk-btc@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-sciOrzATiTaMgRMp+3f2hTp9VDd5eesRAIL3IJSIb2VTVVSA3X5RNv+GgQO1mLZYvWTdeTTe5DmRqD0A0VPJDw=="],
+    "@wormhole-foundation/sdk-btc": ["@wormhole-foundation/sdk-btc@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-x17Yjy2ofowbEqx0I2yhmy8gmu2yQGSrcS98rfNxRHrGvngkLVwQQd/QeJdP+rdKYi73lIekt0LSMMSALFg8GA=="],
 
-    "@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.20.0", "@wormhole-foundation/sdk-definitions": "4.20.0", "axios": "^1.4.0" } }, "sha512-SYfiDGtKp9zNRMEndvLzPpGXa7RQoqdCYL2T1jHN+KiVgMVDABtUVA76ma1iNxlw+jM0H1LnAMHPm9WvstQ75A=="],
+    "@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.0", "@wormhole-foundation/sdk-definitions": "4.17.0", "axios": "^1.4.0" } }, "sha512-mERYuazxyF3f+70oNInd3jwno9LJH+TzIURZQBwLMMMK7v7kqyBDXjamoNTdks5Hd+ctQ1BhQI95FLgjc2SBiw=="],
 
-    "@wormhole-foundation/sdk-cosmwasm": ["@wormhole-foundation/sdk-cosmwasm@4.20.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/proto-signing": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.20.0", "cosmjs-types": "^0.9.0" } }, "sha512-lDzs6dWmfUQFh8OGMV58WKwJgHPqvQ4A9xkqC55Ukh1TzbZggx2Id9YHRNauOEuuONUSrPQO1K8yfFssCw5wJA=="],
+    "@wormhole-foundation/sdk-cosmwasm": ["@wormhole-foundation/sdk-cosmwasm@4.17.1", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/proto-signing": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.1", "cosmjs-types": "^0.9.0" } }, "sha512-+AYKTE/Q/8GiH1F6Mx5XBMH7Qg5pK2ODxpKbZ+jk/50n07shS/sJunS0v5Z/WzVZKgFkbZ5usiJ+V/3Anu2a/Q=="],
 
-    "@wormhole-foundation/sdk-cosmwasm-core": ["@wormhole-foundation/sdk-cosmwasm-core@4.20.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-cosmwasm": "4.20.0" } }, "sha512-qXV6NVxAQpzo0I9UEYvKNYvlvCN/CD0YVd9gEDiu9krXo1iFgaBynnvWJKFRMldb0K/GyqiOsTBmgp6Xx48V9g=="],
+    "@wormhole-foundation/sdk-cosmwasm-core": ["@wormhole-foundation/sdk-cosmwasm-core@4.17.1", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-cosmwasm": "4.17.1" } }, "sha512-az2qc9YrYhbmb4QBIOQnoU+YR9sHHxmVUqOrPG5Rjcr7LKK9Iueie2Hlf1lpoAXXnyqCX4MeC5+mKWM5/U7I/w=="],
 
-    "@wormhole-foundation/sdk-cosmwasm-ibc": ["@wormhole-foundation/sdk-cosmwasm-ibc@4.20.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-cosmwasm": "4.20.0", "@wormhole-foundation/sdk-cosmwasm-core": "4.20.0", "cosmjs-types": "^0.9.0" } }, "sha512-O9oj9Hj75x9Okj5YmLMogqH1PP4Lo+Lx3e3vU3HgHwZhyJXj+cQ4alGlic0LcA9N5QniaBB2aDkEVbplM9qhbA=="],
+    "@wormhole-foundation/sdk-cosmwasm-ibc": ["@wormhole-foundation/sdk-cosmwasm-ibc@4.17.1", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-cosmwasm": "4.17.1", "@wormhole-foundation/sdk-cosmwasm-core": "4.17.1", "cosmjs-types": "^0.9.0" } }, "sha512-cBPinYDR3CZ0D2m4SxRlxX4Eik7g1mbSGwxbnynQKtcODQsluphbPDCYhmfHOOI/EYAsImy1vM9tueRrwRC+EQ=="],
 
-    "@wormhole-foundation/sdk-cosmwasm-tokenbridge": ["@wormhole-foundation/sdk-cosmwasm-tokenbridge@4.20.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-cosmwasm": "4.20.0" } }, "sha512-tvjLtAQnl6pwgG6Mp54Mvb8IaJs4xEJv4J6JiPz6//thDjgibw8Aw/QRZvPyXEcuwn8h3+f07bHp0JZfbGqYaw=="],
+    "@wormhole-foundation/sdk-cosmwasm-tokenbridge": ["@wormhole-foundation/sdk-cosmwasm-tokenbridge@4.17.1", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-cosmwasm": "4.17.1" } }, "sha512-5JgWwAGI5KdRqAbWfhnIFFb/2cGkMY/86aSbD/YOYcpeLF+Cy9p6oCM0Sywo9qGJ6o9XWUql/y+cfGrfAAtPjA=="],
 
-    "@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.20.0", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.20.0" } }, "sha512-Ht/lTI8PKdGTN+ghlUeve6I6oMiWgZnMK6h8VGyyA9mZYsCzRgZ7OlpaxKFHK2WEgUAeO1ITmBjnLxCoUpdb+w=="],
+    "@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.0", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.0" } }, "sha512-GqzHCar6BemFA17y7JEPWoaYCOBtI9XGiuFhuib+3zuc6T4w59BXYi5mIJE/Ci+IesQM0JIukdlBlEg9jWHKQg=="],
 
     "@wormhole-foundation/sdk-definitions-ntt": ["@wormhole-foundation/sdk-definitions-ntt@workspace:sdk/definitions"],
 
-    "@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "ethers": "^6.5.1" } }, "sha512-OxpQ+yiANm3hpITD4w/sLzLwMZkFb0MDW+y+TJl3Ll8Fau1Xg0aGCypNnvXsoWlLmd0QOVr+V+SVM167BRuJMw=="],
+    "@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "ethers": "^6.5.1" } }, "sha512-ewYYruUkp7Ou6BRyhUnfAPSNdw3ToOpVDBQWtAZmjBE2AmZaxhMI1W9OkFd85S0NSKjFfNC3VqRFOq5Lx2pHgg=="],
 
-    "@wormhole-foundation/sdk-evm-cctp": ["@wormhole-foundation/sdk-evm-cctp@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-evm": "4.20.0", "@wormhole-foundation/sdk-evm-core": "4.20.0", "ethers": "^6.5.1" } }, "sha512-n3tD/rLcaJCODN/TObgKZfJFWNnu6gCObJVU3Ozr/FOSxxkgUvPmp33h5BNrKmGYWJAIs/hA6SC6EuEWZebr+Q=="],
+    "@wormhole-foundation/sdk-evm-cctp": ["@wormhole-foundation/sdk-evm-cctp@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "@wormhole-foundation/sdk-evm-core": "4.17.1", "ethers": "^6.5.1" } }, "sha512-TbU44du4hJ13vUDqz4yBZvbq5v7Aj7TfkiR+SL795YzrLnDbfL2+qKBu5tbzgbFU90H2xeOLd0lHyM09G+hCQA=="],
 
-    "@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-evm": "4.20.0", "ethers": "^6.5.1" } }, "sha512-9PV7lkB8+buNBfsPVLWSVPSXYBYc92R431984zbuaD7dR3hf47MaPVe7VYoMlsd/nrIK3eKE3+jXSWavZ8vWTg=="],
+    "@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-evm": "4.17.0", "ethers": "^6.5.1" } }, "sha512-9bGqvr3SUSZd4KKeVG+moNOjKhLsW72zambhNIdGlfYgKSVCOsocYIBryaeShe1/tDLTJJneGLw36LQSjpnWcQ=="],
 
     "@wormhole-foundation/sdk-evm-ntt": ["@wormhole-foundation/sdk-evm-ntt@workspace:evm/ts"],
 
-    "@wormhole-foundation/sdk-evm-portico": ["@wormhole-foundation/sdk-evm-portico@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-evm": "4.20.0", "@wormhole-foundation/sdk-evm-core": "4.20.0", "@wormhole-foundation/sdk-evm-tokenbridge": "4.20.0", "ethers": "^6.5.1" } }, "sha512-H0P2iKc+XUO64ymv52tnm1bD0/efdcULEMTiRQpaeWECUN/IV1G2GygjEl46LNc2VBIMFc8bH9q8mA4dfPIJ7A=="],
+    "@wormhole-foundation/sdk-evm-portico": ["@wormhole-foundation/sdk-evm-portico@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "@wormhole-foundation/sdk-evm-core": "4.17.1", "@wormhole-foundation/sdk-evm-tokenbridge": "4.17.1", "ethers": "^6.5.1" } }, "sha512-e5kEH/qSk/ET8RKBTZYP5Ir0lfcSYqGwZ6nTJ4iO7EXIB6ECAP8jH/gzDyQ4GqXaZcrErowyvxgQPNT8DuicOg=="],
 
-    "@wormhole-foundation/sdk-evm-tbtc": ["@wormhole-foundation/sdk-evm-tbtc@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-evm": "4.20.0", "@wormhole-foundation/sdk-evm-core": "4.20.0", "ethers": "^6.5.1" } }, "sha512-bxi//wxW22LGpd12eK//WxNp4T1yFHW5LENPC5ESd5Wap4yc8HGob9IQBC3gaMwjMxAr4DzKzQN6QVUaCKKaSQ=="],
+    "@wormhole-foundation/sdk-evm-tbtc": ["@wormhole-foundation/sdk-evm-tbtc@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "@wormhole-foundation/sdk-evm-core": "4.17.1", "ethers": "^6.5.1" } }, "sha512-ERfHGDf1TiRDXYcM7w26PfaV1Ei6UlhdTc60fOCQyJynqiVMMQoKByVjj1iwCo5aSu8p8edCxV2gQ0QfiTG1TQ=="],
 
-    "@wormhole-foundation/sdk-evm-tokenbridge": ["@wormhole-foundation/sdk-evm-tokenbridge@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-evm": "4.20.0", "@wormhole-foundation/sdk-evm-core": "4.20.0", "ethers": "^6.5.1" } }, "sha512-C+05OF8ufb4ox91BIVad0rSH7va2vMkP5oqDviG7jOj3R6g1w4h2VR2B2okmI720Dr0Rvn0056MyTMfo4E7z0Q=="],
+    "@wormhole-foundation/sdk-evm-tokenbridge": ["@wormhole-foundation/sdk-evm-tokenbridge@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "@wormhole-foundation/sdk-evm-core": "4.17.1", "ethers": "^6.5.1" } }, "sha512-fECKLJzeD/xquD69pT5Ll01D+SNLTdWgtzsbyJMXS8y1qs5Tn8/CT0BsIkfCERsKCA1QStUGi54jGCO3Z9pRHw=="],
 
     "@wormhole-foundation/sdk-examples-ntt": ["@wormhole-foundation/sdk-examples-ntt@workspace:sdk/examples"],
 
     "@wormhole-foundation/sdk-route-ntt": ["@wormhole-foundation/sdk-route-ntt@workspace:sdk/route"],
 
-    "@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.20.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.20.0", "rpc-websockets": "^7.10.0" } }, "sha512-12ycRHBa810sCLp2XtPpjgG8LS9wGc3E4W6ClqosJ8slxeC8yCr7yH27XtsoX1waGc/N5uAH7VY7/OJB/0k7cA=="],
+    "@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.17.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.0", "rpc-websockets": "^7.10.0" } }, "sha512-KakINbLBFVVQLKdSxePmNA54BQ7GMsCCaKwQmhPEt9aCtL5KaSWSnhAdyENUfK2ZeTMDQPzuQ4nlLUk1vQ3WKQ=="],
 
-    "@wormhole-foundation/sdk-solana-cctp": ["@wormhole-foundation/sdk-solana-cctp@4.20.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-solana": "4.20.0" } }, "sha512-qZpThjhIe69YZKcDimzyEEAXZzb2V3TgZbZnL9/MY9rlZG+/NdnBGwGPoqHAy68UagL3XJzWILnudTz4fdzDHg=="],
+    "@wormhole-foundation/sdk-solana-cctp": ["@wormhole-foundation/sdk-solana-cctp@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1" } }, "sha512-XnHnrvHEBCfM8bbMTVLcd8xc0FrhpZfcwnMXlv3RYIqwy8r5fO/DWyLHIcfCroC5Twljyxg1KEUtwfSrYVXanA=="],
 
-    "@wormhole-foundation/sdk-solana-core": ["@wormhole-foundation/sdk-solana-core@4.20.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-solana": "4.20.0" } }, "sha512-EHNlJ+rTWdYr6HK3D6cZoEhLP7A2BD9O+jwXEaxbWdOcstij6GA091n8Bv6pesH1f/4xx2UEwWZzpCS5G+EPiQ=="],
+    "@wormhole-foundation/sdk-solana-core": ["@wormhole-foundation/sdk-solana-core@4.17.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-solana": "4.17.0" } }, "sha512-FmkLcDTTneGzjqcY8XCizONVWTLTVsDxFX1OnlMP6/8cJzn19hM+G2r/yDyO75mozr9ldxRVEux8GJ9vRI5Lbg=="],
 
     "@wormhole-foundation/sdk-solana-ntt": ["@wormhole-foundation/sdk-solana-ntt@workspace:solana"],
 
-    "@wormhole-foundation/sdk-solana-tbtc": ["@wormhole-foundation/sdk-solana-tbtc@4.20.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-solana": "4.20.0", "@wormhole-foundation/sdk-solana-core": "4.20.0", "@wormhole-foundation/sdk-solana-tokenbridge": "4.20.0" } }, "sha512-9lGOs+q1h00v8/75eUnbYDzWYvpSlTcfGjvuTfmPZR1zs8w9H5EF9Tpuik8MdcpzVZIEtkHJEXK5I8KIvmvZaA=="],
+    "@wormhole-foundation/sdk-solana-tbtc": ["@wormhole-foundation/sdk-solana-tbtc@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1", "@wormhole-foundation/sdk-solana-core": "4.17.1", "@wormhole-foundation/sdk-solana-tokenbridge": "4.17.1" } }, "sha512-oxUddjwHi34/2Wr9mUYENqZ+I2d5NOzSU2IAtzYgOtwkKq4FWfeEaTx5Vr1B5VabfZ7uyWfG5BcciExdIIKXqg=="],
 
-    "@wormhole-foundation/sdk-solana-tokenbridge": ["@wormhole-foundation/sdk-solana-tokenbridge@4.20.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-solana": "4.20.0", "@wormhole-foundation/sdk-solana-core": "4.20.0" } }, "sha512-Dh2aaSpvppTMkGmPxk1qdr50yuO65jM1Mf2d8Gs+zXjNQnzAf/8hh9j1yGrG3BbYDq36EqOlXCQv+gAA8BHMDw=="],
+    "@wormhole-foundation/sdk-solana-tokenbridge": ["@wormhole-foundation/sdk-solana-tokenbridge@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1", "@wormhole-foundation/sdk-solana-core": "4.17.1" } }, "sha512-RXYMdMXP2buF3focVpNNuXoGWQzC9V9XLp6FB8GhFX+Vhr6c/gNb6L5P6G5FOnogAb0eRqGt3XDNLGBqtn0amg=="],
 
-    "@wormhole-foundation/sdk-stacks": ["@wormhole-foundation/sdk-stacks@4.20.0", "", { "dependencies": { "@stacks/network": "^7.0.2", "@stacks/transactions": "^7.1.0", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-mZTVSZbeTqgHI+ivZ7rYMVs1EvR92BnLOprccHG7J/yWjfRRFovYMUp0klzw8ho9hjlLY4+aJ8ufRqtWAhEsEg=="],
+    "@wormhole-foundation/sdk-stacks": ["@wormhole-foundation/sdk-stacks@4.17.1", "", { "dependencies": { "@stacks/network": "^7.0.2", "@stacks/transactions": "^7.1.0", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-wa+41YD9fEmXVAs4MzGCEIMESxUFXLDnQ2IdYxamD6zXae1In/NOJ5Yj//dyPoe4mC9byTtpAuOiGZ+tx+NI8w=="],
 
-    "@wormhole-foundation/sdk-stacks-core": ["@wormhole-foundation/sdk-stacks-core@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-stacks": "4.20.0" } }, "sha512-vPlCPt/uq/7mo1yZ/RZ1DygsxFldaj1rwL3SHOlE3st+t4YRI/gQ86Jqsru+Z1eUNhM3+Cz7Ijj3jq86uTaPpg=="],
+    "@wormhole-foundation/sdk-stacks-core": ["@wormhole-foundation/sdk-stacks-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-stacks": "4.17.1" } }, "sha512-aJAhdqNx4uUG7np4QdYAlLH169dSmQk7xCtG86/IIgYn2CWlw+AYCtr26+krseqj5W3494XaQ97JjDsZkfePLQ=="],
 
-    "@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.20.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.20.0" } }, "sha512-EigJnxS23PywPzlN0n3ZO8vUA0zZUjA5mDfsC6Wq86p7hA53sASk+pQsjIBvD9sHn1yBLNM0+rvT1esT77Z22g=="],
+    "@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.17.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-J539CELeOkxxMpBkhnMNPytiOBnsvIQznr5PoRLIlXF+Fit0Tn+IrdT/ok5O1ZwtRopd+rz5giblp4NLWtCkrg=="],
 
-    "@wormhole-foundation/sdk-sui-cctp": ["@wormhole-foundation/sdk-sui-cctp@4.20.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-sui": "4.20.0" } }, "sha512-v5qxlkZX3PUtVdYM1OsHEa9eedFaMzt4RFjhjY5Wex6z/W4UP0MuO95M/TigC/G5zOWxCfJSf80jr38V6x0FNQ=="],
+    "@wormhole-foundation/sdk-sui-cctp": ["@wormhole-foundation/sdk-sui-cctp@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-sui": "4.17.1" } }, "sha512-+mnj9ZTqMUDs/9u8JYPDiF/jKAGVmn0D+khsPAKgZRUKDYwBGTDeLH3mCXTl4dzbmOU4tsWglik0nEh67HQiAQ=="],
 
-    "@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.20.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-sui": "4.20.0" } }, "sha512-vYemQAIyK0ou8JuCzVWB2l6oUU85giXWlX6KgIG+2dIdd01TKYL5OfAMvmqL8T2CDp27rmPZ81ZHPgujcA0j7g=="],
+    "@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.17.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-sui": "4.17.0" } }, "sha512-WXAPAw/jPFiyLtaSpeOQWqHnIx5teJlmlx0RFp+peU2cyHtavFpSziycVi2m4pHrhPce+t6V70mjt3jTtw+1wA=="],
 
     "@wormhole-foundation/sdk-sui-ntt": ["@wormhole-foundation/sdk-sui-ntt@workspace:sui/ts"],
 
-    "@wormhole-foundation/sdk-sui-tokenbridge": ["@wormhole-foundation/sdk-sui-tokenbridge@4.20.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.20.0", "@wormhole-foundation/sdk-sui": "4.20.0", "@wormhole-foundation/sdk-sui-core": "4.20.0" } }, "sha512-KrlgtPNSu1+ykBCl93OMP0ThM8IX51TRCp7D5bBvjwPFzPuoiYZzUtknqQizTQdLzPGsJJx1bpnm6eMFLNoVyA=="],
+    "@wormhole-foundation/sdk-sui-tokenbridge": ["@wormhole-foundation/sdk-sui-tokenbridge@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-sui": "4.17.1", "@wormhole-foundation/sdk-sui-core": "4.17.1" } }, "sha512-L4iR7kz03uA2VMemxMKi+ZgSqUBwkDD2fcHdSWRQpPIeWx6jfCFeckkfHLO1LpZdQ1Rrf680KdfzOuzICvAXpg=="],
 
-    "@wormhole-foundation/sdk-xrpl": ["@wormhole-foundation/sdk-xrpl@4.20.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.20.0", "xrpl": "^4.2.0" } }, "sha512-EpNT7aev+k8M0pZxLUgTNkc0wJG5eR2DfBp6Gb1zvywnbvsaMnjpoT0+12dhYguYytUXcvkMpc0XtRsWquTYjQ=="],
+    "@wormhole-foundation/sdk-xrpl": ["@wormhole-foundation/sdk-xrpl@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "xrpl": "^4.2.0" } }, "sha512-id1rkqwZyrUbrJP9OOltXiUkyZSAHMbulZQUewhTelV+IWIj4ZoU7ErCnFUNfWZEmDRTfhmvKjSSDoIMm+31CA=="],
 
     "@wormhole-foundation/sdk-xrpl-ntt": ["@wormhole-foundation/sdk-xrpl-ntt@workspace:xrpl/ts"],
 
@@ -1856,25 +1856,125 @@
 
     "@types/ws/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
 
+    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "ethers": "^6.5.1" } }, "sha512-cfJD2oAYyWauN6QdgDnSogTq+BOjc11mBM8liET/rJwhvkpJS8PCO8NIzljS/6zsZoTcPMDhKle2CXtx/CSd8w=="],
+
+    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "ethers": "^6.5.1" } }, "sha512-VdE3fi219iF5qmJFxA3SVZre9PijWJ89jR7x4X+wAeI5HISzWCDVdst3JaGxeXW9GqAFTXyufG4ITn2XJSrq+g=="],
+
+    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "rpc-websockets": "^7.10.0" } }, "sha512-o8a9/IZ4++4niD0WVzhjvwz9hJF/T+EVzpqbixJ/ZujYHusVrvIU0yzzsBvL4wz8aM2y3374xz1WWTZ2OTyAsw=="],
+
+    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-solana-core": ["@wormhole-foundation/sdk-solana-core@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1" } }, "sha512-mTTXro17kxFr7cxI44+SCcvhSZjzpI/3PMwK7x+tGl0U3NIpvepMDwsMa6tMGijdUKc1h47eXF+xRQlwpPjhnA=="],
+
+    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-8w4BCSK6SdnucfZVjyiOSR4k82xL4l4ZGJFpePvtUZoA4wsg6Uai/F9yEqPnUI0QAe3zuTXju51AfDJP7TzKMg=="],
+
+    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-sui": "4.17.1" } }, "sha512-3U64Men/4UVHZAru/xTZXTL0FbiU9JGL0d6EC6Fh5lMdo5EpGLmdlOAdwnr0UqEIHcWcBGdP3QNbzuWLHx2tFg=="],
+
+    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-xrpl": ["@wormhole-foundation/sdk-xrpl@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "xrpl": "^4.2.0" } }, "sha512-NniKnBFMrrvdBG0NqhQLu3r5pY3QyHvvb7TYuoOhAQTrRdzF9S+2S+yocmuKM3CFAvhIcs/VbGtI6nS9whu0lw=="],
+
+    "@wormhole-foundation/sdk-algorand/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-algorand-core/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-algorand-tokenbridge/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-aptos/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-aptos-cctp/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-aptos-core/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-aptos-tokenbridge/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-btc/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate": ["@cosmjs/stargate@0.32.4", "", { "dependencies": { "@confio/ics23": "^0.6.8", "@cosmjs/amino": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "xstream": "^11.14.0" } }, "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ=="],
 
+    "@wormhole-foundation/sdk-cosmwasm/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
     "@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
 
     "@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate": ["@cosmjs/stargate@0.32.4", "", { "dependencies": { "@confio/ics23": "^0.6.8", "@cosmjs/amino": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "xstream": "^11.14.0" } }, "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ=="],
+
+    "@wormhole-foundation/sdk-cosmwasm-core/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
 
     "@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
 
     "@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate": ["@cosmjs/stargate@0.32.4", "", { "dependencies": { "@confio/ics23": "^0.6.8", "@cosmjs/amino": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "xstream": "^11.14.0" } }, "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ=="],
 
+    "@wormhole-foundation/sdk-cosmwasm-ibc/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
     "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
+
+    "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-evm-cctp/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-evm-cctp/@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "ethers": "^6.5.1" } }, "sha512-cfJD2oAYyWauN6QdgDnSogTq+BOjc11mBM8liET/rJwhvkpJS8PCO8NIzljS/6zsZoTcPMDhKle2CXtx/CSd8w=="],
+
+    "@wormhole-foundation/sdk-evm-cctp/@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "ethers": "^6.5.1" } }, "sha512-VdE3fi219iF5qmJFxA3SVZre9PijWJ89jR7x4X+wAeI5HISzWCDVdst3JaGxeXW9GqAFTXyufG4ITn2XJSrq+g=="],
+
+    "@wormhole-foundation/sdk-evm-portico/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-evm-portico/@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "ethers": "^6.5.1" } }, "sha512-cfJD2oAYyWauN6QdgDnSogTq+BOjc11mBM8liET/rJwhvkpJS8PCO8NIzljS/6zsZoTcPMDhKle2CXtx/CSd8w=="],
+
+    "@wormhole-foundation/sdk-evm-portico/@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "ethers": "^6.5.1" } }, "sha512-VdE3fi219iF5qmJFxA3SVZre9PijWJ89jR7x4X+wAeI5HISzWCDVdst3JaGxeXW9GqAFTXyufG4ITn2XJSrq+g=="],
+
+    "@wormhole-foundation/sdk-evm-tbtc/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-evm-tbtc/@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "ethers": "^6.5.1" } }, "sha512-cfJD2oAYyWauN6QdgDnSogTq+BOjc11mBM8liET/rJwhvkpJS8PCO8NIzljS/6zsZoTcPMDhKle2CXtx/CSd8w=="],
+
+    "@wormhole-foundation/sdk-evm-tbtc/@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "ethers": "^6.5.1" } }, "sha512-VdE3fi219iF5qmJFxA3SVZre9PijWJ89jR7x4X+wAeI5HISzWCDVdst3JaGxeXW9GqAFTXyufG4ITn2XJSrq+g=="],
+
+    "@wormhole-foundation/sdk-evm-tokenbridge/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-evm-tokenbridge/@wormhole-foundation/sdk-evm": ["@wormhole-foundation/sdk-evm@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "ethers": "^6.5.1" } }, "sha512-cfJD2oAYyWauN6QdgDnSogTq+BOjc11mBM8liET/rJwhvkpJS8PCO8NIzljS/6zsZoTcPMDhKle2CXtx/CSd8w=="],
+
+    "@wormhole-foundation/sdk-evm-tokenbridge/@wormhole-foundation/sdk-evm-core": ["@wormhole-foundation/sdk-evm-core@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-evm": "4.17.1", "ethers": "^6.5.1" } }, "sha512-VdE3fi219iF5qmJFxA3SVZre9PijWJ89jR7x4X+wAeI5HISzWCDVdst3JaGxeXW9GqAFTXyufG4ITn2XJSrq+g=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk": ["@wormhole-foundation/sdk@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.17.0", "@wormhole-foundation/sdk-algorand-core": "4.17.0", "@wormhole-foundation/sdk-algorand-tokenbridge": "4.17.0", "@wormhole-foundation/sdk-aptos": "4.17.0", "@wormhole-foundation/sdk-aptos-cctp": "4.17.0", "@wormhole-foundation/sdk-aptos-core": "4.17.0", "@wormhole-foundation/sdk-aptos-tokenbridge": "4.17.0", "@wormhole-foundation/sdk-base": "4.17.0", "@wormhole-foundation/sdk-btc": "4.17.0", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-cosmwasm": "4.17.0", "@wormhole-foundation/sdk-cosmwasm-core": "4.17.0", "@wormhole-foundation/sdk-cosmwasm-ibc": "4.17.0", "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.17.0", "@wormhole-foundation/sdk-definitions": "4.17.0", "@wormhole-foundation/sdk-evm": "4.17.0", "@wormhole-foundation/sdk-evm-cctp": "4.17.0", "@wormhole-foundation/sdk-evm-core": "4.17.0", "@wormhole-foundation/sdk-evm-portico": "4.17.0", "@wormhole-foundation/sdk-evm-tbtc": "4.17.0", "@wormhole-foundation/sdk-evm-tokenbridge": "4.17.0", "@wormhole-foundation/sdk-solana": "4.17.0", "@wormhole-foundation/sdk-solana-cctp": "4.17.0", "@wormhole-foundation/sdk-solana-core": "4.17.0", "@wormhole-foundation/sdk-solana-tbtc": "4.17.0", "@wormhole-foundation/sdk-solana-tokenbridge": "4.17.0", "@wormhole-foundation/sdk-stacks": "4.17.0", "@wormhole-foundation/sdk-stacks-core": "4.17.0", "@wormhole-foundation/sdk-sui": "4.17.0", "@wormhole-foundation/sdk-sui-cctp": "4.17.0", "@wormhole-foundation/sdk-sui-core": "4.17.0", "@wormhole-foundation/sdk-sui-tokenbridge": "4.17.0", "@wormhole-foundation/sdk-xrpl": "4.17.0" } }, "sha512-lnthynllsCnDdCK17VTn638Ykt5VTN3BbsfrRn0U5C+ZPO27x3MNgOwZum/6ExLJ7cKtN9jo/8qunMB/q6C+HA=="],
 
     "@wormhole-foundation/sdk-solana/rpc-websockets": ["rpc-websockets@7.11.2", "", { "dependencies": { "eventemitter3": "^4.0.7", "uuid": "^8.3.2", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" } }, "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ=="],
 
+    "@wormhole-foundation/sdk-solana-cctp/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-solana-cctp/@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "rpc-websockets": "^7.10.0" } }, "sha512-o8a9/IZ4++4niD0WVzhjvwz9hJF/T+EVzpqbixJ/ZujYHusVrvIU0yzzsBvL4wz8aM2y3374xz1WWTZ2OTyAsw=="],
+
     "@wormhole-foundation/sdk-solana-ntt/@solana/spl-token": ["@solana/spl-token@0.4.0", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-metadata": "^0.1.2", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.89.1" } }, "sha512-jjBIBG9IsclqQVl5Y82npGE6utdCh7Z9VFcF5qgJa5EUq2XgspW3Dt1wujWjH/vQDRnkp9zGO+BqQU/HhX/3wg=="],
+
+    "@wormhole-foundation/sdk-solana-tbtc/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-solana-tbtc/@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "rpc-websockets": "^7.10.0" } }, "sha512-o8a9/IZ4++4niD0WVzhjvwz9hJF/T+EVzpqbixJ/ZujYHusVrvIU0yzzsBvL4wz8aM2y3374xz1WWTZ2OTyAsw=="],
+
+    "@wormhole-foundation/sdk-solana-tbtc/@wormhole-foundation/sdk-solana-core": ["@wormhole-foundation/sdk-solana-core@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1" } }, "sha512-mTTXro17kxFr7cxI44+SCcvhSZjzpI/3PMwK7x+tGl0U3NIpvepMDwsMa6tMGijdUKc1h47eXF+xRQlwpPjhnA=="],
+
+    "@wormhole-foundation/sdk-solana-tokenbridge/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-solana-tokenbridge/@wormhole-foundation/sdk-solana": ["@wormhole-foundation/sdk-solana@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "rpc-websockets": "^7.10.0" } }, "sha512-o8a9/IZ4++4niD0WVzhjvwz9hJF/T+EVzpqbixJ/ZujYHusVrvIU0yzzsBvL4wz8aM2y3374xz1WWTZ2OTyAsw=="],
+
+    "@wormhole-foundation/sdk-solana-tokenbridge/@wormhole-foundation/sdk-solana-core": ["@wormhole-foundation/sdk-solana-core@4.17.1", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@coral-xyz/borsh": "0.29.0", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-solana": "4.17.1" } }, "sha512-mTTXro17kxFr7cxI44+SCcvhSZjzpI/3PMwK7x+tGl0U3NIpvepMDwsMa6tMGijdUKc1h47eXF+xRQlwpPjhnA=="],
+
+    "@wormhole-foundation/sdk-stacks/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-stacks-core/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-sui-cctp/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-sui-cctp/@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-8w4BCSK6SdnucfZVjyiOSR4k82xL4l4ZGJFpePvtUZoA4wsg6Uai/F9yEqPnUI0QAe3zuTXju51AfDJP7TzKMg=="],
+
+    "@wormhole-foundation/sdk-sui-tokenbridge/@wormhole-foundation/sdk-connect": ["@wormhole-foundation/sdk-connect@4.17.1", "", { "dependencies": { "@wormhole-foundation/sdk-base": "4.17.1", "@wormhole-foundation/sdk-definitions": "4.17.1", "axios": "^1.4.0" } }, "sha512-b3eI+CHv85/7oxrmJkTI3szCPIqGoRMmrTFYvP5SMb5grUXCNyA5SH36wd9s50RvBDZWuaroEO8TY0odocq91w=="],
+
+    "@wormhole-foundation/sdk-sui-tokenbridge/@wormhole-foundation/sdk-sui": ["@wormhole-foundation/sdk-sui@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1" } }, "sha512-8w4BCSK6SdnucfZVjyiOSR4k82xL4l4ZGJFpePvtUZoA4wsg6Uai/F9yEqPnUI0QAe3zuTXju51AfDJP7TzKMg=="],
+
+    "@wormhole-foundation/sdk-sui-tokenbridge/@wormhole-foundation/sdk-sui-core": ["@wormhole-foundation/sdk-sui-core@4.17.1", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.1", "@wormhole-foundation/sdk-sui": "4.17.1" } }, "sha512-3U64Men/4UVHZAru/xTZXTL0FbiU9JGL0d6EC6Fh5lMdo5EpGLmdlOAdwnr0UqEIHcWcBGdP3QNbzuWLHx2tFg=="],
 
     "@wormhole-foundation/wormchain-sdk/axios": ["axios@0.26.1", "", { "dependencies": { "follow-redirects": "^1.14.8" } }, "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA=="],
 
@@ -2318,6 +2418,38 @@
 
     "@types/ws/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
+    "@wormhole-foundation/sdk-algorand-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-algorand-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-algorand-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-algorand-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-algorand/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-algorand/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-aptos-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-aptos-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-aptos-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-aptos-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-aptos-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-aptos-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-aptos/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-aptos/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-btc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-btc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
     "@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
 
     "@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
@@ -2345,6 +2477,10 @@
     "@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
 
     "@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
+
+    "@wormhole-foundation/sdk-cosmwasm-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-cosmwasm-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
 
     "@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
 
@@ -2374,6 +2510,10 @@
 
     "@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
 
+    "@wormhole-foundation/sdk-cosmwasm-ibc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-cosmwasm-ibc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
     "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
 
     "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
@@ -2389,6 +2529,10 @@
     "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
 
     "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
+
+    "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-cosmwasm-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
 
@@ -2423,6 +2567,108 @@
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
+
+    "@wormhole-foundation/sdk-cosmwasm/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-cosmwasm/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-evm-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-evm-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-evm-portico/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-evm-portico/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-evm-tbtc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-evm-tbtc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-evm-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-evm-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-algorand": ["@wormhole-foundation/sdk-algorand@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "algosdk": "2.7.0" } }, "sha512-RpILx+UbR3fwjPavnAEfCan11JVamrx5Ovwk+mZALf76wXXhd3k3O+GbYrst07Og9fRbBWnopoRbukvyTe2mRg=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-algorand-core": ["@wormhole-foundation/sdk-algorand-core@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.17.0", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-G+NecSL90mQoZgRZWf0KVYWnZJJLzEwbV+mxp/NFn6gT5GVJnicaxsC0Cti/u60PfCJOkZlT3Tl0EQs0VPkLbQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-algorand-tokenbridge": ["@wormhole-foundation/sdk-algorand-tokenbridge@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-algorand": "4.17.0", "@wormhole-foundation/sdk-algorand-core": "4.17.0", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-7ZPu3KzH7YijYs9PW9tPu8yd3y5X7LvjYPmh9zrPmnTIiULNrIqG+2VwxECwlUFpd13LTJMFi70P+TBVf3CAmg=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-aptos": ["@wormhole-foundation/sdk-aptos@4.17.0", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-bofhj/nkFMj/xp+j3vzUaHPfUGqRfq698CMS0RuIUD2uOee/m4O+zncfUYt8shN9XeFjFJSqSlATFRCL2XMh1Q=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-aptos-cctp": ["@wormhole-foundation/sdk-aptos-cctp@4.17.0", "", { "dependencies": { "@aptos-labs/ts-sdk": "^2.0.0", "@wormhole-foundation/sdk-aptos": "4.17.0", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-yGktFYehLV/drUsTIt7ZT1EPCHboH8/9ab3WzvaGhrluBHfkIPaiklewNlniOH9JXmTDGo0/WXLZLdDIWfpzlg=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-aptos-core": ["@wormhole-foundation/sdk-aptos-core@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.17.0", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-MUb0tPm1p/JPC+qcPcb+vuaft6/piWH1HRv/GcFi+mdRLiGLBt6cR3N62k8yLEFHq9TcCaGz/QRxeGKc1j+mAA=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-aptos-tokenbridge": ["@wormhole-foundation/sdk-aptos-tokenbridge@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-aptos": "4.17.0", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-JQMq1F88NtNo4cRDcklVzVTfF0GzgJaEIyN9eMopAzvByAHCLp7Ecypy3VNGvPp+Rw1YWyy404Bkyh2hyBgGXQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-btc": ["@wormhole-foundation/sdk-btc@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-/I5vQ2OLgMoOwE60t8FsAcTldjnztgKnM5BMa5OcF+akJCyE2Y6OTBSA+NcLTo4pmRY4rgP3GXKvp/4UX1HqTg=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm": ["@wormhole-foundation/sdk-cosmwasm@4.17.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/proto-signing": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.0", "cosmjs-types": "^0.9.0" } }, "sha512-My2niQQjr7BARQB0Hc2f947xYnR8NdpIrsnFir1k8/2XpOdiyFAkLvxadGjPKvETsodneQkLk1ve9Smjb5c/OQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core": ["@wormhole-foundation/sdk-cosmwasm-core@4.17.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-cosmwasm": "4.17.0" } }, "sha512-qykTmBtoIYwHiD/HsfMMmraiK7I+HEZJPC8oHWN88c1ptFwZ5CFqh8pEPks6xoS10TnsR+14VhBpg4sSnj7fWA=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc": ["@wormhole-foundation/sdk-cosmwasm-ibc@4.17.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@cosmjs/stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-cosmwasm": "4.17.0", "@wormhole-foundation/sdk-cosmwasm-core": "4.17.0", "cosmjs-types": "^0.9.0" } }, "sha512-6XrCXLd8F/QjH97iYjEtQV6Rmn5nWGLQP/KTma3Gi1cuHimRu/9byH5nu63H/zw9UYEgmxn8HPCEG5bCqJT0sA=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge": ["@wormhole-foundation/sdk-cosmwasm-tokenbridge@4.17.0", "", { "dependencies": { "@cosmjs/cosmwasm-stargate": "^0.32.0", "@injectivelabs/sdk-ts": "^1.14.13-beta.2", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-cosmwasm": "4.17.0" } }, "sha512-nX3iJR9gEzpkbNd5Nu6TpnZ2Wul3NWbep1uGv5o5ujvJYm/pgYB4oMS/sA7ee+ExozO8E3aEFvfzMAnYbHJlzA=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-evm-cctp": ["@wormhole-foundation/sdk-evm-cctp@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-evm": "4.17.0", "@wormhole-foundation/sdk-evm-core": "4.17.0", "ethers": "^6.5.1" } }, "sha512-7fqeVdl6OwcMe7ht7BedFEj/M9V9Lwj9fjC8p/13BDUWD3dFOWENO8nSj2moPGGQ1+tEInivJr9QU81Qa2MiUQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-evm-portico": ["@wormhole-foundation/sdk-evm-portico@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-evm": "4.17.0", "@wormhole-foundation/sdk-evm-core": "4.17.0", "@wormhole-foundation/sdk-evm-tokenbridge": "4.17.0", "ethers": "^6.5.1" } }, "sha512-c/Fk3aAp4YjE8WT/9DSY7ERgpQegbNNxtHyB1iISB8BE2mCdFrsZREHdNsQ88S85IS7kEiv7sEFu7B3yiHGPDg=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-evm-tbtc": ["@wormhole-foundation/sdk-evm-tbtc@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-evm": "4.17.0", "@wormhole-foundation/sdk-evm-core": "4.17.0", "ethers": "^6.5.1" } }, "sha512-4Q4sbVAY7fdcptau5zqIB6lfslr7eLgW9X+21bUxS0hK8ogcFGYpUE0ZGKGiK8cjsB1EuYcdw8BGml8Ynw7SlA=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-evm-tokenbridge": ["@wormhole-foundation/sdk-evm-tokenbridge@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-evm": "4.17.0", "@wormhole-foundation/sdk-evm-core": "4.17.0", "ethers": "^6.5.1" } }, "sha512-gt/vfEYH1fTPC83qpHiCunUAvfG+jk82gOnbJOaASXZx7GWy0M0o0vYqOKjcJPFp/G6rcQ4CvAjzGCTtvC/E1A=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-solana-cctp": ["@wormhole-foundation/sdk-solana-cctp@4.17.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-solana": "4.17.0" } }, "sha512-LdikEgiDPBAcaFC2MArsuAiOrFgkLtXc5jGEPDnrCdCIlThEZg39cZit7USg86RcEnPWV/DvbUmAr2lj1Exbhw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-solana-tbtc": ["@wormhole-foundation/sdk-solana-tbtc@4.17.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-solana": "4.17.0", "@wormhole-foundation/sdk-solana-core": "4.17.0", "@wormhole-foundation/sdk-solana-tokenbridge": "4.17.0" } }, "sha512-fI9MXQgdizpfqQyKepyEM7K3rb+UMh8m5VnGLV1Z1GoWsowLSRH0/TYKuui5f9Fb1bf100lxn67f7bBmJIdUVA=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-solana-tokenbridge": ["@wormhole-foundation/sdk-solana-tokenbridge@4.17.0", "", { "dependencies": { "@coral-xyz/anchor": "0.29.0", "@solana/spl-token": "0.3.9", "@solana/web3.js": "^1.95.8", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-solana": "4.17.0", "@wormhole-foundation/sdk-solana-core": "4.17.0" } }, "sha512-CRLuZbT9QmtOdwx4K5wxsfO6LBuWDGGSppDtNuXi72xPCfXHzkd6CMrmB7g9M+xyMOZyP3qkUnz41LVcGp8ZBw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-stacks": ["@wormhole-foundation/sdk-stacks@4.17.0", "", { "dependencies": { "@stacks/network": "^7.0.2", "@stacks/transactions": "^7.1.0", "@wormhole-foundation/sdk-connect": "4.17.0" } }, "sha512-NPICjnjurNW8HiH0citA7qFFxRmXD+ISGZPSb8PwgXGojY1lbNlgBfXV5Vl58a8iOFgypQvIMgTqbxd+817n0A=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-stacks-core": ["@wormhole-foundation/sdk-stacks-core@4.17.0", "", { "dependencies": { "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-stacks": "4.17.0" } }, "sha512-LvEMmGtbhFNNjTyBxTQVDSvMaBqQXyoD6JUPIbKm7vsYgLZWFvybQTunGBOn5oj2lBlHgH4QeFMUQydGIZdHeg=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-sui-cctp": ["@wormhole-foundation/sdk-sui-cctp@4.17.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-sui": "4.17.0" } }, "sha512-q2fNRvmldY+l6l5c95fDrCSGUNRwVKk00IpKt0I7fVg+/psPJ0vPCSx/K1lgXnkgDxCO9TOfd6Y+Y4IRO+UJyg=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-sui-tokenbridge": ["@wormhole-foundation/sdk-sui-tokenbridge@4.17.0", "", { "dependencies": { "@mysten/sui": "^1.37.2", "@wormhole-foundation/sdk-connect": "4.17.0", "@wormhole-foundation/sdk-sui": "4.17.0", "@wormhole-foundation/sdk-sui-core": "4.17.0" } }, "sha512-v7EEhxqXWj4j2cgw90fCiaI7HWEpn7GgvDPtGWF7/KpZ/4bnRcDHJQfe8KbfRPVdgE6WMeUdMt7B8Wh8FKGtiA=="],
+
+    "@wormhole-foundation/sdk-solana-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-solana-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-solana-cctp/@wormhole-foundation/sdk-solana/rpc-websockets": ["rpc-websockets@7.11.2", "", { "dependencies": { "eventemitter3": "^4.0.7", "uuid": "^8.3.2", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" } }, "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ=="],
+
+    "@wormhole-foundation/sdk-solana-tbtc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-solana-tbtc/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-solana-tbtc/@wormhole-foundation/sdk-solana/rpc-websockets": ["rpc-websockets@7.11.2", "", { "dependencies": { "eventemitter3": "^4.0.7", "uuid": "^8.3.2", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" } }, "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ=="],
+
+    "@wormhole-foundation/sdk-solana-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-solana-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-solana-tokenbridge/@wormhole-foundation/sdk-solana/rpc-websockets": ["rpc-websockets@7.11.2", "", { "dependencies": { "eventemitter3": "^4.0.7", "uuid": "^8.3.2", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" } }, "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ=="],
+
+    "@wormhole-foundation/sdk-stacks-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-stacks-core/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-stacks/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-stacks/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-sui-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-sui-cctp/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk-sui-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-base": ["@wormhole-foundation/sdk-base@4.17.1", "", { "dependencies": { "@scure/base": "^1.1.3", "binary-layout": "^1.0.3" } }, "sha512-f2a5VqOBIl0YSSJ5J1jdHXFQefaGwq36q44//2mwhPcFwBKBesrKv41eG+e51/wDnWgjtmDeyFqwm0ea5c89Lg=="],
+
+    "@wormhole-foundation/sdk-sui-tokenbridge/@wormhole-foundation/sdk-connect/@wormhole-foundation/sdk-definitions": ["@wormhole-foundation/sdk-definitions@4.17.1", "", { "dependencies": { "@noble/curves": "^1.4.0", "@noble/hashes": "^1.3.1", "@wormhole-foundation/sdk-base": "4.17.1" } }, "sha512-4sthe6yOPae6C5laE6T3Ima26ZGdE3aGRlcCA5ViuX/Qyr+ITCoxUyWGAZhMlAYp0grwj7yUxMLl532g4DeaBQ=="],
+
+    "@wormhole-foundation/sdk/@wormhole-foundation/sdk-solana/rpc-websockets": ["rpc-websockets@7.11.2", "", { "dependencies": { "eventemitter3": "^4.0.7", "uuid": "^8.3.2", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" } }, "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ=="],
 
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util": ["jest-util@27.5.1", "", { "dependencies": { "@jest/types": "^27.5.1", "@types/node": "*", "chalk": "^4.0.0", "ci-info": "^3.2.0", "graceful-fs": "^4.2.9", "picomatch": "^2.2.3" } }, "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw=="],
 
@@ -2842,6 +3088,22 @@
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
 
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate": ["@cosmjs/stargate@0.32.4", "", { "dependencies": { "@confio/ics23": "^0.6.8", "@cosmjs/amino": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "xstream": "^11.14.0" } }, "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate": ["@cosmjs/stargate@0.32.4", "", { "dependencies": { "@confio/ics23": "^0.6.8", "@cosmjs/amino": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "xstream": "^11.14.0" } }, "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate": ["@cosmjs/stargate@0.32.4", "", { "dependencies": { "@confio/ics23": "^0.6.8", "@cosmjs/amino": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "xstream": "^11.14.0" } }, "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate": ["@cosmjs/cosmwasm-stargate@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "pako": "^2.0.2" } }, "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA=="],
+
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util/@jest/types": ["@jest/types@27.5.1", "", { "dependencies": { "@types/istanbul-lib-coverage": "^2.0.0", "@types/istanbul-reports": "^3.0.0", "@types/node": "*", "@types/yargs": "^16.0.0", "chalk": "^4.0.0" } }, "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw=="],
 
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
@@ -3062,6 +3324,112 @@
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/proto-signing": ["@cosmjs/proto-signing@0.32.4", "", { "dependencies": { "@cosmjs/amino": "^0.32.4", "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0" } }, "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/stargate": ["@cosmjs/stargate@0.32.4", "", { "dependencies": { "@confio/ics23": "^0.6.8", "@cosmjs/amino": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/tendermint-rpc": "^0.32.4", "@cosmjs/utils": "^0.32.4", "cosmjs-types": "^0.9.0", "xstream": "^11.14.0" } }, "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/amino": ["@cosmjs/amino@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4" } }, "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/encoding": ["@cosmjs/encoding@0.32.4", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/math": ["@cosmjs/math@0.32.4", "", { "dependencies": { "bn.js": "^5.2.0" } }, "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
+
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util/@jest/types/@types/yargs": ["@types/yargs@16.0.11", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-sbtvk8wDN+JvEdabmZExoW/HNr1cB7D/j4LT08rMiuikfA7m/JNJg7ATQcgzs34zHnoScDkY0ZRSl29Fkmk36g=="],
 
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
@@ -3152,6 +3520,102 @@
 
     "@jest/fake-timers/jest-util/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/json-rpc": ["@cosmjs/json-rpc@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "xstream": "^11.14.0" } }, "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/amino/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/proto-signing/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/json-rpc": ["@cosmjs/json-rpc@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "xstream": "^11.14.0" } }, "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/json-rpc": ["@cosmjs/json-rpc@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "xstream": "^11.14.0" } }, "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/amino/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/proto-signing/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/json-rpc": ["@cosmjs/json-rpc@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "xstream": "^11.14.0" } }, "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/stargate/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/json-rpc": ["@cosmjs/json-rpc@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "xstream": "^11.14.0" } }, "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/json-rpc": ["@cosmjs/json-rpc@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "xstream": "^11.14.0" } }, "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/stream": ["@cosmjs/stream@0.32.4", "", { "dependencies": { "xstream": "^11.14.0" } }, "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/proto-signing/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/amino/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/encoding/bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/math/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/crypto": ["@cosmjs/crypto@0.32.4", "", { "dependencies": { "@cosmjs/encoding": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/utils": "^0.32.4", "@noble/hashes": "^1", "bn.js": "^5.2.0", "elliptic": "^6.5.4", "libsodium-wrappers-sumo": "^0.7.11" } }, "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/json-rpc": ["@cosmjs/json-rpc@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "xstream": "^11.14.0" } }, "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket": ["@cosmjs/socket@0.32.4", "", { "dependencies": { "@cosmjs/stream": "^0.32.4", "isomorphic-ws": "^4.0.1", "ws": "^7", "xstream": "^11.14.0" } }, "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw=="],
+
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -3173,6 +3637,36 @@
     "@jest/expect/expect/jest-message-util/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "@jest/expect/expect/jest-util/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/amino/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/proto-signing/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-core/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/amino/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/proto-signing/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-ibc/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm-tokenbridge/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/cosmwasm-stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/amino/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/crypto/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@wormhole-foundation/sdk-examples-ntt/@wormhole-foundation/sdk/@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 

--- a/cli/e2e/e2e-anvil.test.ts
+++ b/cli/e2e/e2e-anvil.test.ts
@@ -66,10 +66,23 @@ let anvilSepolia: ReturnType<typeof Bun.spawn> | null = null;
 let anvilBaseSepolia: ReturnType<typeof Bun.spawn> | null = null;
 let testDir: string = "";
 
-/** Wait for an RPC endpoint to respond. */
-async function waitForRpc(url: string, timeoutMs = 30_000): Promise<void> {
+/** Wait for an RPC endpoint to respond. Detects early process exit. */
+async function waitForRpc(
+  url: string,
+  proc?: ReturnType<typeof Bun.spawn>,
+  timeoutMs = 60_000
+): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
+    if (proc && proc.exitCode !== null) {
+      const stderr =
+        proc.stderr && typeof proc.stderr !== "number"
+          ? await new Response(proc.stderr).text()
+          : "(no stderr captured)";
+      throw new Error(
+        `Anvil process exited with code ${proc.exitCode} before RPC ${url} was ready.\nStderr: ${stderr}`
+      );
+    }
     try {
       const res = await fetch(url, {
         method: "POST",
@@ -249,7 +262,7 @@ describe("E2E: NTT deployment on Anvil forks", () => {
         String(SEPOLIA_PORT),
         "--auto-impersonate",
       ],
-      { stdout: "ignore", stderr: "ignore" }
+      { stdout: "ignore", stderr: "pipe" }
     );
 
     anvilBaseSepolia = Bun.spawn(
@@ -262,12 +275,12 @@ describe("E2E: NTT deployment on Anvil forks", () => {
         String(BASE_SEPOLIA_PORT),
         "--auto-impersonate",
       ],
-      { stdout: "ignore", stderr: "ignore" }
+      { stdout: "ignore", stderr: "pipe" }
     );
 
     await Promise.all([
-      waitForRpc(SEPOLIA_FORK_RPC),
-      waitForRpc(BASE_SEPOLIA_FORK_RPC),
+      waitForRpc(SEPOLIA_FORK_RPC, anvilSepolia),
+      waitForRpc(BASE_SEPOLIA_FORK_RPC, anvilBaseSepolia),
     ]);
 
     // 2. Set core bridge message fee

--- a/cli/src/evm/deploy.ts
+++ b/cli/src/evm/deploy.ts
@@ -188,67 +188,57 @@ export async function deployEvm<N extends Network, C extends Chain>(
 
   console.log("Deploying manager...");
 
-  // Build forge environment variables (v2+ scripts).
-  // Reused by deployWithOnChainGasEstimation.
-  const buildForgeEnv = (): NodeJS.ProcessEnv => ({
-    ...process.env,
-    RELEASE_CORE_BRIDGE_ADDRESS: wormhole,
-    RELEASE_TOKEN_ADDRESS: token,
-    RELEASE_DECIMALS: decimals.toString(),
-    RELEASE_MODE: modeUint.toString(),
-    RELEASE_CONSISTENCY_LEVEL: cclConfig ? "203" : "202",
-    RELEASE_GAS_LIMIT: "500000",
-    MANAGER_VARIANT: managerVariant,
-    ...(cclConfig && {
-      RELEASE_CUSTOM_CONSISTENCY_LEVEL:
-        cclConfig.customConsistencyLevel.toString(),
-      RELEASE_ADDITIONAL_BLOCKS: cclConfig.additionalBlocks.toString(),
-      RELEASE_CUSTOM_CONSISTENCY_LEVEL_ADDRESS: cclConfig.cclContractAddress,
-    }),
-  });
+  // Use bundled v1 scripts if version 1 detected
+  const useBundledV1 = scriptVersion === 1;
+
+  // v1 passes deploy params via --sig arguments,
+  // v2+ passes them via environment variables.
+  const zeroAddress = "0x0000000000000000000000000000000000000000";
+  const v1SigArgs =
+    scriptVersion === 1
+      ? `--sig "run(address,address,address,address,uint8,uint8)" ${wormhole} ${token} ${zeroAddress} ${zeroAddress} ${decimals} ${modeUint}`
+      : "";
+
+  const forgeEnv: NodeJS.ProcessEnv =
+    scriptVersion === 1
+      ? { ...process.env }
+      : {
+          ...process.env,
+          RELEASE_CORE_BRIDGE_ADDRESS: wormhole,
+          RELEASE_TOKEN_ADDRESS: token,
+          RELEASE_DECIMALS: decimals.toString(),
+          RELEASE_MODE: modeUint.toString(),
+          RELEASE_CONSISTENCY_LEVEL: cclConfig ? "203" : "202",
+          RELEASE_GAS_LIMIT: "500000",
+          MANAGER_VARIANT: managerVariant,
+          ...(cclConfig && {
+            RELEASE_CUSTOM_CONSISTENCY_LEVEL:
+              cclConfig.customConsistencyLevel.toString(),
+            RELEASE_ADDITIONAL_BLOCKS: cclConfig.additionalBlocks.toString(),
+            RELEASE_CUSTOM_CONSISTENCY_LEVEL_ADDRESS:
+              cclConfig.cclContractAddress,
+          }),
+        };
+
+  const slowFlag = getSlowFlag(ch.chain);
+  const gasMultiplier = getGasMultiplier(gasEstimateMultiplier);
 
   const deploy = async (simulate: boolean): Promise<string> => {
     const simulateArg = simulate ? "" : "--skip-simulation";
-    const slowFlag = getSlowFlag(ch.chain);
-    const gasMultiplier = getGasMultiplier(gasEstimateMultiplier);
-
-    // Use bundled v1 scripts if version 1 detected
-    const useBundledV1 = scriptVersion === 1;
 
     await withDeploymentScript(pwd, useBundledV1, async () => {
       try {
-        let command: string;
-        let env: NodeJS.ProcessEnv = { ...process.env };
-
-        if (scriptVersion === 1) {
-          // Version 1: Use explicit signature with parameters (6 params including relayers)
-          // The bundled v1 scripts expect relayer addresses, use zero addresses as defaults
-          const zeroAddress = "0x0000000000000000000000000000000000000000";
-          const sig = "run(address,address,address,address,uint8,uint8)";
-          command = `forge script --via-ir script/DeployWormholeNtt.s.sol \
+        const command = `forge script --via-ir script/DeployWormholeNtt.s.sol \
 --rpc-url "${rpc}" \
 ${simulateArg} \
---sig "${sig}" ${wormhole} ${token} ${zeroAddress} ${zeroAddress} ${decimals} ${modeUint} \
---broadcast ${slowFlag} ${gasMultiplier} ${verifyArgs.join(
-            " "
-          )} ${signerArgs} 2>&1 | tee last-run.stdout`;
-        } else {
-          // Version 2+: Use environment variables
-          env = buildForgeEnv();
-
-          command = `forge script --via-ir script/DeployWormholeNtt.s.sol \
---rpc-url "${rpc}" \
-${simulateArg} \
---broadcast ${slowFlag} ${gasMultiplier} ${verifyArgs.join(
-            " "
-          )} ${signerArgs} 2>&1 | tee last-run.stdout`;
-        }
+${v1SigArgs} \
+--broadcast ${slowFlag} ${gasMultiplier} ${verifyArgs.join(" ")} ${signerArgs} 2>&1 | tee last-run.stdout`;
 
         execSync(command, {
           cwd: `${pwd}/evm`,
           encoding: "utf8",
           stdio: "inherit",
-          env,
+          env: forgeEnv,
         });
       } catch (error) {
         console.error("Failed to deploy manager");

--- a/cli/src/evm/deploy.ts
+++ b/cli/src/evm/deploy.ts
@@ -263,7 +263,15 @@ ${simulateArg} \
   // we attempt to deploy with simulation first, then without if it fails
   let out = await deploy(true);
   if (out.includes("Simulated execution failed")) {
-    if (out.includes("OpcodeNotFound") || out.includes("StaticcallFailed")) {
+    if (out.includes("NotActivated")) {
+      console.error(
+        "Simulation failed, likely because the token contract is compiled against a different EVM version. It's probably safe to continue without simulation."
+      );
+      await askForConfirmation(
+        "Do you want to proceed with the deployment without simulation?"
+      );
+      out = await deploy(false);
+    } else if (out.includes("OpcodeNotFound") || out.includes("StaticcallFailed")) {
       // Precompile/system contract token — Forge's local EVM can't handle the
       // token's bytecode. Generate transactions via dry-run, fix gas limits
       // using eth_estimateGas from the actual RPC, then broadcast with --resume.
@@ -282,14 +290,6 @@ ${simulateArg} \
         gasEstimateMultiplier,
         buildForgeEnv
       );
-    } else if (out.includes("NotActivated")) {
-      console.error(
-        "Simulation failed, likely because the token contract is compiled against a different EVM version. It's probably safe to continue without simulation."
-      );
-      await askForConfirmation(
-        "Do you want to proceed with the deployment without simulation?"
-      );
-      out = await deploy(false);
     } else {
       console.error(
         "Simulation failed. Please read the error message carefully, and proceed with caution."

--- a/cli/src/evm/deploy.ts
+++ b/cli/src/evm/deploy.ts
@@ -275,24 +275,18 @@ ${simulateArg} \
       out.includes("OpcodeNotFound") ||
       out.includes("StaticcallFailed")
     ) {
-      // Precompile/system contract token — Forge's local EVM can't handle the
-      // token's bytecode. Generate transactions via dry-run, fix gas limits
-      // using eth_estimateGas from the actual RPC, then broadcast with --resume.
+      // Precompile/system contract token — Forge's local EVM (revm) can't
+      // execute precompile bytecode, causing simulation to fail. However, the
+      // real RPC can handle precompiles fine, so --skip-simulation with
+      // --broadcast works: Forge uses eth_estimateGas from the RPC.
       console.log(
         colors.yellow(
-          "Precompile token detected. Using on-chain gas estimation for deployment..."
+          "Precompile token detected. Forge's local simulation can't handle " +
+            "precompile bytecode, but the on-chain RPC can. Retrying with " +
+            "--skip-simulation..."
         )
       );
-      out = await deployWithOnChainGasEstimation(
-        pwd,
-        rpc,
-        ch,
-        scriptVersion,
-        signerType,
-        verifyArgs,
-        gasEstimateMultiplier,
-        buildForgeEnv
-      );
+      out = await deploy(false);
     } else {
       console.error(
         "Simulation failed. Please read the error message carefully, and proceed with caution."
@@ -352,164 +346,3 @@ ${simulateArg} \
   return { chain: ch.chain, address: universalManager };
 }
 
-/**
- * Deploy NTT contracts on chains with precompile/system contract tokens.
- *
- * Forge's local EVM (revm) can't execute precompile bytecode, producing
- * OpcodeNotFound errors and wrong gas estimates. This function:
- * 1. Runs forge script WITHOUT --broadcast (dry-run) to generate tx JSON
- * 2. Fixes gas limits: eth_estimateGas for CREATE txs, keeps forge gas for others
- * 3. Copies fixed JSON to broadcast dir and runs forge --resume to broadcast
- */
-async function deployWithOnChainGasEstimation<
-  N extends Network,
-  C extends Chain,
->(
-  pwd: string,
-  rpc: string,
-  ch: ChainContext<N, C>,
-  scriptVersion: number,
-  signerType: SignerType,
-  verifyArgs: string[],
-  gasEstimateMultiplier: number | undefined,
-  buildForgeEnv: () => NodeJS.ProcessEnv
-): Promise<string> {
-  const slowFlag = getSlowFlag(ch.chain);
-  const gasMultiplier = getGasMultiplier(gasEstimateMultiplier);
-  const signer = await getSigner(ch, signerType);
-  const signerArgs = forgeSignerArgs(signer.source);
-  const useBundledV1 = scriptVersion === 1;
-  const chainId = ch.config.nativeChainId;
-
-  // Step 1: Generate transactions WITHOUT broadcasting (dry-run only).
-  // This avoids consuming nonces with failed on-chain txs.
-  const dryRunStdoutPath = `${pwd}/evm/dry-run.stdout`;
-  console.log(colors.cyan("Step 1: Generating transactions (dry-run)..."));
-  await withDeploymentScript(pwd, useBundledV1, async () => {
-    try {
-      const env = buildForgeEnv();
-      // No --broadcast flag — generates dry-run JSON only
-      const command = `forge script --via-ir script/DeployWormholeNtt.s.sol \
---rpc-url "${rpc}" \
---skip-simulation \
-${slowFlag} ${gasMultiplier} ${verifyArgs.join(" ")} ${signerArgs} 2>&1 | tee dry-run.stdout`;
-
-      execSync(command, {
-        cwd: `${pwd}/evm`,
-        encoding: "utf8",
-        stdio: "inherit",
-        env,
-      });
-    } catch {
-      // Script may "fail" due to simulation traces but still generates the dry-run JSON.
-      // The dry-run file existence check below handles real failures.
-      console.log(
-        colors.yellow(
-          "Dry-run exited with non-zero status (may be expected for precompile tokens)"
-        )
-      );
-    }
-  });
-
-  // Step 2: Copy dry-run JSON to broadcast dir and fix gas limits
-  const broadcastDir = `${pwd}/evm/broadcast/DeployWormholeNtt.s.sol/${chainId}`;
-  const dryRunPath = `${broadcastDir}/dry-run/run-latest.json`;
-  const broadcastPath = `${broadcastDir}/run-latest.json`;
-
-  if (!fs.existsSync(dryRunPath)) {
-    console.error(
-      colors.red(
-        "Dry-run file not found. Forge may not have generated transactions."
-      )
-    );
-    return "";
-  }
-
-  // Copy dry-run to broadcast location so --resume can pick it up
-  fs.mkdirSync(broadcastDir, { recursive: true });
-  fs.copyFileSync(dryRunPath, broadcastPath);
-
-  console.log(colors.cyan("Step 2: Fixing gas limits..."));
-  const provider = new ethers.JsonRpcProvider(rpc);
-  const broadcast = JSON.parse(fs.readFileSync(broadcastPath, "utf8"));
-
-  for (const tx of broadcast.transactions) {
-    const oldGasHex = tx.transaction.gas;
-    const oldGas = parseInt(oldGasHex, 16);
-    const label = `${tx.contractName || "Unknown"}(${tx.transactionType})`;
-
-    if (tx.transactionType === "CREATE") {
-      // CREATE txs are independent — we can estimate gas from the RPC
-      const txData: Record<string, string> = {
-        from: tx.transaction.from,
-        value: tx.transaction.value || "0x0",
-        data: tx.transaction.input || tx.transaction.data,
-      };
-
-      try {
-        const estimated = await provider.estimateGas(txData);
-        // Use the higher of: estimated + 5% buffer, or forge's original gas.
-        // Keep the buffer small to avoid hitting RPC per-tx gas caps.
-        const buffered = (estimated * 105n) / 100n;
-        const newGas = buffered > BigInt(oldGas) ? buffered : BigInt(oldGas);
-        tx.transaction.gas = "0x" + newGas.toString(16);
-        console.log(
-          `  ${label}: ${oldGas.toLocaleString()} → ${Number(newGas).toLocaleString()} gas (estimated)`
-        );
-      } catch (e) {
-        // Estimation failed (e.g., proxy CREATE referencing un-deployed impl).
-        // Keep forge's original gas — it's from local sim and usually close
-        // enough for non-precompile txs.
-        const message = e instanceof Error ? e.message : String(e);
-        console.log(
-          colors.yellow(
-            `  ${label}: keeping ${oldGas.toLocaleString()} gas (estimate failed: ${message.slice(0, 80)})`
-          )
-        );
-      }
-    } else {
-      // CALL txs depend on contracts from prior CREATE txs that don't exist
-      // on-chain yet. Keep forge's original gas from the local simulation.
-      console.log(
-        `  ${label}: keeping ${oldGas.toLocaleString()} gas (forge estimate)`
-      );
-    }
-  }
-
-  // Clear any receipts so --resume treats all txs as pending
-  broadcast.receipts = [];
-  fs.writeFileSync(broadcastPath, JSON.stringify(broadcast, null, 2));
-
-  // Step 3: Resume broadcast with fixed gas limits
-  console.log(colors.cyan("Step 3: Broadcasting with corrected gas limits..."));
-  await withDeploymentScript(pwd, useBundledV1, async () => {
-    try {
-      const env = buildForgeEnv();
-      const command = `forge script --via-ir script/DeployWormholeNtt.s.sol \
---rpc-url "${rpc}" \
---resume \
---broadcast ${slowFlag} ${signerArgs} 2>&1 | tee last-run.stdout`;
-
-      execSync(command, {
-        cwd: `${pwd}/evm`,
-        encoding: "utf8",
-        stdio: "inherit",
-        env,
-      });
-    } catch (error) {
-      console.error("Failed to broadcast transactions");
-      // NOTE: we don't exit here. The caller checks for NttManager address
-      // in the output and handles the missing-address case.
-    }
-  });
-
-  // Return dry-run output which has the contract addresses (NttManager: 0x...).
-  // The --resume output doesn't re-print forge logs.
-  if (!fs.existsSync(dryRunStdoutPath)) {
-    console.error(
-      colors.red("Dry-run stdout not found at " + dryRunStdoutPath)
-    );
-    return "";
-  }
-  return fs.readFileSync(dryRunStdoutPath).toString();
-}

--- a/cli/src/evm/deploy.ts
+++ b/cli/src/evm/deploy.ts
@@ -345,4 +345,3 @@ ${simulateArg} \
 
   return { chain: ch.chain, address: universalManager };
 }
-

--- a/cli/src/evm/deploy.ts
+++ b/cli/src/evm/deploy.ts
@@ -187,6 +187,26 @@ export async function deployEvm<N extends Network, C extends Chain>(
   }
 
   console.log("Deploying manager...");
+
+  // Build forge environment variables (v2+ scripts).
+  // Reused by deployWithOnChainGasEstimation.
+  const buildForgeEnv = (): NodeJS.ProcessEnv => ({
+    ...process.env,
+    RELEASE_CORE_BRIDGE_ADDRESS: wormhole,
+    RELEASE_TOKEN_ADDRESS: token,
+    RELEASE_DECIMALS: decimals.toString(),
+    RELEASE_MODE: modeUint.toString(),
+    RELEASE_CONSISTENCY_LEVEL: cclConfig ? "203" : "202",
+    RELEASE_GAS_LIMIT: "500000",
+    MANAGER_VARIANT: managerVariant,
+    ...(cclConfig && {
+      RELEASE_CUSTOM_CONSISTENCY_LEVEL:
+        cclConfig.customConsistencyLevel.toString(),
+      RELEASE_ADDITIONAL_BLOCKS: cclConfig.additionalBlocks.toString(),
+      RELEASE_CUSTOM_CONSISTENCY_LEVEL_ADDRESS: cclConfig.cclContractAddress,
+    }),
+  });
+
   const deploy = async (simulate: boolean): Promise<string> => {
     const simulateArg = simulate ? "" : "--skip-simulation";
     const slowFlag = getSlowFlag(ch.chain);
@@ -214,26 +234,7 @@ ${simulateArg} \
           )} ${signerArgs} 2>&1 | tee last-run.stdout`;
         } else {
           // Version 2+: Use environment variables
-          env = {
-            ...env,
-            RELEASE_CORE_BRIDGE_ADDRESS: wormhole,
-            RELEASE_TOKEN_ADDRESS: token,
-            RELEASE_DECIMALS: decimals.toString(),
-            RELEASE_MODE: modeUint.toString(),
-            RELEASE_CONSISTENCY_LEVEL: cclConfig ? "203" : "202",
-            RELEASE_GAS_LIMIT: "500000",
-            MANAGER_VARIANT: managerVariant,
-          };
-
-          // Add CCL-specific environment variables when CCL is enabled
-          if (cclConfig) {
-            env.RELEASE_CUSTOM_CONSISTENCY_LEVEL =
-              cclConfig.customConsistencyLevel.toString();
-            env.RELEASE_ADDITIONAL_BLOCKS =
-              cclConfig.additionalBlocks.toString();
-            env.RELEASE_CUSTOM_CONSISTENCY_LEVEL_ADDRESS =
-              cclConfig.cclContractAddress;
-          }
+          env = buildForgeEnv();
 
           command = `forge script --via-ir script/DeployWormholeNtt.s.sol \
 --rpc-url "${rpc}" \
@@ -262,13 +263,33 @@ ${simulateArg} \
   // we attempt to deploy with simulation first, then without if it fails
   let out = await deploy(true);
   if (out.includes("Simulated execution failed")) {
-    if (out.includes("NotActivated")) {
+    if (out.includes("OpcodeNotFound") || out.includes("StaticcallFailed")) {
+      // Precompile/system contract token — Forge's local EVM can't handle the
+      // token's bytecode. Generate transactions via dry-run, fix gas limits
+      // using eth_estimateGas from the actual RPC, then broadcast with --resume.
+      console.log(
+        colors.yellow(
+          "Precompile token detected. Using on-chain gas estimation for deployment..."
+        )
+      );
+      out = await deployWithOnChainGasEstimation(
+        pwd,
+        rpc,
+        ch,
+        scriptVersion,
+        signerType,
+        verifyArgs,
+        gasEstimateMultiplier,
+        buildForgeEnv
+      );
+    } else if (out.includes("NotActivated")) {
       console.error(
         "Simulation failed, likely because the token contract is compiled against a different EVM version. It's probably safe to continue without simulation."
       );
       await askForConfirmation(
         "Do you want to proceed with the deployment without simulation?"
       );
+      out = await deploy(false);
     } else {
       console.error(
         "Simulation failed. Please read the error message carefully, and proceed with caution."
@@ -276,8 +297,8 @@ ${simulateArg} \
       await askForConfirmation(
         "Do you want to proceed with the deployment without simulation?"
       );
+      out = await deploy(false);
     }
-    out = await deploy(false);
   }
 
   if (!out) {
@@ -326,4 +347,166 @@ ${simulateArg} \
   }
 
   return { chain: ch.chain, address: universalManager };
+}
+
+/**
+ * Deploy NTT contracts on chains with precompile/system contract tokens.
+ *
+ * Forge's local EVM (revm) can't execute precompile bytecode, producing
+ * OpcodeNotFound errors and wrong gas estimates. This function:
+ * 1. Runs forge script WITHOUT --broadcast (dry-run) to generate tx JSON
+ * 2. Fixes gas limits: eth_estimateGas for CREATE txs, keeps forge gas for others
+ * 3. Copies fixed JSON to broadcast dir and runs forge --resume to broadcast
+ */
+async function deployWithOnChainGasEstimation<
+  N extends Network,
+  C extends Chain,
+>(
+  pwd: string,
+  rpc: string,
+  ch: ChainContext<N, C>,
+  scriptVersion: number,
+  signerType: SignerType,
+  verifyArgs: string[],
+  gasEstimateMultiplier: number | undefined,
+  buildForgeEnv: () => NodeJS.ProcessEnv
+): Promise<string> {
+  const slowFlag = getSlowFlag(ch.chain);
+  const gasMultiplier = getGasMultiplier(gasEstimateMultiplier);
+  const signer = await getSigner(ch, signerType);
+  const signerArgs = forgeSignerArgs(signer.source);
+  const useBundledV1 = scriptVersion === 1;
+  const chainId = ch.config.nativeChainId;
+
+  // Step 1: Generate transactions WITHOUT broadcasting (dry-run only).
+  // This avoids consuming nonces with failed on-chain txs.
+  const dryRunStdoutPath = `${pwd}/evm/dry-run.stdout`;
+  console.log(colors.cyan("Step 1: Generating transactions (dry-run)..."));
+  await withDeploymentScript(pwd, useBundledV1, async () => {
+    try {
+      const env = buildForgeEnv();
+      // No --broadcast flag — generates dry-run JSON only
+      const command = `forge script --via-ir script/DeployWormholeNtt.s.sol \
+--rpc-url "${rpc}" \
+--skip-simulation \
+${slowFlag} ${gasMultiplier} ${verifyArgs.join(" ")} ${signerArgs} 2>&1 | tee dry-run.stdout`;
+
+      execSync(command, {
+        cwd: `${pwd}/evm`,
+        encoding: "utf8",
+        stdio: "inherit",
+        env,
+      });
+    } catch {
+      // Script may "fail" due to simulation traces but still generates the dry-run JSON.
+      // The dry-run file existence check below handles real failures.
+      console.log(
+        colors.yellow(
+          "Dry-run exited with non-zero status (may be expected for precompile tokens)"
+        )
+      );
+    }
+  });
+
+  // Step 2: Copy dry-run JSON to broadcast dir and fix gas limits
+  const broadcastDir = `${pwd}/evm/broadcast/DeployWormholeNtt.s.sol/${chainId}`;
+  const dryRunPath = `${broadcastDir}/dry-run/run-latest.json`;
+  const broadcastPath = `${broadcastDir}/run-latest.json`;
+
+  if (!fs.existsSync(dryRunPath)) {
+    console.error(
+      colors.red(
+        "Dry-run file not found. Forge may not have generated transactions."
+      )
+    );
+    return "";
+  }
+
+  // Copy dry-run to broadcast location so --resume can pick it up
+  fs.mkdirSync(broadcastDir, { recursive: true });
+  fs.copyFileSync(dryRunPath, broadcastPath);
+
+  console.log(colors.cyan("Step 2: Fixing gas limits..."));
+  const provider = new ethers.JsonRpcProvider(rpc);
+  const broadcast = JSON.parse(fs.readFileSync(broadcastPath, "utf8"));
+
+  for (const tx of broadcast.transactions) {
+    const oldGasHex = tx.transaction.gas;
+    const oldGas = parseInt(oldGasHex, 16);
+    const label = `${tx.contractName || "Unknown"}(${tx.transactionType})`;
+
+    if (tx.transactionType === "CREATE") {
+      // CREATE txs are independent — we can estimate gas from the RPC
+      const txData: Record<string, string> = {
+        from: tx.transaction.from,
+        value: tx.transaction.value || "0x0",
+        data: tx.transaction.input || tx.transaction.data,
+      };
+
+      try {
+        const estimated = await provider.estimateGas(txData);
+        // Use the higher of: estimated + 5% buffer, or forge's original gas.
+        // Keep the buffer small to avoid hitting RPC per-tx gas caps.
+        const buffered = (estimated * 105n) / 100n;
+        const newGas = buffered > BigInt(oldGas) ? buffered : BigInt(oldGas);
+        tx.transaction.gas = "0x" + newGas.toString(16);
+        console.log(
+          `  ${label}: ${oldGas.toLocaleString()} → ${Number(newGas).toLocaleString()} gas (estimated)`
+        );
+      } catch (e) {
+        // Estimation failed (e.g., proxy CREATE referencing un-deployed impl).
+        // Keep forge's original gas — it's from local sim and usually close
+        // enough for non-precompile txs.
+        const message = e instanceof Error ? e.message : String(e);
+        console.log(
+          colors.yellow(
+            `  ${label}: keeping ${oldGas.toLocaleString()} gas (estimate failed: ${message.slice(0, 80)})`
+          )
+        );
+      }
+    } else {
+      // CALL txs depend on contracts from prior CREATE txs that don't exist
+      // on-chain yet. Keep forge's original gas from the local simulation.
+      console.log(
+        `  ${label}: keeping ${oldGas.toLocaleString()} gas (forge estimate)`
+      );
+    }
+  }
+
+  // Clear any receipts so --resume treats all txs as pending
+  broadcast.receipts = [];
+  fs.writeFileSync(broadcastPath, JSON.stringify(broadcast, null, 2));
+
+  // Step 3: Resume broadcast with fixed gas limits
+  console.log(colors.cyan("Step 3: Broadcasting with corrected gas limits..."));
+  await withDeploymentScript(pwd, useBundledV1, async () => {
+    try {
+      const env = buildForgeEnv();
+      const command = `forge script --via-ir script/DeployWormholeNtt.s.sol \
+--rpc-url "${rpc}" \
+--resume \
+--broadcast ${slowFlag} ${signerArgs} 2>&1 | tee last-run.stdout`;
+
+      execSync(command, {
+        cwd: `${pwd}/evm`,
+        encoding: "utf8",
+        stdio: "inherit",
+        env,
+      });
+    } catch (error) {
+      console.error("Failed to broadcast transactions");
+      // NOTE: we don't exit here. The caller checks for NttManager address
+      // in the output and handles the missing-address case.
+    }
+  });
+
+  // Return dry-run output which has the contract addresses (NttManager: 0x...).
+  // The --resume output doesn't re-print forge logs.
+  if (!fs.existsSync(dryRunStdoutPath)) {
+    console.error(
+      colors.red("Dry-run stdout not found at " + dryRunStdoutPath)
+    );
+    return "";
+  }
+  return fs.readFileSync(dryRunStdoutPath).toString();
 }

--- a/cli/src/evm/deploy.ts
+++ b/cli/src/evm/deploy.ts
@@ -271,7 +271,10 @@ ${simulateArg} \
         "Do you want to proceed with the deployment without simulation?"
       );
       out = await deploy(false);
-    } else if (out.includes("OpcodeNotFound") || out.includes("StaticcallFailed")) {
+    } else if (
+      out.includes("OpcodeNotFound") ||
+      out.includes("StaticcallFailed")
+    ) {
       // Precompile/system contract token — Forge's local EVM can't handle the
       // token's bytecode. Generate transactions via dry-run, fix gas limits
       // using eth_estimateGas from the actual RPC, then broadcast with --resume.

--- a/cli/src/evm/signer.ts
+++ b/cli/src/evm/signer.ts
@@ -106,13 +106,16 @@ export class EvmNativeSigner<N extends Network, C extends EvmChains = EvmChains>
 
     let gasLimit: bigint;
 
-    // Specialized for Mantle and Arbitrum Sepolia
+    // Per-chain gas limit overrides where the default 500k is insufficient
     switch (chain) {
       case "Mantle":
         gasLimit = 2600_000_000_000n;
         break;
       case "ArbitrumSepolia":
         gasLimit = 4_000_000n;
+        break;
+      case "Tempo":
+        gasLimit = 2_000_000n;
         break;
       default:
         // default gas limit


### PR DESCRIPTION
Chains with precompile/system contract tokens (e.g. Tempo) cause `OpcodeNotFound` errors in Forge's local EVM. When simulation fails with `OpcodeNotFound` or `StaticcallFailed`, the CLI now:

1. Runs forge script without --broadcast to generate dry-run tx JSON
2. Fixes gas limits via eth_estimateGas for CREATE txs
3. Broadcasts with --resume using corrected gas values

Also:
- Add Tempo per-chain gas limit override (2M) in signer.ts
- Bump SDK to 4.17.1 (sendWait fix for custom tx types)
- Improve e2e waitForRpc to detect early Anvil process exit