### PR TITLE
fix(solana): revert on dust, block pause attestation, add cancel outbound transfer

### DIFF
--- a/solana/programs/example-native-token-transfers/src/error.rs
+++ b/solana/programs/example-native-token-transfers/src/error.rs
@@ -65,6 +65,10 @@ pub enum NTTError {
     ThresholdTooHigh,
     #[msg("InvalidTransceiverProgram")]
     InvalidTransceiverProgram,
+    #[msg("TransferAmountHasDust")]
+    TransferAmountHasDust,
+    #[msg("CancellerNotSender")]
+    CancellerNotSender,
 }
 
 impl From<ScalingError> for NTTError {

--- a/solana/programs/example-native-token-transfers/src/instructions/cancel_outbound_transfer.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/cancel_outbound_transfer.rs
@@ -1,0 +1,131 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token_interface;
+use ntt_messages::{mode::Mode, trimmed_amount::TrimmedAmount};
+use spl_token_2022::onchain;
+
+use crate::{
+    config::*,
+    error::NTTError,
+    queue::outbox::OutboxItem,
+};
+
+#[derive(Accounts)]
+pub struct CancelOutboundTransfer<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    pub config: NotPausedConfig<'info>,
+
+    #[account(
+        mut,
+        close = payer,
+        constraint = outbox_item.sender == payer.key() @ NTTError::CancellerNotSender,
+    )]
+    pub outbox_item: Account<'info, OutboxItem>,
+
+    #[account(
+        mut,
+        address = config.mint,
+    )]
+    /// CHECK: the mint address matches the config
+    pub mint: InterfaceAccount<'info, token_interface::Mint>,
+
+    #[account(
+        mut,
+        address = config.custody,
+    )]
+    pub custody: InterfaceAccount<'info, token_interface::TokenAccount>,
+
+    #[account(
+        mut,
+        associated_token::authority = payer,
+        associated_token::mint = mint,
+        associated_token::token_program = token_program,
+    )]
+    pub sender_ata: InterfaceAccount<'info, token_interface::TokenAccount>,
+
+    #[account(
+        seeds = [crate::TOKEN_AUTHORITY_SEED],
+        bump,
+    )]
+    /// CHECK: The seeds constraint ensures this is the correct address
+    pub token_authority: UncheckedAccount<'info>,
+
+    pub token_program: Interface<'info, token_interface::TokenInterface>,
+
+    pub system_program: Program<'info, System>,
+}
+
+/// Cancel a queued outbound transfer and refund tokens to the sender.
+///
+/// Only the original sender can cancel their transfer. Transfers that have
+/// already been picked up by a transceiver (i.e. `released` is non-empty)
+/// cannot be cancelled.
+///
+/// In BURNING mode: mints new tokens to custody, then transfers to sender.
+/// In LOCKING mode: transfers tokens from custody back to sender.
+///
+/// This closes the outbox_item account and returns rent to the payer.
+pub fn cancel_outbound_transfer<'info>(
+    ctx: Context<'_, '_, '_, 'info, CancelOutboundTransfer<'info>>,
+) -> Result<()> {
+    let accs = ctx.accounts;
+
+    // Verify no transceiver has released this item yet.
+    // Once a transceiver has picked it up, cancel is not possible.
+    if accs.outbox_item.released.count_enabled_votes(&accs.config.enabled_transceivers) > 0 {
+        return Err(NTTError::MessageAlreadySent.into());
+    }
+
+    let amount = accs.outbox_item.amount.untrim(accs.mint.decimals)
+        .map_err(NTTError::from)?;
+
+    let token_authority_signer: &[&[&[u8]]] = &[&[
+        crate::TOKEN_AUTHORITY_SEED,
+        &[ctx.bumps.token_authority],
+    ]];
+
+    if accs.config.mode == Mode::Burning {
+        // Step 1: mint tokens to the custody account
+        token_interface::mint_to(
+            CpiContext::new_with_signer(
+                accs.token_program.to_account_info(),
+                token_interface::MintTo {
+                    mint: accs.mint.to_account_info(),
+                    to: accs.custody.to_account_info(),
+                    authority: accs.token_authority.to_account_info(),
+                },
+                token_authority_signer,
+            ),
+            amount,
+        )?;
+
+        // Step 2: transfer tokens from custody to sender's ATA
+        onchain::invoke_transfer_checked(
+            &accs.token_program.key(),
+            accs.custody.to_account_info(),
+            accs.mint.to_account_info(),
+            accs.sender_ata.to_account_info(),
+            accs.token_authority.to_account_info(),
+            ctx.remaining_accounts,
+            amount,
+            accs.mint.decimals,
+            token_authority_signer,
+        )?;
+    } else {
+        // LOCKING mode: transfer tokens from custody to sender's ATA
+        onchain::invoke_transfer_checked(
+            &accs.token_program.key(),
+            accs.custody.to_account_info(),
+            accs.mint.to_account_info(),
+            accs.sender_ata.to_account_info(),
+            accs.token_authority.to_account_info(),
+            ctx.remaining_accounts,
+            amount,
+            accs.mint.decimals,
+            token_authority_signer,
+        )?;
+    }
+
+    Ok(())
+}

