### PR TITLE
fix(ci): remove unrecognized --generic_relayer flag from tilt invocation

### DIFF
--- a/.github/workflows/tilt.yml
+++ b/.github/workflows/tilt.yml
@@ -57,7 +57,7 @@ jobs:
           kubectl config set-context ci --namespace=$DEPLOY_NS
           kubectl config use-context ci
 
-      - run: tilt ci -- --evm2 --generic_relayer --solana_watcher --wormchain --guardiand_loglevel=warn --namespace=$DEPLOY_NS
+      - run: tilt ci -- --evm2 --solana_watcher --wormchain --guardiand_loglevel=warn --namespace=$DEPLOY_NS
         timeout-minutes: 30
 
       # Clean up k8s resources


### PR DESCRIPTION
## Summary
The Tilt CI job has been failing on every PR (and main) since at least Apr 21 with:

```
ERROR: Traceback (most recent call last):
  /home/wormhole/actions-runner/_work/native-token-transfers/native-token-transfers/.wormhole/Tiltfile:77:19: in <toplevel>
Error in config.parse: invalid Tiltfile config args: unknown flag: --generic_relayer
```

The `.wormhole/` submodule's Tiltfile no longer declares `--generic_relayer` as a valid flag in its `config.define_*()` block, so the `tilt ci` invocation in `.github/workflows/tilt.yml` aborts before any Kubernetes resources are spun up.

## Fix
Drop `--generic_relayer` from the `tilt ci` flag list. This is the same one-line change Douglas Galico made on the `feat/tempo-precompile-deploy-support` branch (commit `ddbc520e`); cherry-picked here so the fix lands on `main` independent of that feature work.

## Diff
```diff
- - run: tilt ci -- --evm2 --generic_relayer --solana_watcher --wormchain --guardiand_loglevel=warn --namespace=$DEPLOY_NS
+ - run: tilt ci -- --evm2 --solana_watcher --wormchain --guardiand_loglevel=warn --namespace=$DEPLOY_NS
```

## Why now
Tilt is a required check on `main`, so every PR is blocked behind it. The fix exists on a feature branch that hasn't merged. Pulling it out into a standalone PR unblocks every PR currently in flight (including #863 and others).

## Test plan
- [ ] Tilt CI on this PR passes
- [ ] No other workflows regress

## Refs
- The same fix on another branch: [`ddbc520e fix: tilt`](https://github.com/wormhole-foundation/native-token-transfers/commit/ddbc520eb847ca6db01db8fe7d79d0f01167ecec) (on `feat/tempo-precompile-deploy-support`)
