### PR TITLE
chore: revert source package.json versions

### DIFF
--- a/evm/ts/package.json
+++ b/evm/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wormhole-foundation/sdk-evm-ntt",
-  "version": "5.0.0",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wormhole-foundation/native-token-transfers.git"
@@ -46,7 +46,7 @@
     "prettier": "prettier --write ./src ./__tests__"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk-definitions-ntt": "5.0.0",
+    "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
     "ethers": "^6.5.1"
   },
   "devDependencies": {

--- a/sdk/definitions/package.json
+++ b/sdk/definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wormhole-foundation/sdk-definitions-ntt",
-  "version": "5.0.0",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wormhole-foundation/native-token-transfers.git"

--- a/sdk/examples/package.json
+++ b/sdk/examples/package.json
@@ -35,9 +35,9 @@
   },
   "dependencies": {
     "@wormhole-foundation/sdk": "^4.18.0",
-    "@wormhole-foundation/sdk-definitions-ntt": "5.0.0",
-    "@wormhole-foundation/sdk-evm-ntt": "5.0.0",
-    "@wormhole-foundation/sdk-route-ntt": "5.0.0",
-    "@wormhole-foundation/sdk-solana-ntt": "5.0.0"
+    "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
+    "@wormhole-foundation/sdk-evm-ntt": "1.0.0",
+    "@wormhole-foundation/sdk-route-ntt": "1.0.0",
+    "@wormhole-foundation/sdk-solana-ntt": "1.0.0"
   }
 }

--- a/sdk/route/package.json
+++ b/sdk/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wormhole-foundation/sdk-route-ntt",
-  "version": "5.0.0",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wormhole-foundation/native-token-transfers.git"
@@ -46,9 +46,9 @@
     "ts-node": "^10.9.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk-definitions-ntt": "5.0.0",
-    "@wormhole-foundation/sdk-evm-ntt": "5.0.0",
-    "@wormhole-foundation/sdk-solana-ntt": "5.0.0"
+    "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
+    "@wormhole-foundation/sdk-evm-ntt": "1.0.0",
+    "@wormhole-foundation/sdk-solana-ntt": "1.0.0"
   },
   "peerDependencies": {
     "@wormhole-foundation/sdk-connect": "^4.18.0",

--- a/solana/package.json
+++ b/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wormhole-foundation/sdk-solana-ntt",
-  "version": "5.0.0",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wormhole-foundation/native-token-transfers.git"
@@ -54,7 +54,7 @@
     "@coral-xyz/borsh": "0.29.0",
     "@solana/spl-token": "0.4.0",
     "@solana/web3.js": "^1.95.8",
-    "@wormhole-foundation/sdk-definitions-ntt": "5.0.0",
+    "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
     "bn.js": "5.2.1"
   },
   "type": "module",

--- a/sui/ts/package.json
+++ b/sui/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wormhole-foundation/sdk-sui-ntt",
-  "version": "5.0.0",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wormhole-foundation/native-token-transfers.git"
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@mysten/sui": "1.37.2",
-    "@wormhole-foundation/sdk-definitions-ntt": "5.0.0"
+    "@wormhole-foundation/sdk-definitions-ntt": "1.0.0"
   },
   "type": "module",
   "exports": {

--- a/xrpl/ts/package.json
+++ b/xrpl/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wormhole-foundation/sdk-xrpl-ntt",
-  "version": "5.0.0",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wormhole-foundation/native-token-transfers.git"
@@ -41,7 +41,7 @@
     "test": "jest --config ./jest.config.ts"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk-definitions-ntt": "5.0.0",
+    "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
     "xrpl": "^4.6.0"
   },
   "type": "module",


### PR DESCRIPTION
## Summary
The auto-register PR (#863) inadvertently bumped source `package.json` `version` from `1.0.0` to `5.0.0` across the six NTT SDK packages, and updated internal dep ranges to match. Source should hold the placeholder version; the publish workflow stamps the real release version at publish time via the `bun run version` script (which invokes `setSdkVersion.ts`).

The publish pipeline didn't fail on `5.0.0-beta.*` releases because `setSdkVersion.ts` is idempotent (just rewrites the JSON), unlike `pnpm version` in the executor-route repos which errors on no-op bumps. But the placeholder convention is still the right one to keep — pinned source versions cause subtle confusion downstream and could break tooling that does compare source vs npm.

## Changes
- `sdk/definitions`, `evm/ts`, `solana`, `sui/ts`, `xrpl/ts`, `sdk/route`: `version` `5.0.0` → `1.0.0`
- Internal NTT dep ranges in `sdk/route`, `sdk/examples`, `evm/ts`, `solana`, `sui/ts`, `xrpl/ts`: `5.0.0` → `1.0.0`

## Impact
Zero impact on what's published to npm. `5.0.0-beta.{0..4}` and `5.0.0` are unaffected — they're stamped at publish time, not from source. This only changes the placeholder in source so future publishes don't drift further from convention.

## Diff stat
```
7 files changed, 17 insertions(+), 17 deletions(-)
```