--- a/solana/programs/example-native-token-transfers/src/instructions/mod.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin;
+pub mod cancel_outbound_transfer;
 pub mod initialize;
 pub mod luts;
 pub mod mark_outbox_item_as_released;
@@ -7,6 +8,7 @@ pub mod release_inbound;
 pub mod transfer;
 
 pub use admin::*;
+pub use cancel_outbound_transfer::*;
 pub use initialize::*;
 pub use luts::*;
 pub use mark_outbox_item_as_released::*;

--- a/solana/programs/example-native-token-transfers/src/instructions/redeem.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/redeem.rs
@@ -26,7 +26,7 @@ pub struct Redeem<'info> {
     #[account(
         constraint = config.threshold > 0 @ NTTError::ZeroThreshold
     )]
-    pub config: Account<'info, Config>,
+    pub config: NotPausedConfig<'info>,
 
     #[account(
         seeds = [NttManagerPeer::SEED_PREFIX, ValidatedTransceiverMessage::<NativeTokenTransfer<Payload>>::from_chain(&transceiver_message)?.id.to_be_bytes().as_ref()],

--- a/solana/programs/example-native-token-transfers/src/instructions/transfer.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/transfer.rs
@@ -167,13 +167,18 @@ pub fn transfer_burn<'info>(
         should_queue,
     } = args;
 
-    // TODO: should we revert if we have dust?
+    let original_amount = amount;
     let trimmed_amount = TrimmedAmount::remove_dust(
         &mut amount,
         accs.common.mint.decimals,
         accs.peer.token_decimals,
     )
     .map_err(NTTError::from)?;
+
+    // Revert if dust was silently removed, aligning with EVM behavior
+    if original_amount != amount {
+        return Err(NTTError::TransferAmountHasDust.into());
+    }
 
     let before = accs.common.custody.amount;
 
@@ -309,13 +314,18 @@ pub fn transfer_lock<'info>(
         should_queue,
     } = args;
 
-    // TODO: should we revert if we have dust?
+    let original_amount = amount;
     let trimmed_amount = TrimmedAmount::remove_dust(
         &mut amount,
         accs.common.mint.decimals,
         accs.peer.token_decimals,
     )
     .map_err(NTTError::from)?;
+
+    // Revert if dust was silently removed, aligning with EVM behavior
+    if original_amount != amount {
+        return Err(NTTError::TransferAmountHasDust.into());
+    }
 
     let before = accs.common.custody.amount;
 

--- a/solana/programs/example-native-token-transfers/src/lib.rs
+++ b/solana/programs/example-native-token-transfers/src/lib.rs
@@ -166,6 +166,10 @@ pub mod example_native_token_transfers {
         instructions::set_paused(ctx, pause)
     }
 
+    pub fn cancel_outbound_transfer(ctx: Context<CancelOutboundTransfer>) -> Result<()> {
+        instructions::cancel_outbound_transfer(ctx)
+    }
+
     pub fn set_peer(ctx: Context<SetPeer>, args: SetPeerArgs) -> Result<()> {
         instructions::set_peer(ctx, args)
     }


### PR DESCRIPTION
## Summary

Fixes three security issues reported in:
- [#877](https://github.com/wormhole-foundation/native-token-transfers/issues/877) — Dust silently lost
- [#878](https://github.com/wormhole-foundation/native-token-transfers/issues/878) — No cancel mechanism
- [#879](https://github.com/wormhole-foundation/native-token-transfers/issues/879) — Attestation during pause

## Changes

### 1. Dust revert (`transfer.rs`)
Replaces `remove_dust` silent modification with explicit revert `TransferAmountHasDust`.
Aligns Solana with EVM behavior.

### 2. Pause attestation block (`redeem.rs`)
Changes `Account<'info, Config>` to `NotPausedConfig<'info>` so redeem() is blocked during pause.
Aligns Solana with EVM and Sui.

### 3. Cancel outbound transfer (new `cancel_outbound_transfer.rs`)
New instruction allowing senders to cancel queued outbound transfers and recover tokens.
Handles both BURNING (mint+transfer) and LOCKING (transfer from custody) modes.
Closes the outbox_item account and returns rent.

## Verification
- Rust code compiles with existing dependencies
- Error variants follow existing patterns
- Uses same account structures and PDA signing as existing instructions