### PR TITLE
fix(sdk-route): use routes subpath import + remove redundant module-top register calls

### DIFF
--- a/sdk/route/src/automatic.ts
+++ b/sdk/route/src/automatic.ts
@@ -24,9 +24,9 @@ import {
   isRedeemed,
   isSourceFinalized,
   isSourceInitiated,
-  routes,
   signSendWait,
 } from "@wormhole-foundation/sdk-connect";
+import * as routes from "@wormhole-foundation/sdk-connect/routes";
 import { register as registerDefinitionsNtt } from "@wormhole-foundation/sdk-definitions-ntt";
 import { NttRoute } from "./types.js";
 

--- a/sdk/route/src/automatic.ts
+++ b/sdk/route/src/automatic.ts
@@ -27,13 +27,7 @@ import {
   signSendWait,
 } from "@wormhole-foundation/sdk-connect";
 import * as routes from "@wormhole-foundation/sdk-connect/routes";
-import { register as registerDefinitionsNtt } from "@wormhole-foundation/sdk-definitions-ntt";
 import { NttRoute } from "./types.js";
-
-// Ensure NTT payload layouts are registered before any route is constructed.
-// In v4 this happened via the side-effect of importing sdk-definitions-ntt;
-// in v5 the auto-register was removed, so the route SDK has to call it.
-registerDefinitionsNtt();
 
 type Op = NttRoute.Options;
 type Tp = routes.TransferParams<Op>;

--- a/sdk/route/src/executor/executor.ts
+++ b/sdk/route/src/executor/executor.ts
@@ -45,10 +45,7 @@ import {
   fetchStatus,
   isRelayStatusFailed,
 } from "./utils.js";
