### PR TITLE
feat: migrate executor to v2 helper contracts

### DIFF
--- a/cli/src/commands/token-transfer.ts
+++ b/cli/src/commands/token-transfer.ts
@@ -7,7 +7,6 @@ import {
   Wormhole,
   amount,
   assertChain,
-  canonicalAddress,
   chainToPlatform,
   chains,
   isNetwork,
@@ -81,8 +80,6 @@ class TokenTransferError extends Error {
   }
 }
 
-const DEFAULT_SOLANA_MSG_VALUE = 11_500_000n; // lamports
-
 /**
  * Registers the `token-transfer` command and all associated validation / execution logic.
  */
@@ -134,7 +131,7 @@ export function createTokenTransferCommand(
         })
         .option("destination-msg-value", {
           describe:
-            "Override msgValue (native units) for the destination chain. Required when destination is Solana/SVM to cover executor rent.",
+            "Override the executor's destination msgValue (native units of the destination chain). When unset, the SDK estimates the required amount.",
           type: "string",
         })
         .option("rpc", {
@@ -211,7 +208,6 @@ async function executeTokenTransfer(
     (message) => new TokenTransferError(message)
   );
   const sourcePlatform = chainToPlatform(sourceChainInput);
-  const destinationPlatform = chainToPlatform(destinationChainInput);
 
   const amountInput = argv.amount.trim();
   if (!amountInput) {
@@ -472,26 +468,9 @@ async function executeTokenTransfer(
   getContractsForChain(contractsByChain, destinationChainInput, deploymentPath);
 
   const executorConfig = buildExecutorRouteConfig(contractsByChain);
-  if (destinationPlatform === "Solana") {
-    const msgValueToUse =
-      destinationMsgValueOverride ?? DEFAULT_SOLANA_MSG_VALUE;
-    applyMsgValueOverride(executorConfig, destinationTokenId, msgValueToUse);
-    if (destinationMsgValueOverride === undefined) {
-      console.warn(
-        colors.yellow(
-          `Destination ${destinationChainInput} requires msgValue funding for the Wormhole Executor. Using default ${msgValueToUse.toString()} lamports. Pass --destination-msg-value to override.`
-        )
-      );
-    } else {
-      console.log(
-        `Using custom msgValue ${destinationMsgValueOverride.toString()} for ${destinationChainInput}.`
-      );
-    }
-  } else if (destinationMsgValueOverride !== undefined) {
-    console.warn(
-      colors.yellow(
-        `--destination-msg-value is only required for SVM destinations. Ignoring override for ${destinationChainInput}.`
-      )
+  if (destinationMsgValueOverride !== undefined) {
+    console.log(
+      `Using custom msgValue ${destinationMsgValueOverride.toString()} for ${destinationChainInput}.`
     );
   }
   const Route = argv.manual
@@ -504,11 +483,17 @@ async function executeTokenTransfer(
     destination: destinationTokenId,
   });
 
+  const options = argv.manual
+    ? { automatic: false, skipDstRateLimitCheck: true }
+    : destinationMsgValueOverride !== undefined
+      ? { msgValue: destinationMsgValueOverride }
+      : undefined;
   const validation = await routeInstance.validate(transferRequest, {
     amount: amountInput,
-    options: argv.manual
-      ? { automatic: false, skipDstRateLimitCheck: true }
-      : undefined,
+    // The route shape (manual vs. executor) drives which Options branch above
+    // applies; TS narrows to the intersection so we cast to the active route's
+    // Options type at runtime.
+    options: options as NttRoute.Options & NttExecutorRoute.Options,
   });
   if (!validation.valid) {
     const reason =
@@ -590,12 +575,6 @@ async function executeTokenTransfer(
     );
   }
   if (!argv.manual) {
-    console.log(
-      `Executor referrer fee: ${formatAmount(
-        executorQuote.referrerFee,
-        decimals
-      )} (${executorQuote.referrerFeeDbps.toString()} dBps)`
-    );
     console.log(
       `Estimated execution cost (${sourceChainInput} native): ${formatAmount(
         executorQuote.estimatedCost,
@@ -813,33 +792,6 @@ function buildExecutorRouteConfig(
   };
 }
 
-type ReferrerFeeConfig = NttExecutorRoute.ReferrerFeeConfig;
-type PerTokenOverrides = NonNullable<
-  NonNullable<ReferrerFeeConfig["perTokenOverrides"]>[Chain]
->;
-
-/**
- * Attach a msgValue override so the executor funds rent/gas for a given destination token.
- */
-function applyMsgValueOverride(
-  config: NttExecutorRoute.Config,
-  token: TokenId,
-  msgValue: bigint
-): void {
-  if (!config.referrerFee) {
-    config.referrerFee = { feeDbps: 0n, perTokenOverrides: {} };
-  } else if (!config.referrerFee.perTokenOverrides) {
-    config.referrerFee.perTokenOverrides = {};
-  }
-  const perTokenOverrides = (config.referrerFee.perTokenOverrides ??=
-    {} as NonNullable<ReferrerFeeConfig["perTokenOverrides"]>);
-  const canonicalToken = canonicalAddress(token);
-  const chainOverrides = (perTokenOverrides[token.chain] ??=
-    {} as PerTokenOverrides);
-  const tokenOverride = (chainOverrides[canonicalToken] ??= {});
-  tokenOverride.msgValue = msgValue;
-}
-
 /**
  * Prompt the operator to confirm they entered a human-readable amount before Mainnet submissions.
  */
@@ -920,8 +872,8 @@ function isExecutorQuote(value: unknown): value is NttWithExecutor.Quote {
   const hasValidExpiry =
     candidate.expires === undefined || candidate.expires instanceof Date;
   return (
-    typeof candidate.referrerFee === "bigint" &&
-    typeof candidate.referrerFeeDbps === "bigint" &&
+    typeof candidate.transferTokenFee === "bigint" &&
+    typeof candidate.nativeTokenFee === "bigint" &&
     typeof candidate.estimatedCost === "bigint" &&
     typeof candidate.gasDropOff === "bigint" &&
     hasValidExpiry

--- a/evm/ts/__tests__/nttWithExecutorV2.test.ts
+++ b/evm/ts/__tests__/nttWithExecutorV2.test.ts
@@ -1,0 +1,204 @@
+import { Interface } from "ethers";
+import { Wormhole } from "@wormhole-foundation/sdk";
+import { EvmPlatform } from "@wormhole-foundation/sdk-evm";
+import {
+  EvmNttWithExecutor,
+  hasExecutorDeployed,
+  nttWithExecutorAbi,
+} from "../src/nttWithExecutor.js";
+import { EvmNtt } from "../src/ntt.js";
+import type { NttWithExecutor } from "@wormhole-foundation/sdk-definitions-ntt";
+
+const iface = new Interface(nttWithExecutorAbi);
+
+describe("NttWithExecutor V2", () => {
+  describe("hasExecutorDeployed", () => {
+    it("returns true for chains with addresses", () => {
+      expect(hasExecutorDeployed("Mainnet", "Ethereum")).toBe(true);
+      expect(hasExecutorDeployed("Testnet", "Monad")).toBe(true);
+    });
+
+    it("returns false for chains without any executor", () => {
+      expect(hasExecutorDeployed("Mainnet", "Klaytn")).toBe(false);
+    });
+  });
+
+  describe("transfer calldata", () => {
+    const MANAGER_ADDRESS = "0x649fF7B32C2DE771043ea105c4aAb2D724497238";
+    const TOKEN_ADDRESS = "0x738141EFf659625F2eAD4feECDfCD94155C67f18";
+    const REFERRER_ADDRESS = "0x9b2A3B92b1D86938D3Ed37B0519952C227bA6D09";
+
+    let executor: EvmNttWithExecutor<"Testnet", "Sepolia">;
+    let mockNtt: EvmNtt<"Testnet", "Sepolia">;
+
+    beforeAll(async () => {
+      const wh = new Wormhole("Testnet", [EvmPlatform]);
+      const ctx = wh.getChain("Sepolia");
+      const rpc = await ctx.getRpc();
+
+      executor = new EvmNttWithExecutor("Testnet", "Sepolia", rpc, {
+        ntt: {
+          token: TOKEN_ADDRESS,
+          manager: MANAGER_ADDRESS,
+          transceiver: {
+            wormhole: "0x06413c42e913327Bc9a08B7C1E362BAE7C0b9598",
+          },
+        },
+      });
+
+      mockNtt = {
+        managerAddress: MANAGER_ADDRESS,
+        tokenAddress: TOKEN_ADDRESS,
+        quoteDeliveryPrice: jest.fn().mockResolvedValue(10_000n),
+        encodeOptions: jest.fn().mockReturnValue([]),
+        createUnsignedTx: jest.fn().mockImplementation((txReq, desc) => ({
+          transaction: txReq,
+          description: desc,
+        })),
+      } as unknown as EvmNtt<"Testnet", "Sepolia">;
+    });
+
+    function makeQuote(
+      overrides: Partial<NttWithExecutor.Quote> = {}
+    ): NttWithExecutor.Quote {
+      return {
+        signedQuote: new Uint8Array(64),
+        relayInstructions: new Uint8Array(32),
+        estimatedCost: 50_000n,
+        payeeAddress: new Uint8Array(32),
+        referrer: Wormhole.chainAddress("Sepolia", REFERRER_ADDRESS),
+        transferTokenFee: 1_000_000n,
+        nativeTokenFee: 0n,
+        remainingAmount: 99_000_000n,
+        expires: new Date(Date.now() + 60_000),
+        gasDropOff: 0n,
+        ...overrides,
+      };
+    }
+
+    async function collectTxs(gen: AsyncGenerator<any>) {
+      const txs = [];
+      for await (const tx of gen) {
+        txs.push(tx);
+      }
+      return txs;
+    }
+
+    it("passes remainingAmount as the contract amount param", async () => {
+      const quote = makeQuote();
+      const sender = Wormhole.chainAddress("Sepolia", REFERRER_ADDRESS);
+
+      // Mock approveIfNeeded to skip RPC
+      (executor as any).approveIfNeeded = async function* () {};
+
+      const txs = await collectTxs(
+        executor.transfer(
+          sender.address,
+          Wormhole.chainAddress("ArbitrumSepolia", REFERRER_ADDRESS),
+          100_000_000n,
+          quote,
+          mockNtt
+        )
+      );
+
+      const transferTx = txs[txs.length - 1];
+      const decoded = iface.decodeFunctionData(
+        "transfer",
+        transferTx.transaction.data
+      );
+
+      expect(decoded["amount"]).toBe(99_000_000n);
+    });
+
+    it("encodes transferTokenFee and nativeTokenFee in feeArgs", async () => {
+      const quote = makeQuote({
+        transferTokenFee: 1_000_000n,
+        nativeTokenFee: 500_000n,
+      });
+      const sender = Wormhole.chainAddress("Sepolia", REFERRER_ADDRESS);
+      (executor as any).approveIfNeeded = async function* () {};
+
+      const txs = await collectTxs(
+        executor.transfer(
+          sender.address,
+          Wormhole.chainAddress("ArbitrumSepolia", REFERRER_ADDRESS),
+          100_000_000n,
+          quote,
+          mockNtt
+        )
+      );
+
+      const decoded = iface.decodeFunctionData(
+        "transfer",
+        txs[txs.length - 1].transaction.data
+      );
+
+      expect(decoded["feeArgs"].transferTokenFee).toBe(1_000_000n);
+      expect(decoded["feeArgs"].nativeTokenFee).toBe(500_000n);
+      expect(decoded["feeArgs"].payee).toBe(REFERRER_ADDRESS);
+    });
+
+    it("sets correct msgValue for ERC20 transfer", async () => {
+      const quote = makeQuote({
+        estimatedCost: 50_000n,
+        nativeTokenFee: 500_000n,
+      });
+      const sender = Wormhole.chainAddress("Sepolia", REFERRER_ADDRESS);
+      (executor as any).approveIfNeeded = async function* () {};
+
+      const txs = await collectTxs(
+        executor.transfer(
+          sender.address,
+          Wormhole.chainAddress("ArbitrumSepolia", REFERRER_ADDRESS),
+          100_000_000n,
+          quote,
+          mockNtt
+        )
+      );
+
+      const transferTx = txs[txs.length - 1];
+      // msgValue = estimatedCost + deliveryPrice + nativeTokenFee
+      // deliveryPrice = 10_000n (mocked)
+      expect(transferTx.transaction.value).toBe(50_000n + 10_000n + 500_000n);
+    });
+
+    it("uses transferETH when wrapNative is true", async () => {
+      const quote = makeQuote({
+        remainingAmount: 99_000_000n,
+        transferTokenFee: 1_000_000n,
+        nativeTokenFee: 500_000n,
+        estimatedCost: 50_000n,
+      });
+      const sender = Wormhole.chainAddress("Sepolia", REFERRER_ADDRESS);
+
+      const txs = await collectTxs(
+        executor.transfer(
+          sender.address,
+          Wormhole.chainAddress("ArbitrumSepolia", REFERRER_ADDRESS),
+          100_000_000n,
+          quote,
+          mockNtt,
+          true // wrapNative
+        )
+      );
+
+      const transferTx = txs[txs.length - 1];
+      const decoded = iface.decodeFunctionData(
+        "transferETH",
+        transferTx.transaction.data
+      );
+
+      expect(decoded["amount"]).toBe(99_000_000n);
+      // For wrapNative, transferTokenFee is folded into nativeTokenFee so the
+      // contract can pay the referrer out of msg.value instead of attempting an
+      // ERC20 transferFrom against a user who only sent native gas.
+      expect(decoded["feeArgs"].transferTokenFee).toBe(0n);
+      expect(decoded["feeArgs"].nativeTokenFee).toBe(500_000n + 1_000_000n);
+      // msgValue = estimatedCost + deliveryPrice + combinedNativeFee + remainingAmount
+      // Equivalent to estimatedCost + deliveryPrice + originalNativeTokenFee + totalAmount.
+      expect(transferTx.transaction.value).toBe(
+        50_000n + 10_000n + 1_500_000n + 99_000_000n
+      );
+    });
+  });
+});

--- a/evm/ts/src/nttWithExecutor.ts
+++ b/evm/ts/src/nttWithExecutor.ts
@@ -24,54 +24,48 @@ const nttManagerWithExecutorAddresses: Partial<
   Record<Network, Partial<Record<EvmChains, string>>>
 > = {
   Mainnet: {
-    Arbitrum: "0x0Af42A597b0C201D4dcf450DcD0c06d55ddC1C77",
-    Avalanche: "0x4e9Af03fbf1aa2b79A2D4babD3e22e09f18Bb8EE",
-    Base: "0x83216747fC21b86173D800E2960c0D5395de0F30",
-    Berachain: "0x0a2AF374Cc9CCCbB0Acc4E34B20b9d02a0f08c30",
-    Bsc: "0x39B57Dd9908F8be02CfeE283b67eA1303Bc29fe1",
-    Celo: "0x3d69869fcB9e1CD1F4020b637fb8256030BAc8fC",
-    Ethereum: "0xD2D9c936165a85F27a5a7e07aFb974D022B89463",
-    HyperEVM: "0x431017B1718b86898C7590fFcCC380DEf0456393",
-    Ink: "0x420370DC2ECC4D44b47514B7859fd11809BbeFF5",
-    Linea: "0xEAa5AddB5b8939Eb73F7faF46e193EefECaF13E9",
-    Mezo: "0x484b5593BbB90383f94FB299470F09427cf6cfE2",
-    Moonbeam: "0x1365593C8bae71a55e48E105a2Bb76d5928c7DE3",
-    Optimism: "0x85C0129bE5226C9F0Cf4e419D2fefc1c3FCa25cF",
-    Plume: "0x6Eb53371f646788De6B4D0225a4Ed1d9267188AD",
-    Polygon: "0x6762157b73941e36cEd0AEf54614DdE545d0F990",
-    Sonic: "0xaCa00703bb87F31D6F9fCcc963548b48FA46DfeB",
-    Unichain: "0x607723D6353Dae3ef62B7B277Cfabd0F4bc6CB4C",
-    Worldchain: "0x66b1644400D51e104272337226De3EF1A820eC79",
-    XRPLEVM: "0x6bBd1ff3bB303F88835A714EE3241bF45DE26d29",
-    Seievm: "0x3F2D6441C7a59Dfe80f8e14142F9E28F6D440445",
-    CreditCoin: "0x5454b995719626256C96fb57454b044ffb3Da2F9",
-    Monad: "0xc3F3dDa544815a440633176c7598f5B97500793e",
-    Moca: "0xE612837749a0690BA2BCe490D6eFb5F8Fc347df3",
-    MegaETH: "0x3EFEc0c7Ee79135330DD03e995872f84b1AD49b6",
-    ZeroGravity: "0xe175A8b838f3CdB2e1AAf4Ff74c05cF2F3AEA9a8",
-    Nexus: "0x0F8B6B4Bd7Fd645478D7b33346653427814f41FA",
+    Arbitrum: "0x5029a23E0EE11f6c9120EAb7eB48a94a49907EC4",
+    Avalanche: "0xf1Aa9693265E0Ba892C4a7AE77591424eEEd5cE9",
+    Base: "0x27db1967D469D89318B7119Ced5609f327095de4",
+    Berachain: "0x7424E82D27dD80ca47eab5e739C4D5A2D220f64f",
+    Bsc: "0x83f5c7b03BBbE20FE2e39312b957D86dc7C3Dee2",
+    Celo: "0xb466bA8798a5B516b43cbE6AA7bBb9532bB1708D",
+    CreditCoin: "0xcA43AE520E308C6Fb444EB723406febF7c310Da3",
+    Ethereum: "0xC079bFA54F348199bA51B2717595fE24e96f1542",
+    HyperEVM: "0xBc275e094e031e990b060134AbbDa00132f9A163",
+    Ink: "0x9e9980848FcbC11F9e84b5b6f5b88887966F5DAe",
+    Linea: "0x6FE9625F59107a4D49a9b5bC10a701dD0Bb396C0",
+    MegaETH: "0x7215f45Ea622E0350DF410D2e780BfD03bDc8a4D",
+    Mezo: "0x50F11Fe8B0D2B6f18a12291FeD345914D7Ec69d3",
+    Moca: "0x494726C75053F63CA906Aee00d6f910afE761B35",
+    Monad: "0xcc9FE3526F527bB0A14242A92818e132f3c12059",
+    Moonbeam: "0x40bBdD737f2Ca6316777F0B24ac94aaDE1ad1e4b",
+    Optimism: "0xC25396Ce2F6FBE6996374a5527c636C71AD5a757",
+    Plume: "0x00F39D8897e32B129435499F406b2fD76e37B51E",
+    Polygon: "0x9d165221c3c68868D15B154c5Aa66C32e044Eb4b",
+    Seievm: "0x70b85A416146A2dc3c760Ad30102F4280471C2b1",
+    Sonic: "0x98D1A98Cc398Ef6F5F84D134C1370480AaabA546",
+    Unichain: "0x2ceB44DE347641804856E2c468E703e06C5A8A33",
+    Worldchain: "0xDdBBa9509B9587516a0736D218B193a0DCf2B3e4",
+    XRPLEVM: "0xeddc0228C8719E7220eF4D8D95503258285BD482",
+    ZeroGravity: "0x4E62C24F9c18D3053B8E84A73a2ec7A40b74AF8a",
   },
   Testnet: {
-    ArbitrumSepolia: "0xd048170F1ECB8D47E499D3459aC379DA023E2C1B",
-    Avalanche: "0x4e9Af03fbf1aa2b79A2D4babD3e22e09f18Bb8EE",
-    BaseSepolia: "0x5845E08d890E21687F7Ebf7CbAbD360cD91c6245",
-    Bsc: "0x39B57Dd9908F8be02CfeE283b67eA1303Bc29fe1",
-    OptimismSepolia: "0xaDB1C56D363FF5A75260c3bd27dd7C1fC8421EF5",
-    Sepolia: "0x54DD7080aE169DD923fE56d0C4f814a0a17B8f41",
-    Ink: "0xF420BFFf922D11c2bBF587C9dF71b83651fAf8Bc",
-    Seievm: "0x3F2D6441C7a59Dfe80f8e14142F9E28F6D440445",
-    Converge: "0x3d8c26b67BDf630FBB44F09266aFA735F1129197",
-    Plume: "0x6Eb53371f646788De6B4D0225a4Ed1d9267188AD",
-    PolygonSepolia: "0x2982B9566E912458fE711FB1Fd78158264596937",
-    Monad: "0x93FE94Ad887a1B04DBFf1f736bfcD1698D4cfF66",
-    Linea: "0xaA469cb84C91D5a63bf4B370dE35f0831F2CE4FF",
-    Celo: "0x3d69869fcB9e1CD1F4020b637fb8256030BAc8fC",
-    Unichain: "0x607723D6353Dae3ef62B7B277Cfabd0F4bc6CB4C",
-    XRPLEVM: "0xcDD9d7C759b29680f7a516d0058de8293b2AC7b1",
-    Mezo: "0x484b5593BbB90383f94FB299470F09427cf6cfE2",
-    Moca: "0x47f26bF9253Eb398fBAf825D7565FE975D839a71",
-    ZeroGravity: "0xA8CA118f4C8d44Ab651Dad52B5E1a212e5d5c55b",
-    Nexus: "0x5C2768b4aF4483ffeB2B8de8D8b14829C0F19c9E",
+    ArbitrumSepolia: "0xD69CF144C31aE8C12b5C7c3D52411F32C824C9a3",
+    Avalanche: "0x8196EBa42b2947f519002B8aDa53b1880F580c69",
+    BaseSepolia: "0x9fBC8aA6B2f626D13005De92B3f0e4541919f721",
+    Bsc: "0x2c9F87bE2eb0caEB8AfFE6F7ae1f046E5D40Ff2a",
+    Ink: "0x86B93560FeAbc95a0067a498d8afe1219f3ED0D7",
+    Linea: "0x5d98Ded0E46d0aEAB37EA4fEe45A38dc5ccee673",
+    Mezo: "0x117F5F5E8d29ED6254c6098457Cea28E3Ee7cDdA",
+    Monad: "0x8BcA0315627DA3D2e5FA349a6A1ad2FAde36BCe5",
+    OptimismSepolia: "0xA8b1d0520D556b4Ea115562D35077cAA2f13C6D6",
+    Plume: "0x6D87C7d416dFf428117b560A981d788E39707195",
+    Seievm: "0xdb66Dc163A03220661ca33B492c72a6a15B3a8cf",
+    Sepolia: "0xc2386453598811D88613331D52e2Ca4B2AEe16E4",
+    Unichain: "0xc41853C70bf70a2FFeE3ddd8f38D2b774Fe3E264",
+    XRPLEVM: "0x0fbDaE31440f5549e2F08193b5B034F2F9768304",
+    ZeroGravity: "0x69BeC29e71711B30F58585C0bb1622e7b47e3707",
   },
 };
 
@@ -94,23 +88,16 @@ const gasLimitOverrides: Partial<
   },
 };
 
-// Tracks which executor contracts support the transferETH method.
-// Currently only Monad Mainnet supports this, but all executor contracts should eventually
-// be upgraded to support transferETH.
-const supportsTransferETH: Partial<
-  Record<Network, Partial<Record<EvmChains, boolean>>>
-> = {
-  Mainnet: {
-    Monad: true,
-  },
-};
+export const nttWithExecutorAbi = [
+  "function transfer(address nttManager, uint256 amount, uint16 recipientChain, bytes32 recipientAddress, bytes32 refundAddress, bytes encodedInstructions, (uint256 value, address refundAddress, bytes signedQuote, bytes instructions) executorArgs, (uint256 transferTokenFee, uint256 nativeTokenFee, address payee) feeArgs) external payable returns (uint64 msgId)",
+  "function transferETH(address nttManager, uint256 amount, uint16 recipientChain, bytes32 recipientAddress, bytes32 refundAddress, bytes encodedInstructions, (uint256 value, address refundAddress, bytes signedQuote, bytes instructions) executorArgs, (uint256 transferTokenFee, uint256 nativeTokenFee, address payee) feeArgs) external payable returns (uint64 msgId)",
+];
 
 export class EvmNttWithExecutor<N extends Network, C extends EvmChains>
   implements NttWithExecutor<N, C>
 {
   readonly chainId: bigint;
   readonly executorAddress: string;
-  readonly supportsTransferETH: boolean;
 
   constructor(
     readonly network: N,
@@ -128,8 +115,6 @@ export class EvmNttWithExecutor<N extends Network, C extends EvmChains>
     if (!executorAddress)
       throw new Error(`Executor address not found for chain ${this.chain}`);
     this.executorAddress = executorAddress;
-    this.supportsTransferETH =
-      supportsTransferETH[this.network]?.[this.chain] ?? false;
   }
 
   static async fromRpc<N extends Network>(
@@ -158,112 +143,99 @@ export class EvmNttWithExecutor<N extends Network, C extends EvmChains>
     wrapNative: boolean = false
   ): AsyncGenerator<UnsignedTransaction<N, C>> {
     const senderAddress = new EvmAddress(sender).toString();
+    const deliveryPrice = await ntt.quoteDeliveryPrice(destination.chain, {
+      queue: false,
+      automatic: false,
+    });
 
-    const options = { queue: false, automatic: false };
+    // Fee is deducted from the transfer amount.
+    // Approval covers remainingAmount + transferTokenFee = the full user amount.
+    const totalAmount = quote.remainingAmount + quote.transferTokenFee;
 
-    // This will include any transceiver fees
-    const deliveryPrice = await ntt.quoteDeliveryPrice(
-      destination.chain,
-      options
-    );
+    const iface = new Interface(nttWithExecutorAbi);
 
-    // Use transferETH if wrapNative is requested and the contract supports it
-    const useTransferETH = wrapNative && this.supportsTransferETH;
-
-    if (wrapNative && !this.supportsTransferETH) {
-      yield ntt.wrapNative(sender, amount);
-    }
-
-    // ABI for the INttManagerWithExecutor transfer functions
-    // TODO: type safety. typechain brings in so much boilerplate code and is soft deprecated. Use Viem instead?
-    const abi = [
-      "function transfer(address nttManager, uint256 amount, uint16 recipientChain, bytes32 recipientAddress, bytes32 refundAddress, bytes encodedInstructions, (uint256 value, address refundAddress, bytes signedQuote, bytes instructions) executorArgs, (uint16 dbps, address payee) feeArgs) external payable returns (uint64 msgId)",
-      "function transferETH(address nttManager, uint256 amount, uint16 recipientChain, bytes32 recipientAddress, bytes32 refundAddress, bytes encodedInstructions, (uint256 value, address refundAddress, bytes signedQuote, bytes instructions) executorArgs, (uint16 dbps, address payee) feeArgs) external payable returns (uint64 msgId)",
-    ];
-
-    const iface = new Interface(abi);
-
-    const nttManager = ntt.managerAddress;
-    const recipientChain = toChainId(destination.chain);
-    const recipientAddress = destination.address
-      .toUniversalAddress()
-      .toUint8Array();
-    const refundAddress = sender.toUniversalAddress().toUint8Array();
-    const encodedInstructions = Ntt.encodeTransceiverInstructions(
-      ntt.encodeOptions({ queue: false, automatic: false })
-    );
-    const executorArgs = {
-      value: quote.estimatedCost,
-      refundAddress: senderAddress,
-      signedQuote: quote.signedQuote,
-      instructions: quote.relayInstructions,
-    };
-    const feeArgs = {
-      dbps: quote.referrerFeeDbps,
-      payee: quote.referrer.address.toString(),
-    };
+    const commonArgs = [
+      ntt.managerAddress,
+      quote.remainingAmount,
+      toChainId(destination.chain),
+      destination.address.toUniversalAddress().toUint8Array(),
+      sender.toUniversalAddress().toUint8Array(),
+      Ntt.encodeTransceiverInstructions(
+        ntt.encodeOptions({ queue: false, automatic: false })
+      ),
+      {
+        value: quote.estimatedCost,
+        refundAddress: senderAddress,
+        signedQuote: quote.signedQuote,
+        instructions: quote.relayInstructions,
+      },
+    ] as const;
 
     let data: string;
     let msgValue: bigint;
 
-    if (useTransferETH) {
-      data = iface.encodeFunctionData("transferETH", [
-        nttManager,
-        amount,
-        recipientChain,
-        recipientAddress,
-        refundAddress,
-        encodedInstructions,
-        executorArgs,
-        feeArgs,
-      ]);
-      msgValue = quote.estimatedCost + deliveryPrice + amount;
+    if (wrapNative) {
+      // The source token is native gas, so the contract can't pull
+      // transferTokenFee as ERC20 from msg.sender (no WETH approval exists).
+      // Fold it into nativeTokenFee — denominated in the same units — so the
+      // referrer is paid out of msg.value directly.
+      const combinedNativeFee = quote.nativeTokenFee + quote.transferTokenFee;
+      const feeArgs = {
+        transferTokenFee: 0n,
+        nativeTokenFee: combinedNativeFee,
+        payee: quote.referrer.address.toString(),
+      };
+      data = iface.encodeFunctionData("transferETH", [...commonArgs, feeArgs]);
+      msgValue =
+        quote.estimatedCost +
+        deliveryPrice +
+        combinedNativeFee +
+        quote.remainingAmount;
     } else {
-      // Standard ERC20 transfer flow with approval
-      const tokenContract = EvmPlatform.getTokenImplementation(
-        this.provider,
-        ntt.tokenAddress
-      );
-
-      const allowance = await tokenContract.allowance(
+      const feeArgs = {
+        transferTokenFee: quote.transferTokenFee,
+        nativeTokenFee: quote.nativeTokenFee,
+        payee: quote.referrer.address.toString(),
+      };
+      yield* this.approveIfNeeded(
         senderAddress,
-        this.executorAddress
+        this.executorAddress,
+        totalAmount,
+        ntt
       );
-
-      if (allowance < amount) {
-        const txReq = await tokenContract.approve.populateTransaction(
-          this.executorAddress,
-          amount
-        );
-
-        yield ntt.createUnsignedTx(txReq, "Ntt.Approve");
-      }
-
-      data = iface.encodeFunctionData("transfer", [
-        nttManager,
-        amount,
-        recipientChain,
-        recipientAddress,
-        refundAddress,
-        encodedInstructions,
-        executorArgs,
-        feeArgs,
-      ]);
-      msgValue = quote.estimatedCost + deliveryPrice;
+      data = iface.encodeFunctionData("transfer", [...commonArgs, feeArgs]);
+      msgValue = quote.estimatedCost + deliveryPrice + quote.nativeTokenFee;
     }
 
-    const txReq = {
-      to: this.executorAddress,
-      data,
-      value: msgValue,
-    };
-
     yield ntt.createUnsignedTx(
-      txReq,
-      useTransferETH
-        ? "NttWithExecutor.transferETH"
-        : "NttWithExecutor.transfer"
+      { to: this.executorAddress, data, value: msgValue },
+      wrapNative ? "NttWithExecutor.transferETH" : "NttWithExecutor.transfer"
     );
+  }
+
+  private async *approveIfNeeded(
+    senderAddress: string,
+    contractAddress: string,
+    requiredAmount: bigint,
+    ntt: EvmNtt<N, C>
+  ): AsyncGenerator<UnsignedTransaction<N, C>> {
+    const tokenContract = EvmPlatform.getTokenImplementation(
+      this.provider,
+      ntt.tokenAddress
+    );
+
+    const allowance = await tokenContract.allowance(
+      senderAddress,
+      contractAddress
+    );
+
+    if (allowance < requiredAmount) {
+      const txReq = await tokenContract.approve.populateTransaction(
+        contractAddress,
+        requiredAmount
+      );
+      yield ntt.createUnsignedTx(txReq, "Ntt.Approve");
+    }
   }
 
   async estimateMsgValueAndGasLimit(
@@ -275,10 +247,7 @@ export class EvmNttWithExecutor<N extends Network, C extends EvmChains>
 }
 
 /**
- * Check if an executor (NttWithExecutor) is deployed for a given network and chain combination
- * @param network - The network (e.g., 'Mainnet', 'Testnet')
- * @param chain - The EVM chain (e.g., 'Arbitrum', 'ArbitrumSepolia')
- * @returns true if an executor address exists for this network/chain combination
+ * Check if an executor (NttWithExecutor) is deployed for a given network and chain combination.
  */
 export function hasExecutorDeployed(
   network: Network,

--- a/sdk/definitions/src/multiTokenNttWithExecutor.ts
+++ b/sdk/definitions/src/multiTokenNttWithExecutor.ts
@@ -7,11 +7,19 @@ import type {
   TokenId,
   UnsignedTransaction,
 } from "@wormhole-foundation/sdk-connect";
-import { NttWithExecutor } from "./nttWithExecutor.js";
 import { Ntt } from "./ntt.js";
 
 export namespace MultiTokenNttWithExecutor {
-  export type Quote = NttWithExecutor.Quote & {
+  export type Quote = {
+    signedQuote: Uint8Array;
+    relayInstructions: Uint8Array;
+    estimatedCost: bigint;
+    payeeAddress: Uint8Array;
+    referrer: ChainAddress;
+    referrerFeeDbps: bigint;
+    remainingAmount: bigint;
+    expires: Date;
+    gasDropOff: bigint;
     deliveryPrice: bigint;
     transceiverInstructions: Ntt.TransceiverInstruction[];
   };

--- a/sdk/definitions/src/nttWithExecutor.ts
+++ b/sdk/definitions/src/nttWithExecutor.ts
@@ -13,10 +13,10 @@ export namespace NttWithExecutor {
     relayInstructions: Uint8Array; // The relay instructions for the transfer
     estimatedCost: bigint; // The estimated cost of the transfer in native token base units
     payeeAddress: Uint8Array; // The wallet address on the source chain, designated by the Quoter, to receive funds when requesting an execution
-    referrer: ChainAddress; // The referrer address (to whom the referrer fee should be paid)
-    referrerFee: bigint; // The referrer fee in NTT token base units
-    remainingAmount: bigint; // The remaining amount after the referrer fee in NTT token base units
-    referrerFeeDbps: bigint; // The referrer fee in *tenths* of basis points
+    referrer: ChainAddress; // The referrer address (to whom the fees should be paid)
+    transferTokenFee: bigint; // Fee in transfer token base units, deducted from the transfer amount
+    nativeTokenFee: bigint; // Fee in native token base units
+    remainingAmount: bigint; // The amount after fee deduction (what gets bridged)
     expires: Date; // The expiry time of the quote
     gasDropOff: bigint; // The gas drop-off amount in native token base units
   };

--- a/sdk/route/__tests__/executorFee.test.ts
+++ b/sdk/route/__tests__/executorFee.test.ts
@@ -59,7 +59,7 @@ function createRoute(config: NttExecutorRoute.Config) {
   return new Route(wh);
 }
 
-describe("NttExecutorRoute referrer fee", () => {
+describe("NttExecutorRoute getFee", () => {
   let request: routes.RouteTransferRequest<"Testnet">;
 
   beforeAll(async () => {
@@ -69,48 +69,52 @@ describe("NttExecutorRoute referrer fee", () => {
     });
   });
 
-  it("uses getReferrerFee callback when defined", async () => {
-    const getReferrerFee = jest.fn(async () => ({
-      feeDbps: 42n,
+  it("uses getFee callback when defined", async () => {
+    const getFee = jest.fn(async () => ({
+      transferTokenFee: 1_000_000n,
+      nativeTokenFee: 500_000n,
       referrerAddress: "0x9b2A3B92b1D86938D3Ed37B0519952C227bA6D09",
     }));
-    const route = createRoute({ ntt: nttConfig, getReferrerFee });
+    const route = createRoute({ ntt: nttConfig, getFee });
 
     const result = await route.validate(request, { amount: "1.0" });
     expect(result.valid).toBe(true);
     if (!result.valid) throw new Error("unexpected");
 
-    expect(getReferrerFee).toHaveBeenCalledWith({
+    expect(getFee).toHaveBeenCalledWith({
+      amount: expect.any(BigInt),
       sourceChain: "Solana",
       sourceToken: SOL_TOKEN,
       destinationChain: "Sepolia",
       destinationToken: SEPOLIA_TOKEN,
     });
+
     const params = result.params as NttExecutorRoute.ValidatedParams;
-    expect(params.normalizedParams.referrerFeeDbps).toBe(42n);
+    expect(params.normalizedParams.transferTokenFee).toBe(1_000_000n);
+    expect(params.normalizedParams.nativeTokenFee).toBe(500_000n);
   });
 
-  it("uses static referrerFee when getReferrerFee is not defined", async () => {
-    const route = createRoute({
-      ntt: nttConfig,
-      referrerFee: { feeDbps: 100n },
-    });
+  it("defaults to zero fees when getFee is not defined", async () => {
+    const route = createRoute({ ntt: nttConfig });
 
     const result = await route.validate(request, { amount: "1.0" });
     expect(result.valid).toBe(true);
     if (!result.valid) throw new Error("unexpected");
 
     const params = result.params as NttExecutorRoute.ValidatedParams;
-    expect(params.normalizedParams.referrerFeeDbps).toBe(100n);
+    expect(params.normalizedParams.transferTokenFee).toBe(0n);
+    expect(params.normalizedParams.nativeTokenFee).toBe(0n);
+    expect(params.normalizedParams.referrerAddress).toBeUndefined();
   });
 
-  it("getReferrerFee takes priority over static referrerFee", async () => {
+  it("sets referrer address from getFee result", async () => {
+    const referrer = "9q2q3EtP1VNdyaxzju1CGfh3EDj7heGABgxAJNyQDXgT";
     const route = createRoute({
       ntt: nttConfig,
-      referrerFee: { feeDbps: 100n },
-      getReferrerFee: async () => ({
-        feeDbps: 77n,
-        referrerAddress: "0x9b2A3B92b1D86938D3Ed37B0519952C227bA6D09",
+      getFee: async () => ({
+        transferTokenFee: 0n,
+        nativeTokenFee: 0n,
+        referrerAddress: referrer,
       }),
     });
 
@@ -119,38 +123,29 @@ describe("NttExecutorRoute referrer fee", () => {
     if (!result.valid) throw new Error("unexpected");
 
     const params = result.params as NttExecutorRoute.ValidatedParams;
-    expect(params.normalizedParams.referrerFeeDbps).toBe(77n);
+    expect(params.normalizedParams.referrerAddress).toBeDefined();
+    expect(params.normalizedParams.referrerAddress?.chain).toBe("Solana");
   });
 
-  it("defaults to 0 when neither is defined", async () => {
+  it("validates nativeGas option bounds", async () => {
     const route = createRoute({ ntt: nttConfig });
 
-    const result = await route.validate(request, { amount: "1.0" });
-    expect(result.valid).toBe(true);
-    if (!result.valid) throw new Error("unexpected");
-
-    const params = result.params as NttExecutorRoute.ValidatedParams;
-    expect(params.normalizedParams.referrerFeeDbps).toBe(0n);
-  });
-
-  it("resolves per-token feeDbps override from static config", async () => {
-    const route = createRoute({
-      ntt: nttConfig,
-      referrerFee: {
-        feeDbps: 10n,
-        perTokenOverrides: {
-          Solana: {
-            [SOL_TOKEN]: { referrerFeeDbps: 50n },
-          },
-        },
-      },
+    const tooLow = await route.validate(request, {
+      amount: "1.0",
+      options: { nativeGas: -0.1 },
     });
+    expect(tooLow.valid).toBe(false);
 
-    const result = await route.validate(request, { amount: "1.0" });
-    expect(result.valid).toBe(true);
-    if (!result.valid) throw new Error("unexpected");
+    const tooHigh = await route.validate(request, {
+      amount: "1.0",
+      options: { nativeGas: 1.1 },
+    });
+    expect(tooHigh.valid).toBe(false);
 
-    const params = result.params as NttExecutorRoute.ValidatedParams;
-    expect(params.normalizedParams.referrerFeeDbps).toBe(50n);
+    const valid = await route.validate(request, {
+      amount: "1.0",
+      options: { nativeGas: 0.5 },
+    });
+    expect(valid.valid).toBe(true);
   });
 });

--- a/sdk/route/src/executor/executor.ts
+++ b/sdk/route/src/executor/executor.ts
@@ -74,6 +74,10 @@ export namespace NttExecutorRoute {
   export type Options = {
     // 0.0 - 1.0 percentage of the maximum gas drop-off amount
     nativeGas?: number;
+    // Override the executor's destination relay funding / gas budget. When
+    // unset, estimateMsgValueAndGasLimit on the destination protocol is used.
+    msgValue?: bigint;
+    gasLimit?: bigint;
   };
 
   export type NormalizedParams = {
@@ -371,8 +375,10 @@ export class NttExecutorRoute<N extends Network>
           100n
         : 0n;
 
-    const { msgValue, gasLimit } =
+    const estimate =
       await dstNttWithExec.estimateMsgValueAndGasLimit(recipient);
+    const msgValue = params.options.msgValue ?? estimate.msgValue;
+    const gasLimit = params.options.gasLimit ?? estimate.gasLimit;
 
     const relayRequests = [];
 

--- a/sdk/route/src/executor/executor.ts
+++ b/sdk/route/src/executor/executor.ts
@@ -32,13 +32,11 @@ import {
   serializeLayout,
   signSendWait,
   toChainId,
-  Platform,
   chainToPlatform,
 } from "@wormhole-foundation/sdk-connect";
 import * as routes from "@wormhole-foundation/sdk-connect/routes";
 import { NttRoute } from "../types.js";
 import {
-  calculateReferrerFee,
   collectTransactions,
   fetchCapabilities,
   fetchSignedQuote,
@@ -56,45 +54,22 @@ import { getDefaultReferrerAddress } from "./consts.js";
 export namespace NttExecutorRoute {
   export type Config = {
     ntt: NttRoute.Config;
-    /** @deprecated Use getReferrerFee instead */
-    referrerFee?: ReferrerFeeConfig;
-    // Takes priority over referrerFee if defined
-    getReferrerFee?: ReferrerFeeCallback;
+    getFee?: GetFeeCallback;
   };
 
-  export type ReferrerFeeConfig = {
-    // Referrer Fee in *tenths* of basis points - e.g. 10 = 1 basis point (0.01%)
-    feeDbps: bigint;
-    // The address to which the referrer fee will be sent
-    referrerAddresses?: Partial<Record<Platform, string>>;
-    perTokenOverrides?: Partial<
-      Record<
-        Chain,
-        Record<
-          string,
-          {
-            referrerFeeDbps?: bigint;
-            // Some tokens may require more gas to redeem than the default.
-            gasLimit?: bigint;
-            // Some tokens may require more msgValue than the default.
-            msgValue?: bigint;
-          }
-        >
-      >
-    >;
-  };
-
-  export type ReferrerFeeResult = {
-    feeDbps: bigint;
+  export type GetFeeResult = {
+    transferTokenFee: bigint;
+    nativeTokenFee: bigint;
     referrerAddress: string;
   };
 
-  export type ReferrerFeeCallback = (token: {
+  export type GetFeeCallback = (params: {
+    amount: bigint;
     sourceChain: Chain;
     sourceToken: string;
     destinationChain: Chain;
     destinationToken: string;
-  }) => Promise<ReferrerFeeResult>;
+  }) => Promise<GetFeeResult>;
 
   export type Options = {
     // 0.0 - 1.0 percentage of the maximum gas drop-off amount
@@ -105,7 +80,8 @@ export namespace NttExecutorRoute {
     amount: amount.Amount;
     sourceContracts: Ntt.Contracts;
     destinationContracts: Ntt.Contracts;
-    referrerFeeDbps: bigint;
+    transferTokenFee: bigint;
+    nativeTokenFee: bigint;
     referrerAddress?: ChainAddress;
   };
 
@@ -226,41 +202,24 @@ export class NttExecutorRoute<N extends Network>
       request.destination.id
     );
 
-    let referrerFeeDbps = 0n;
-    let referrerAddress = getDefaultReferrerAddress(request.source.id.chain);
-    if (this.staticConfig.getReferrerFee) {
-      const result = await this.staticConfig.getReferrerFee({
+    let transferTokenFee = 0n;
+    let nativeTokenFee = 0n;
+    let referrerAddress: ChainAddress | undefined;
+
+    if (this.staticConfig.getFee) {
+      const result = await this.staticConfig.getFee({
+        amount: amount.units(trimmedAmount),
         sourceChain: request.source.id.chain,
         sourceToken: canonicalAddress(request.source.id),
         destinationChain: request.destination.id.chain,
         destinationToken: canonicalAddress(request.destination.id),
       });
-      referrerFeeDbps = result.feeDbps;
+      transferTokenFee = result.transferTokenFee;
+      nativeTokenFee = result.nativeTokenFee;
       referrerAddress = Wormhole.chainAddress(
         request.source.id.chain,
         result.referrerAddress
       );
-    } else if (this.staticConfig.referrerFee) {
-      referrerFeeDbps = this.staticConfig.referrerFee.feeDbps;
-      if (this.staticConfig.referrerFee.perTokenOverrides) {
-        const srcTokenAddress = canonicalAddress(request.source.id);
-        const override =
-          this.staticConfig.referrerFee.perTokenOverrides[
-            request.source.id.chain
-          ]?.[srcTokenAddress];
-        if (override?.referrerFeeDbps !== undefined) {
-          referrerFeeDbps = override.referrerFeeDbps;
-        }
-      }
-      const platform = chainToPlatform(request.source.id.chain);
-      const configuredAddress =
-        this.staticConfig.referrerFee.referrerAddresses?.[platform];
-      if (configuredAddress) {
-        referrerAddress = Wormhole.chainAddress(
-          request.source.id.chain,
-          configuredAddress
-        );
-      }
     }
 
     const validatedParams: Vp = {
@@ -269,7 +228,8 @@ export class NttExecutorRoute<N extends Network>
         amount: trimmedAmount,
         sourceContracts: srcContracts,
         destinationContracts: dstContracts,
-        referrerFeeDbps,
+        transferTokenFee,
+        nativeTokenFee,
         referrerAddress,
       },
       options,
@@ -368,12 +328,19 @@ export class NttExecutorRoute<N extends Network>
       params.normalizedParams.referrerAddress ??
       getDefaultReferrerAddress(fromChain.chain);
 
-    const { referrerFee, remainingAmount, referrerFeeDbps } =
-      calculateReferrerFee(
-        params.normalizedParams.amount,
-        params.normalizedParams.referrerFeeDbps,
+    const nativeTokenFee = params.normalizedParams.nativeTokenFee;
+    const transferAmount = amount.units(params.normalizedParams.amount);
+    // Trim the fee to destination decimals to avoid dust on the remaining amount.
+    const transferTokenFee = amount.units(
+      NttRoute.trimAmount(
+        amount.fromBaseUnits(
+          params.normalizedParams.transferTokenFee,
+          request.source.decimals
+        ),
         request.destination.decimals
-      );
+      )
+    );
+    const remainingAmount = transferAmount - transferTokenFee;
     if (remainingAmount <= 0n) {
       throw new Error("Amount after fee <= 0");
     }
@@ -404,23 +371,8 @@ export class NttExecutorRoute<N extends Network>
           100n
         : 0n;
 
-    let { msgValue, gasLimit } =
+    const { msgValue, gasLimit } =
       await dstNttWithExec.estimateMsgValueAndGasLimit(recipient);
-
-    // Check for overrides in the config.
-    if (this.staticConfig.referrerFee?.perTokenOverrides) {
-      const dstTokenAddress = canonicalAddress(request.destination.id);
-      const override =
-        this.staticConfig.referrerFee.perTokenOverrides[
-          request.destination.id.chain
-        ]?.[dstTokenAddress];
-      if (override?.gasLimit !== undefined) {
-        gasLimit = override.gasLimit;
-      }
-      if (override?.msgValue !== undefined) {
-        msgValue = override.msgValue;
-      }
-    }
 
     const relayRequests = [];
 
@@ -474,9 +426,9 @@ export class NttExecutorRoute<N extends Network>
       estimatedCost,
       payeeAddress: signedQuote.quote.payeeAddress,
       referrer,
-      referrerFee,
+      transferTokenFee,
+      nativeTokenFee,
       remainingAmount,
-      referrerFeeDbps,
       expires: signedQuote.quote.expiryTime,
       gasDropOff: dropOff,
     };
@@ -719,7 +671,8 @@ export class NttExecutorRoute<N extends Network>
               wormhole: dstInfo.transceiver["wormhole"]!,
             },
           },
-          referrerFeeDbps: 0n,
+          transferTokenFee: 0n,
+          nativeTokenFee: 0n,
         },
       },
     };

--- a/sdk/route/src/executor/multiToken.ts
+++ b/sdk/route/src/executor/multiToken.ts
@@ -20,6 +20,7 @@ import {
   deserializeLayout,
   guardians,
   UniversalAddress,
+  Platform,
   chainToPlatform,
   encoding,
   serializeLayout,
@@ -32,7 +33,6 @@ import {
   MultiTokenNtt,
   MultiTokenNttWithExecutor,
   Ntt,
-  NttWithExecutor,
 } from "@wormhole-foundation/sdk-definitions-ntt";
 import {
   calculateReferrerFee,
@@ -43,7 +43,6 @@ import {
   fetchStatus,
 } from "./utils.js";
 import { getDefaultReferrerAddress } from "./consts.js";
-import { NttExecutorRoute } from "./executor.js";
 
 export namespace MultiTokenNttExecutorRoute {
   export type Config = {
@@ -52,7 +51,23 @@ export namespace MultiTokenNttExecutorRoute {
     axelarGasMultiplier?: number | "auto";
   };
 
-  export type ReferrerFeeConfig = NttExecutorRoute.ReferrerFeeConfig;
+  export type ReferrerFeeConfig = {
+    feeDbps: bigint;
+    referrerAddresses?: Partial<Record<Platform, string>>;
+    perTokenOverrides?: Partial<
+      Record<
+        Chain,
+        Record<
+          string,
+          {
+            referrerFeeDbps?: bigint;
+            gasLimit?: bigint;
+            msgValue?: bigint;
+          }
+        >
+      >
+    >;
+  };
 }
 
 type Op = MultiTokenNttRoute.Options;
@@ -387,17 +402,21 @@ export class MultiTokenNttExecutorRoute<N extends Network>
   async fetchExecutorQuote(
     request: routes.RouteTransferRequest<N>,
     params: Vp
-  ): Promise<NttWithExecutor.Quote> {
+  ): Promise<
+    Omit<
+      MultiTokenNttWithExecutor.Quote,
+      "deliveryPrice" | "transceiverInstructions"
+    >
+  > {
     const { fromChain, toChain } = request;
 
     const referrer = this.getReferrerAddress(fromChain);
 
-    const { referrerFee, remainingAmount, referrerFeeDbps } =
-      calculateReferrerFee(
-        params.normalizedParams.amount,
-        params.normalizedParams.referrerFeeDbps ?? 0n,
-        request.destination.decimals
-      );
+    const { remainingAmount, referrerFeeDbps } = calculateReferrerFee(
+      params.normalizedParams.amount,
+      params.normalizedParams.referrerFeeDbps ?? 0n,
+      request.destination.decimals
+    );
     if (remainingAmount <= 0n) {
       throw new Error("Amount after fee <= 0");
     }
@@ -464,7 +483,6 @@ export class MultiTokenNttExecutorRoute<N extends Network>
       estimatedCost,
       payeeAddress: signedQuote.quote.payeeAddress,
       referrer,
-      referrerFee,
       remainingAmount,
       referrerFeeDbps,
       expires: signedQuote.quote.expiryTime,

--- a/solana/ts/sdk/nttWithExecutor.ts
+++ b/solana/ts/sdk/nttWithExecutor.ts
@@ -120,7 +120,7 @@ export class SolanaNttWithExecutor<N extends Network, C extends SolanaChains>
           { addressLookupTableAccounts: luts }
         );
 
-        if (quote.referrerFee > 0n) {
+        if (quote.transferTokenFee > 0n) {
           const referrer = new PublicKey(quote.referrer.address.toString());
 
           const { mint, tokenProgram } = await ntt.getConfig();
@@ -161,11 +161,22 @@ export class SolanaNttWithExecutor<N extends Network, C extends SolanaChains>
               mint,
               referrerAta,
               senderPk,
-              quote.referrerFee,
+              quote.transferTokenFee,
               mintInfo.decimals,
               undefined,
               tokenProgram
             )
+          );
+        }
+
+        if (quote.nativeTokenFee > 0n) {
+          const referrer = new PublicKey(quote.referrer.address.toString());
+          message.instructions.push(
+            SystemProgram.transfer({
+              fromPubkey: senderPk,
+              toPubkey: referrer,
+              lamports: quote.nativeTokenFee,
+            })
           );
         }
 

--- a/sui/ts/__tests__/nttWithExecutor.test.ts
+++ b/sui/ts/__tests__/nttWithExecutor.test.ts
@@ -24,9 +24,9 @@ describe("SuiNttWithExecutor", () => {
         toUint8Array: () => new Uint8Array(32).fill(0xbb),
       },
     } as any,
-    referrerFee: 500000n, // 0.0005 SUI
+    transferTokenFee: 500000n,
+    nativeTokenFee: 0n,
     remainingAmount: 999500000n, // 0.9995 SUI
-    referrerFeeDbps: 5n, // 0.05%
     expires: new Date(Date.now() + 3600000), // 1 hour from now
     gasDropOff: 100000n, // 0.0001 SUI
   };

--- a/sui/ts/src/nttWithExecutor.ts
+++ b/sui/ts/src/nttWithExecutor.ts
@@ -315,20 +315,31 @@ export class SuiNttWithExecutor<N extends Network, C extends SuiChains>
       );
     }
 
-    // Handle referrer fee if present
-    if (quote.referrerFee > 0n) {
-      // Convert referrer address to Sui address format
+    // Transfer token fee to referrer
+    if (quote.transferTokenFee > 0n) {
       const referrerAddress = `0x${Buffer.from(
         quote.referrer.address.toUint8Array()
       ).toString("hex")}`;
 
-      // Split coins for referrer fee from the same source
       const [referrerCoin] = isNative
-        ? tx.splitCoins(tx.gas, [tx.pure.u64(quote.referrerFee)])
-        : tx.splitCoins(primaryCoinInput!, [tx.pure.u64(quote.referrerFee)]);
+        ? tx.splitCoins(tx.gas, [tx.pure.u64(quote.transferTokenFee)])
+        : tx.splitCoins(primaryCoinInput!, [
+            tx.pure.u64(quote.transferTokenFee),
+          ]);
 
-      // Transfer the referrer fee
       tx.transferObjects([referrerCoin], referrerAddress);
+    }
+
+    // Transfer native fee to referrer
+    if (quote.nativeTokenFee > 0n) {
+      const referrerAddress = `0x${Buffer.from(
+        quote.referrer.address.toUint8Array()
+      ).toString("hex")}`;
+
+      const [nativeFeeCoin] = tx.splitCoins(tx.gas, [
+        tx.pure.u64(quote.nativeTokenFee),
+      ]);
+      tx.transferObjects([nativeFeeCoin], referrerAddress);
     }
 
     // Convert manager state ID to bytes


### PR DESCRIPTION
This PR migrates the EVM executor route from using the `NttManagerWithExecutor-0.0.1` to `NttManagerWithExecutor-0.0.2` contract. The biggest change is that the contract ABI changed:

v1: `(uint16 dbps, address payee)`
v2: `(uint256 transferTokenFee, uint256 nativeTokenFee, address payee)`

The fee can now be paid in units of the token being transferred (NTT token) and the gas token

Resolves CORE-2670