-import {
-  Ntt,
-  NttWithExecutor,
-} from "@wormhole-foundation/sdk-definitions-ntt";
+import { Ntt, NttWithExecutor } from "@wormhole-foundation/sdk-definitions-ntt";
 import {
   isNative,
   relayInstructionsLayout,

--- a/sdk/route/src/executor/executor.ts
+++ b/sdk/route/src/executor/executor.ts
@@ -48,13 +48,7 @@ import {
 import {
   Ntt,
   NttWithExecutor,
-  register as registerDefinitionsNtt,
 } from "@wormhole-foundation/sdk-definitions-ntt";
-
-// Ensure NTT payload layouts are registered before any route is constructed.
-// In v4 this happened via the side-effect of importing sdk-definitions-ntt;
-// in v5 the auto-register was removed, so the route SDK has to call it.
-registerDefinitionsNtt();
 import {
   isNative,
   relayInstructionsLayout,

--- a/sdk/route/src/executor/executor.ts
+++ b/sdk/route/src/executor/executor.ts
@@ -29,13 +29,13 @@ import {
   isSourceFinalized,
   isSourceInitiated,
   nativeTokenId,
-  routes,
   serializeLayout,
   signSendWait,
   toChainId,
   Platform,
   chainToPlatform,
 } from "@wormhole-foundation/sdk-connect";
+import * as routes from "@wormhole-foundation/sdk-connect/routes";
 import { NttRoute } from "../types.js";
 import {
   calculateReferrerFee,

--- a/sdk/route/src/executor/multiToken.ts
+++ b/sdk/route/src/executor/multiToken.ts
@@ -33,13 +33,7 @@ import {
   MultiTokenNttWithExecutor,
   Ntt,
   NttWithExecutor,
-  register as registerDefinitionsNtt,
 } from "@wormhole-foundation/sdk-definitions-ntt";
-
-// Ensure NTT payload layouts are registered before any route is constructed.
-// In v4 this happened via the side-effect of importing sdk-definitions-ntt;
-// in v5 the auto-register was removed, so the route SDK has to call it.
-registerDefinitionsNtt();
 import {
   calculateReferrerFee,
   Capabilities,

--- a/sdk/route/src/executor/multiToken.ts
+++ b/sdk/route/src/executor/multiToken.ts
@@ -15,7 +15,6 @@ import {
   isDestinationQueued,
   isNative,
   nativeTokenId,
-  routes,
   signSendWait,
   relayInstructionsLayout,
   deserializeLayout,
@@ -27,14 +26,20 @@ import {
   signedQuoteLayout,
   toChainId,
 } from "@wormhole-foundation/sdk-connect";
-import "@wormhole-foundation/sdk-definitions-ntt";
+import * as routes from "@wormhole-foundation/sdk-connect/routes";
 import { MultiTokenNttRoute, NttRoute } from "../types.js";
 import {
   MultiTokenNtt,
   MultiTokenNttWithExecutor,
   Ntt,
   NttWithExecutor,
+  register as registerDefinitionsNtt,
 } from "@wormhole-foundation/sdk-definitions-ntt";
+
+// Ensure NTT payload layouts are registered before any route is constructed.
+// In v4 this happened via the side-effect of importing sdk-definitions-ntt;
+// in v5 the auto-register was removed, so the route SDK has to call it.
+registerDefinitionsNtt();
 import {
   calculateReferrerFee,
   Capabilities,

--- a/sdk/route/src/manual.ts
+++ b/sdk/route/src/manual.ts
@@ -27,13 +27,7 @@ import {
   chainToPlatform,
 } from "@wormhole-foundation/sdk-connect";
 import * as routes from "@wormhole-foundation/sdk-connect/routes";
-import { register as registerDefinitionsNtt } from "@wormhole-foundation/sdk-definitions-ntt";
 import { NttRoute } from "./types.js";
-
-// Ensure NTT payload layouts are registered before any route is constructed.
-// In v4 this happened via the side-effect of importing sdk-definitions-ntt;
-// in v5 the auto-register was removed, so the route SDK has to call it.
-registerDefinitionsNtt();
 
 type Op = NttRoute.Options;
 type Tp = routes.TransferParams<Op>;

--- a/sdk/route/src/manual.ts
+++ b/sdk/route/src/manual.ts
@@ -20,13 +20,13 @@ import {
   isRedeemed,
   isSourceFinalized,
   isSourceInitiated,
-  routes,
   signSendWait,
   finality,
   isNative,
   guardians,
   chainToPlatform,
 } from "@wormhole-foundation/sdk-connect";
+import * as routes from "@wormhole-foundation/sdk-connect/routes";
 import { register as registerDefinitionsNtt } from "@wormhole-foundation/sdk-definitions-ntt";
 import { NttRoute } from "./types.js";
 

--- a/sdk/route/src/multiTokenManual.ts
+++ b/sdk/route/src/multiTokenManual.ts
@@ -9,12 +9,12 @@ import {
   TransferState,
   Wormhole,
   amount,
-  routes,
   signSendWait,
   finality,
   guardians,
   isNative,
 } from "@wormhole-foundation/sdk-connect";
+import * as routes from "@wormhole-foundation/sdk-connect/routes";
 import {
   MultiTokenNtt,
   register as registerDefinitionsNtt,

--- a/sdk/route/src/multiTokenManual.ts
+++ b/sdk/route/src/multiTokenManual.ts
@@ -15,16 +15,8 @@ import {
   isNative,
 } from "@wormhole-foundation/sdk-connect";
 import * as routes from "@wormhole-foundation/sdk-connect/routes";
-import {
-  MultiTokenNtt,
-  register as registerDefinitionsNtt,
-} from "@wormhole-foundation/sdk-definitions-ntt";
+import { MultiTokenNtt } from "@wormhole-foundation/sdk-definitions-ntt";
 import { MultiTokenNttRoute, NttRoute } from "./types.js";
-
-// Ensure NTT payload layouts are registered before any route is constructed.
-// In v4 this happened via the side-effect of importing sdk-definitions-ntt;
-// in v5 the auto-register was removed, so the route SDK has to call it.
-registerDefinitionsNtt();
 
 type Op = routes.Options;
 type Tp = routes.TransferParams<Op>;

--- a/sdk/route/src/tracking.ts
+++ b/sdk/route/src/tracking.ts
@@ -2,9 +2,9 @@ import {
   Network,
   TransferState,
   isFailed,
-  routes,
   isAttested,
 } from "@wormhole-foundation/sdk-connect";
+import * as routes from "@wormhole-foundation/sdk-connect/routes";
 import { MultiTokenNttRoute } from "./types.js";
 import {
   getAxelarTransactionStatus,

--- a/sdk/route/src/types.ts
+++ b/sdk/route/src/types.ts
@@ -25,10 +25,10 @@ import {
   isSourceFinalized,
   isSourceInitiated,
   nativeTokenId,
-  routes,
   signSendWait,
   toUniversal,
 } from "@wormhole-foundation/sdk-connect";
+import * as routes from "@wormhole-foundation/sdk-connect/routes";
 import { MultiTokenNtt, Ntt } from "@wormhole-foundation/sdk-definitions-ntt";
 import { trackAxelar, trackExecutor } from "./tracking.js";
 


### PR DESCRIPTION
## Summary
Two related cleanups to `sdk/route/src/`:

1. **Routes-subpath migration** — switch the `routes` namespace value-import from the deprecated `@wormhole-foundation/sdk-connect` barrel to the subpath `@wormhole-foundation/sdk-connect/routes`. Silences the `[sdk-connect] Accessing "routes" from the barrel export is deprecated` warning at consumer runtime.

2. **Remove redundant module-top `registerDefinitionsNtt()` calls** — these were introduced in #863 as a tilt-fix substitute for the v4 `setTimeout` auto-register. They re-introduce the same library-on-import side effect v5 was designed to delete, *and* are redundant: every platform NTT package's `register()` already transitively calls `registerDefinitions()`. A consumer who follows the migration guide and calls `registerEvmNtt()` (or any platform's register) gets payload-layout registration for free.

## Files changed (sdk/route/src/)

```
automatic.ts        — routes barrel → subpath; drop registerDefinitionsNtt() module-top
manual.ts           — same
multiTokenManual.ts — same
tracking.ts         — routes barrel → subpath
types.ts            — routes barrel → subpath
executor/executor.ts   — same as automatic.ts + import-block formatting
executor/multiToken.ts — same
```

## Type/value surface
Identical. `routes.RouteTransferRequest`, `routes.AutomaticRoute`, `routes.RelayFailedError`, etc. all resolve the same way under both barrel and subpath. **No public API change** — consumers don't see a difference. Patch bump (5.0.2) is appropriate.

## Consumer registration audit (within this repo)

To verify removing the module-top `registerDefinitionsNtt()` calls didn't strand any consumer, I audited every file in the repo that imports from `@wormhole-foundation/sdk-{definitions,evm,solana,sui,xrpl,route}-ntt`:

### Already registers explicitly ✅

| Consumer | Where | Calls |
|---|---|---|
| **CLI entry** | `cli/src/index.ts` | `registerEvm()`, `registerSolana()`, `registerSui()` (top of file) |
| **Examples** | `sdk/examples/src/{index,route,multiToken}.ts` | `registerDefinitionsNtt()` + `registerEvmNtt()` + `registerSolanaNtt()` |
| **Anchor tests** | `solana/tests/anchor/anchor.test.ts` | `registerDefinitionsNtt()` + `registerSolanaNtt()` |
| **Route tests** | `sdk/route/__tests__/{route,executorReferrerFee}.test.ts` | EVM + Solana + definitions registers |
| **Tilt integration test** | `sdk/__tests__/index.test.ts` | EVM + Solana + definitions registers |

Each platform's `register()` transitively calls `registerDefinitions()`, so payload layouts get registered via the platform call without needing a separate definitions register.

### Type-only usage — no register needed ✅

| File | Pattern |
|---|---|
| `evm/ts/__tests__/transceiverIndex.test.ts` | uses `Ntt` as a type only |
| `evm/ts/__tests__/calculateLocalTokenAddress.test.ts` | uses `MultiTokenNtt` namespace for type access |
| `xrpl/ts/src/__tests__/utils.test.ts` | uses `Ntt` as a type only |
| `cli/src/__tests__/module-exports.test.ts` | module-exports test, no runtime NTT ops |

## Two observations (non-blocking, flagging for awareness)

1. **CLI doesn't call `registerXrpl`** in `cli/src/index.ts`. If XRPL CLI commands are added later, the entry point will need that line. No-op for the current PR since CLI today doesn't have XRPL flows.
2. **Examples redundantly call `registerDefinitionsNtt()`** — harmless because platform registers cover it. Idiomatic-clear in consumer code, fine to leave.

## Verification
- `bun run --filter '@wormhole-foundation/sdk-route-ntt' build` — ✅ clean
- All affected consumers in the repo verified to register before NTT protocol use
- Prettier — ✅ green

## Refs
- Companion bridge-monorepo cleanup: [wormholelabs-xyz/bridge-monorepo#614](https://github.com/wormholelabs-xyz/bridge-monorepo/pull/614)
- Companion upstream PRs (cctp/base-bridge): [cctp #65](https://github.com/wormholelabs-xyz/cctp-w7-executor-route/pull/65), [base-bridge #28](https://github.com/wormholelabs-xyz/base-bridge-w7-executor-route/pull/28)
- Linear: PROD-1838
