### PR TITLE
feat(cli): XRPL subcommand group

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
       },
       "dependencies": {
         "@msgpack/msgpack": "^3.1.3",
+        "binary-layout": "^1.0.0",
         "xrpl": "^4.6.0",
         "yargs": "18.0.0",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
       },
       "dependencies": {
         "@msgpack/msgpack": "^3.1.3",
+        "xrpl": "^4.6.0",
         "yargs": "18.0.0",
       },
       "devDependencies": {
@@ -1030,7 +1031,7 @@
 
     "ethers": ["ethers@6.15.0", "", { "dependencies": { "@adraffy/ens-normalize": "1.10.1", "@noble/curves": "1.2.0", "@noble/hashes": "1.3.2", "@types/node": "22.7.5", "aes-js": "4.0.0-beta.5", "tslib": "2.7.0", "ws": "8.17.1" } }, "sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ=="],
 
-    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+    "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
@@ -1694,8 +1695,6 @@
 
     "@aptos-labs/ts-sdk/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
 
-    "@aptos-labs/ts-sdk/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
-
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -1711,6 +1710,8 @@
     "@coral-xyz/anchor/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@coral-xyz/anchor/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+
+    "@coral-xyz/anchor/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "@coral-xyz/anchor/superstruct": ["superstruct@0.15.5", "", {}, "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="],
 
@@ -1934,8 +1935,6 @@
 
     "@xrplf/isomorphic/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
-    "@xrplf/isomorphic/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
-
     "@xrplf/isomorphic/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
@@ -2124,8 +2123,6 @@
 
     "ox/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
 
-    "ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
-
     "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
@@ -2139,8 +2136,6 @@
     "ripple-keypairs/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "rpc-websockets/@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
-
-    "rpc-websockets/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "rxjs/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -2201,8 +2196,6 @@
     "xrpl/@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
 
     "xrpl/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
-
-    "xrpl/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
@@ -2493,6 +2486,8 @@
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/tendermint-rpc": ["@cosmjs/tendermint-rpc@0.32.4", "", { "dependencies": { "@cosmjs/crypto": "^0.32.4", "@cosmjs/encoding": "^0.32.4", "@cosmjs/json-rpc": "^0.32.4", "@cosmjs/math": "^0.32.4", "@cosmjs/socket": "^0.32.4", "@cosmjs/stream": "^0.32.4", "@cosmjs/utils": "^0.32.4", "axios": "^1.6.0", "readonly-date": "^1.0.0", "xstream": "^11.14.0" } }, "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw=="],
 
     "@wormhole-foundation/sdk-cosmwasm/@cosmjs/stargate/@cosmjs/utils": ["@cosmjs/utils@0.32.4", "", {}, "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="],
+
+    "@wormhole-foundation/sdk-solana/rpc-websockets/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "@wormhole-foundation/wormchain-sdk/ts-jest/jest-util": ["jest-util@27.5.1", "", { "dependencies": { "@jest/types": "^27.5.1", "@types/node": "*", "chalk": "^4.0.0", "ci-info": "^3.2.0", "graceful-fs": "^4.2.9", "picomatch": "^2.2.3" } }, "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@msgpack/msgpack": "^3.1.3",
+    "xrpl": "^4.6.0",
     "yargs": "18.0.0"
   },
   "overrides": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@msgpack/msgpack": "^3.1.3",
+    "binary-layout": "^1.0.0",
     "xrpl": "^4.6.0",
     "yargs": "18.0.0"
   },

--- a/cli/src/__tests__/cli-help.test.ts
+++ b/cli/src/__tests__/cli-help.test.ts
@@ -55,7 +55,13 @@ const SOLANA_SUBCOMMANDS = [
   "build",
 ];
 
-const XRPL_SUBCOMMANDS = ["emitter", "parse-vaa", "relay"];
+const XRPL_SUBCOMMANDS = [
+  "emitter",
+  "parse-vaa",
+  "relay",
+  "register-peer",
+  "rotate-admin",
+];
 
 const CONFIG_SUBCOMMANDS = ["set-chain", "unset-chain", "get-chain"];
 

--- a/cli/src/__tests__/cli-help.test.ts
+++ b/cli/src/__tests__/cli-help.test.ts
@@ -44,6 +44,7 @@ const EXPECTED_COMMANDS = [
   "solana",
   "hype",
   "manual",
+  "xrpl",
 ];
 
 const SOLANA_SUBCOMMANDS = [
@@ -53,6 +54,8 @@ const SOLANA_SUBCOMMANDS = [
   "create-spl-multisig",
   "build",
 ];
+
+const XRPL_SUBCOMMANDS = ["emitter", "parse-vaa", "relay"];
 
 const CONFIG_SUBCOMMANDS = ["set-chain", "unset-chain", "get-chain"];
 
@@ -121,6 +124,22 @@ describe("CLI Help Output", () => {
     const results = await Promise.all(
       CONFIG_SUBCOMMANDS.map(async (sub) => {
         const { exitCode, stdout } = await runCli("config", sub, "--help");
+        return { sub, exitCode, hasOutput: stdout.length > 0 };
+      })
+    );
+    const failures = results.filter((r) => r.exitCode !== 0 || !r.hasOutput);
+    expect(failures).toEqual([]);
+  });
+
+  it("xrpl subcommands are listed and their --help exits with 0", async () => {
+    if (!cliAvailable) return;
+    const { stdout: xrplHelp } = await runCli("xrpl", "--help");
+    for (const sub of XRPL_SUBCOMMANDS) {
+      expect(xrplHelp).toContain(sub);
+    }
+    const results = await Promise.all(
+      XRPL_SUBCOMMANDS.map(async (sub) => {
+        const { exitCode, stdout } = await runCli("xrpl", sub, "--help");
         return { sub, exitCode, hasOutput: stdout.length > 0 };
       })
     );

--- a/cli/src/__tests__/xrpl-admin.test.ts
+++ b/cli/src/__tests__/xrpl-admin.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "bun:test";
+import {
+  buildRegisterPeerPayload,
+  buildRotateAdminPayload,
+} from "../xrpl/admin";
+import { parseAdmin } from "../xrpl/payloads";
+import { toChainId } from "@wormhole-foundation/sdk";
+
+// The XADM encoders (admin.ts) and decoder (payloads.ts::parseAdmin) must agree.
+describe("XADM admin payloads round-trip through parseAdmin", () => {
+  const manager = "rwooXFqJZc5cwuG3XJT5eWUgmdvKs2br4Q";
+
+  it("RegisterPeer (0x01)", () => {
+    const peer =
+      "bd9ea0c58c349b4c6768e005c0b794418c46c71a1953f59e089f181bf6d81457";
+    const hex = buildRegisterPeerPayload({
+      manager,
+      peerChainId: toChainId("Solana"),
+      peerAddress: peer,
+    });
+    const parsed = parseAdmin(Buffer.from(hex, "hex"));
+    expect(parsed.actionName).toBe("RegisterPeer");
+    expect(parsed.targetAccount).toBe(manager);
+    expect(parsed.chainId).toBe(toChainId("Solana"));
+    expect(parsed.peerAddress).toBe(peer);
+  });
+
+  it("RegisterPeer accepts a 0x-prefixed peer address", () => {
+    const peer =
+      "bd9ea0c58c349b4c6768e005c0b794418c46c71a1953f59e089f181bf6d81457";
+    const hex = buildRegisterPeerPayload({
+      manager,
+      peerChainId: 1,
+      peerAddress: "0x" + peer,
+    });
+    const parsed = parseAdmin(Buffer.from(hex, "hex"));
+    expect(parsed.peerAddress).toBe(peer);
+  });
+
+  it("rejects a peer address that is not 32 bytes", () => {
+    expect(() =>
+      buildRegisterPeerPayload({ manager, peerChainId: 1, peerAddress: "abcd" })
+    ).toThrow();
+  });
+
+  it("RotateAdmin (0x02)", () => {
+    const newAdmin = "rnv8uG8r7mewUqTZ7us3KESFE4cAEqsjm1";
+    const hex = buildRotateAdminPayload({ manager, newAdmin });
+    const parsed = parseAdmin(Buffer.from(hex, "hex"));
+    expect(parsed.actionName).toBe("RotateAdmin");
+    expect(parsed.targetAccount).toBe(manager);
+    expect(parsed.newAdmin).toBe(newAdmin);
+  });
+});

--- a/cli/src/__tests__/xrpl-custody.test.ts
+++ b/cli/src/__tests__/xrpl-custody.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { Wallet, decodeAccountID } from "xrpl";
+import { validateRAddress } from "../xrpl/helpers";
+import {
+  deriveSignerEntries,
+  parseManagerSet,
+  signerEntriesFromAddresses,
+} from "../xrpl/manager-set";
+
+describe("validateRAddress", () => {
+  test("accepts a valid classic address", () => {
+    expect(validateRAddress("r9qAVHiq4gNPFJTHduy7fWEgUPvre2VLpG")).toBe(
+      "r9qAVHiq4gNPFJTHduy7fWEgUPvre2VLpG"
+    );
+  });
+
+  test("rejects an invalid address", () => {
+    expect(() => validateRAddress("not-an-address")).toThrow(/Invalid XRPL/);
+  });
+});
+
+describe("parseManagerSet", () => {
+  function pk(byte: number): Buffer {
+    const b = Buffer.alloc(33, byte);
+    b[0] = 0x02; // compressed-key prefix-ish (value irrelevant to parsing)
+    return b;
+  }
+
+  test("parses version, threshold, total and 33-byte pubkeys", () => {
+    const header = Buffer.from([1, 2, 3]); // version 1, mThreshold 2, nTotal 3
+    const body = Buffer.concat([pk(0xaa), pk(0xbb), pk(0xcc)]);
+    const set = parseManagerSet(Buffer.concat([header, body]));
+    expect(set.mThreshold).toBe(2);
+    expect(set.nTotal).toBe(3);
+    expect(set.pubkeys.length).toBe(3);
+    expect(set.pubkeys[0].length).toBe(33);
+  });
+
+  test("rejects a bad version", () => {
+    expect(() => parseManagerSet(Buffer.from([0, 1, 0]))).toThrow(/version/);
+  });
+
+  test("rejects truncated pubkey data", () => {
+    // nTotal says 2 but only one 33-byte key follows
+    const buf = Buffer.concat([Buffer.from([1, 1, 2]), Buffer.alloc(33)]);
+    expect(() => parseManagerSet(buf)).toThrow(/expected/);
+  });
+});
+
+describe("signer entries", () => {
+  test("deriveSignerEntries: pubkey -> account, weight 1, sorted", () => {
+    const w1 = Wallet.generate();
+    const w2 = Wallet.generate();
+    const entries = deriveSignerEntries([
+      Buffer.from(w1.publicKey, "hex"),
+      Buffer.from(w2.publicKey, "hex"),
+    ]);
+    // derived accounts match the wallets' classic addresses
+    const accounts = entries.map((e) => e.SignerEntry.Account);
+    expect(accounts).toContain(w1.classicAddress);
+    expect(accounts).toContain(w2.classicAddress);
+    expect(entries.every((e) => e.SignerEntry.SignerWeight === 1)).toBe(true);
+    // sorted ascending by account ID
+    const ids = accounts.map((a) => Buffer.from(decodeAccountID(a)));
+    expect(Buffer.compare(ids[0], ids[1])).toBeLessThanOrEqual(0);
+  });
+
+  test("signerEntriesFromAddresses: trims, weight 1, sorted", () => {
+    const a = "r9qAVHiq4gNPFJTHduy7fWEgUPvre2VLpG";
+    const b = "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De";
+    const entries = signerEntriesFromAddresses([` ${a} `, b]);
+    expect(entries.length).toBe(2);
+    expect(entries.every((e) => e.SignerEntry.SignerWeight === 1)).toBe(true);
+    const ids = entries.map((e) =>
+      Buffer.from(decodeAccountID(e.SignerEntry.Account))
+    );
+    expect(Buffer.compare(ids[0], ids[1])).toBeLessThanOrEqual(0);
+  });
+});

--- a/cli/src/__tests__/xrpl-executorLayouts.test.ts
+++ b/cli/src/__tests__/xrpl-executorLayouts.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "bun:test";
+import {
+  serializeRequest,
+  deserializeRequest,
+  RequestPrefix,
+  buildGasInstructionHex,
+  type RequestLayout,
+} from "../xrpl/executorLayouts";
+
+describe("request layout round-trip", () => {
+  it("ERN1 (NTT transfer) serializes with prefix 0x45524e31 and round-trips", () => {
+    const req: RequestLayout = {
+      request: {
+        prefix: RequestPrefix.ERN1,
+        srcChain: 66,
+        srcManager: `0x${"11".repeat(32)}`,
+        messageId: `0x${"22".repeat(32)}`,
+      },
+    };
+    const hex = serializeRequest(req);
+    expect(hex.slice(2, 10)).toBe("45524e31"); // "ERN1"
+    const back = deserializeRequest(hex);
+    expect(back).toEqual(req);
+  });
+
+  it("ERV1 (VAA_V1) serializes with prefix 0x45525631 and round-trips", () => {
+    const req: RequestLayout = {
+      request: {
+        prefix: RequestPrefix.ERV1,
+        chain: 66,
+        address: `0x${"ab".repeat(32)}`,
+        sequence: 1234567890n,
+      },
+    };
+    const hex = serializeRequest(req);
+    expect(hex.slice(2, 10)).toBe("45525631"); // "ERV1"
+    const back = deserializeRequest(hex);
+    expect(back).toEqual(req);
+  });
+});
+
+describe("buildGasInstructionHex", () => {
+  it("encodes 0x01 + 16-byte gasLimit + 16-byte msgValue", () => {
+    const hex = buildGasInstructionHex(250_000n, 0n);
+    // 1 + 16 + 16 = 33 bytes => 66 hex chars + 0x
+    expect(hex.length).toBe(2 + 66);
+    expect(hex.slice(2, 4)).toBe("01");
+    // gasLimit 250000 = 0x3d090 as a 16-byte big-endian field, then 16 zero bytes
+    const gasLimitField = (250_000).toString(16).padStart(32, "0");
+    const msgValueField = "00".repeat(16);
+    expect(hex.slice(2)).toBe("01" + gasLimitField + msgValueField);
+  });
+});

--- a/cli/src/__tests__/xrpl-helpers.test.ts
+++ b/cli/src/__tests__/xrpl-helpers.test.ts
@@ -82,9 +82,9 @@ describe("validateMptIssuanceParams", () => {
   });
 
   test("rejects out-of-range asset scale", () => {
-    expect(() =>
-      validateMptIssuanceParams({ ...ok, assetScale: 256 })
-    ).toThrow(/asset-scale/);
+    expect(() => validateMptIssuanceParams({ ...ok, assetScale: 256 })).toThrow(
+      /asset-scale/
+    );
   });
 
   test("rejects out-of-range transfer fee", () => {
@@ -107,9 +107,9 @@ describe("validateMptIssuanceParams", () => {
     expect(() =>
       validateMptIssuanceParams({ ...ok, maxAmount: "1000000" })
     ).not.toThrow();
-    expect(() =>
-      validateMptIssuanceParams({ ...ok, maxAmount: "0" })
-    ).toThrow(/greater than 0/);
+    expect(() => validateMptIssuanceParams({ ...ok, maxAmount: "0" })).toThrow(
+      /greater than 0/
+    );
     expect(() =>
       validateMptIssuanceParams({ ...ok, maxAmount: "1.5" })
     ).toThrow(/non-negative integer/);

--- a/cli/src/__tests__/xrpl-helpers.test.ts
+++ b/cli/src/__tests__/xrpl-helpers.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+import {
+  XRPL_ENDPOINTS,
+  loadMetadataHex,
+  loadSeed,
+  normalizeCurrency,
+  parseMptFlags,
+  resolveXrplEndpoint,
+  validateMptIssuanceParams,
+} from "../xrpl/helpers";
+
+describe("parseMptFlags", () => {
+  test("returns 0 for empty/undefined input", () => {
+    expect(parseMptFlags(undefined)).toBe(0);
+    expect(parseMptFlags("")).toBe(0);
+  });
+
+  test("parses a single named flag", () => {
+    expect(parseMptFlags("tfMPTCanTransfer")).toBe(0x0020);
+  });
+
+  test("ORs multiple named flags (with whitespace)", () => {
+    expect(parseMptFlags("tfMPTCanTransfer, tfMPTCanClawback")).toBe(
+      0x0020 | 0x0040
+    );
+  });
+
+  test("accepts raw decimal and hex integers", () => {
+    expect(parseMptFlags("96")).toBe(96);
+    expect(parseMptFlags("0x60")).toBe(0x60);
+  });
+
+  test("throws on an unknown flag name", () => {
+    expect(() => parseMptFlags("tfNope")).toThrow(/Unknown MPT flag/);
+  });
+});
+
+describe("normalizeCurrency", () => {
+  test("passes through a 3-char ASCII code", () => {
+    expect(normalizeCurrency("FOO")).toBe("FOO");
+  });
+
+  test("uppercases and accepts a 40-char hex code", () => {
+    const hex = "524c555344000000000000000000000000000000"; // RLUSD
+    expect(normalizeCurrency(hex)).toBe(hex.toUpperCase());
+  });
+
+  test("rejects other lengths / non-hex", () => {
+    expect(() => normalizeCurrency("RLUSD")).toThrow(/Invalid currency/);
+    expect(() => normalizeCurrency("ZZ")).toThrow(/Invalid currency/);
+  });
+});
+
+describe("loadMetadataHex", () => {
+  test("returns undefined when no input given", () => {
+    expect(loadMetadataHex(undefined)).toBeUndefined();
+  });
+
+  test("hex-encodes inline JSON (round-trips)", () => {
+    const hex = loadMetadataHex('{"n":"BAR"}');
+    expect(hex).toBeDefined();
+    expect(JSON.parse(Buffer.from(hex!, "hex").toString("utf8"))).toEqual({
+      n: "BAR",
+    });
+  });
+
+  test("throws on invalid JSON", () => {
+    expect(() => loadMetadataHex("not json")).toThrow(/valid JSON/);
+  });
+
+  test("throws when the encoded blob exceeds 1024 bytes", () => {
+    const big = JSON.stringify({ d: "x".repeat(1100) });
+    expect(() => loadMetadataHex(big)).toThrow(/1024 bytes/);
+  });
+});
+
+describe("validateMptIssuanceParams", () => {
+  const ok = { assetScale: 0, transferFee: 0, flags: 0 };
+
+  test("accepts valid defaults", () => {
+    expect(() => validateMptIssuanceParams(ok)).not.toThrow();
+  });
+
+  test("rejects out-of-range asset scale", () => {
+    expect(() =>
+      validateMptIssuanceParams({ ...ok, assetScale: 256 })
+    ).toThrow(/asset-scale/);
+  });
+
+  test("rejects out-of-range transfer fee", () => {
+    expect(() =>
+      validateMptIssuanceParams({ ...ok, transferFee: 50001, flags: 0x0020 })
+    ).toThrow(/transfer-fee/);
+  });
+
+  test("requires tfMPTCanTransfer when transfer fee is set", () => {
+    expect(() =>
+      validateMptIssuanceParams({ ...ok, transferFee: 100, flags: 0 })
+    ).toThrow(/tfMPTCanTransfer/);
+    // with the flag set, the same fee is fine
+    expect(() =>
+      validateMptIssuanceParams({ ...ok, transferFee: 100, flags: 0x0020 })
+    ).not.toThrow();
+  });
+
+  test("validates maxAmount: integer, > 0, within UInt64 ceiling", () => {
+    expect(() =>
+      validateMptIssuanceParams({ ...ok, maxAmount: "1000000" })
+    ).not.toThrow();
+    expect(() =>
+      validateMptIssuanceParams({ ...ok, maxAmount: "0" })
+    ).toThrow(/greater than 0/);
+    expect(() =>
+      validateMptIssuanceParams({ ...ok, maxAmount: "1.5" })
+    ).toThrow(/non-negative integer/);
+    expect(() =>
+      validateMptIssuanceParams({ ...ok, maxAmount: (2n ** 63n).toString() })
+    ).toThrow(/2\^63/);
+  });
+});
+
+describe("loadSeed", () => {
+  test("prefers the flag value", () => {
+    expect(loadSeed("sFlag", "seed", "XRPL_TEST_SEED_UNSET")).toBe("sFlag");
+  });
+
+  test("falls back to the env var", () => {
+    process.env.XRPL_TEST_SEED = "sEnv";
+    expect(loadSeed(undefined, "seed", "XRPL_TEST_SEED")).toBe("sEnv");
+    delete process.env.XRPL_TEST_SEED;
+  });
+
+  test("throws when neither flag nor env is present", () => {
+    expect(() => loadSeed(undefined, "seed", "XRPL_TEST_SEED_UNSET")).toThrow(
+      /Missing seed/
+    );
+  });
+});
+
+describe("resolveXrplEndpoint", () => {
+  test("uses the network default when nothing else is provided", () => {
+    expect(resolveXrplEndpoint("Testnet")).toBe(XRPL_ENDPOINTS.Testnet);
+  });
+
+  test("--rpc override wins over everything", () => {
+    expect(resolveXrplEndpoint("Mainnet", "wss://custom", undefined)).toBe(
+      "wss://custom"
+    );
+  });
+
+  test("falls back to overrides.json (chains.Xrpl.rpc) before the default", () => {
+    const overrides = { chains: { Xrpl: { rpc: "wss://override" } } } as any;
+    expect(resolveXrplEndpoint("Mainnet", undefined, overrides)).toBe(
+      "wss://override"
+    );
+  });
+});

--- a/cli/src/__tests__/xrpl-onboarding.test.ts
+++ b/cli/src/__tests__/xrpl-onboarding.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import { decodeAccountID } from "xrpl";
+import {
+  XRPL_ONBOARDING_PREFIX,
+  buildInitData,
+  buildOnboardingPayload,
+  buildPublishMemoData,
+  currencyToHex40,
+} from "../xrpl/onboarding";
+
+const ADMIN = "r9qAVHiq4gNPFJTHduy7fWEgUPvre2VLpG";
+const FOO_CURRENCY = "000000000000000000000000464F4F0000000000";
+const MPT_ID = "00EE5E8C05394002CF8CF3975AC29D11553735BBEDF87BF9";
+
+describe("currencyToHex40", () => {
+  test("passes through a 40-char hex code (lowercased)", () => {
+    expect(currencyToHex40(FOO_CURRENCY)).toBe(FOO_CURRENCY.toLowerCase());
+  });
+
+  test("encodes a 3-char ASCII code into bytes 12-14", () => {
+    // "FOO" => 0x46 0x4F 0x4F at offset 12
+    expect(currencyToHex40("FOO")).toBe(FOO_CURRENCY.toLowerCase());
+  });
+
+  test("rejects invalid lengths", () => {
+    expect(() => currencyToHex40("RLUSD")).toThrow(/Invalid currency/);
+  });
+});
+
+describe("buildInitData", () => {
+  test("xrp: short form is just the decimals byte", () => {
+    expect(buildInitData(6, { type: "xrp" })).toBe("06");
+    expect(buildInitData(8, { type: "xrp" })).toBe("08");
+  });
+
+  test("iou: decimals + 0x01 + currency + issuer, right-padded to 43 bytes total", () => {
+    const out = buildInitData(9, {
+      type: "iou",
+      currency: FOO_CURRENCY,
+      issuer: ADMIN,
+    });
+    const issuerHex = Buffer.from(decodeAccountID(ADMIN)).toString("hex");
+    // 1 (decimals) + 42 (token_id padded) = 43 bytes => 86 hex chars
+    expect(out.length).toBe(86);
+    expect(out.startsWith("09" + "01" + FOO_CURRENCY.toLowerCase() + issuerHex)).toBe(
+      true
+    );
+    // trailing byte is zero padding (41 bytes of data -> padded to 42)
+    expect(out.endsWith("00")).toBe(true);
+  });
+
+  test("mpt: decimals + 0x02 + mpt_id, right-padded to 43 bytes total", () => {
+    const out = buildInitData(9, { type: "mpt", mptId: MPT_ID });
+    expect(out.length).toBe(86);
+    expect(out.startsWith("09" + "02" + MPT_ID.toLowerCase())).toBe(true);
+    // 1 + 2 + 48 = 51 hex of data, padded to 84 -> ends in zeros
+    expect(out.endsWith("0000")).toBe(true);
+  });
+
+  test("mpt: rejects a wrong-length issuance id", () => {
+    expect(() => buildInitData(9, { type: "mpt", mptId: "00EE" })).toThrow(
+      /48/
+    );
+  });
+
+  test("rejects decimals out of byte range", () => {
+    expect(() => buildInitData(256, { type: "xrp" })).toThrow(/one unsigned byte/);
+  });
+});
+
+describe("buildOnboardingPayload", () => {
+  test("xrp: assembles prefix + admin + app + tickets + init_data", () => {
+    const initData = buildInitData(6, { type: "xrp" });
+    const out = buildOnboardingPayload({
+      admin: ADMIN,
+      app: "NTT",
+      initialTicket: 100,
+      ticketCount: 150,
+      initData,
+    });
+
+    const adminHex = Buffer.from(decodeAccountID(ADMIN)).toString("hex");
+    const appHex = Buffer.from("NTT", "utf8").toString("hex").padStart(64, "0");
+    const expected =
+      XRPL_ONBOARDING_PREFIX +
+      adminHex +
+      appHex +
+      "0000000000000064" + // 100
+      "0000000000000096" + // 150
+      "06";
+    expect(out).toBe(expected);
+    // 4 + 20 + 32 + 8 + 8 + 1 = 73 bytes => 146 hex chars
+    expect(out.length).toBe(146);
+  });
+
+  test("full form (iou) is 115 bytes", () => {
+    const initData = buildInitData(8, {
+      type: "iou",
+      currency: FOO_CURRENCY,
+      issuer: ADMIN,
+    });
+    const out = buildOnboardingPayload({
+      admin: ADMIN,
+      app: "NTT",
+      initialTicket: 1,
+      ticketCount: 2,
+      initData,
+    });
+    // 72 (fixed) + 43 (init_data) = 115 bytes => 230 hex chars
+    expect(out.length).toBe(230);
+  });
+});
+
+describe("buildPublishMemoData", () => {
+  test("prepends version + nonce and uppercases", () => {
+    expect(buildPublishMemoData("abcd")).toBe("0100000000ABCD");
+  });
+});

--- a/cli/src/__tests__/xrpl-onboarding.test.ts
+++ b/cli/src/__tests__/xrpl-onboarding.test.ts
@@ -42,9 +42,9 @@ describe("buildInitData", () => {
     const issuerHex = Buffer.from(decodeAccountID(ADMIN)).toString("hex");
     // 1 (decimals) + 42 (token_id padded) = 43 bytes => 86 hex chars
     expect(out.length).toBe(86);
-    expect(out.startsWith("09" + "01" + FOO_CURRENCY.toLowerCase() + issuerHex)).toBe(
-      true
-    );
+    expect(
+      out.startsWith("09" + "01" + FOO_CURRENCY.toLowerCase() + issuerHex)
+    ).toBe(true);
     // trailing byte is zero padding (41 bytes of data -> padded to 42)
     expect(out.endsWith("00")).toBe(true);
   });
@@ -64,7 +64,9 @@ describe("buildInitData", () => {
   });
 
   test("rejects decimals out of byte range", () => {
-    expect(() => buildInitData(256, { type: "xrp" })).toThrow(/one unsigned byte/);
+    expect(() => buildInitData(256, { type: "xrp" })).toThrow(
+      /one unsigned byte/
+    );
   });
 });
 

--- a/cli/src/__tests__/xrpl-payloads.test.ts
+++ b/cli/src/__tests__/xrpl-payloads.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "bun:test";
+import { ethers } from "ethers";
+import { decodeAccountID } from "xrpl";
+import {
+  parsePayload,
+  parseOnboarding,
+  parseAdmin,
+  parseVaa,
+} from "../xrpl/payloads";
+import { toChainId } from "@wormhole-foundation/sdk";
+
+// Build an onboarding payload exactly as xrpl_accounts/init.ts does, then parse it back.
+function buildOnboardingHex(
+  admin: string,
+  initialTicket: number,
+  ticketCount: number,
+  initDataHex: string,
+): string {
+  return (
+    "5852504C" + // "XRPL"
+    ethers.hexlify(decodeAccountID(admin)).substring(2) +
+    ethers
+      .zeroPadValue(ethers.hexlify(ethers.toUtf8Bytes("NTT")), 32)
+      .substring(2) +
+    ethers.toBeHex(initialTicket, 8).substring(2) +
+    ethers.toBeHex(ticketCount, 8).substring(2) +
+    initDataHex
+  );
+}
+
+describe("parseOnboarding — round-trips xrpl_accounts/init.ts encoding", () => {
+  it("XRP onboarding (init data = 0x06)", () => {
+    const admin = "rypanhdnNhrtnDMGq6RRr497oDBLJnPeA";
+    const hex = buildOnboardingHex(admin, 15229056, 10, "06");
+    const parsed = parseOnboarding(Buffer.from(hex, "hex"));
+    expect(parsed.admin).toBe(admin);
+    expect(parsed.appType).toBe("NTT");
+    expect(parsed.initialTicket).toBe(15229056n);
+    expect(parsed.ticketCount).toBe(10n);
+    expect(parsed.initDataHex).toBe("06");
+  });
+
+  it("dispatch via parsePayload tags it Onboarding", () => {
+    const hex = buildOnboardingHex("rypanhdnNhrtnDMGq6RRr497oDBLJnPeA", 1, 2, "06");
+    const parsed = parsePayload(Buffer.from(hex, "hex"));
+    expect(parsed.kind).toBe("Onboarding");
+  });
+});
+
+describe("parseAdmin — round-trips xrpl_accounts/register_peer.ts encoding", () => {
+  it("RegisterPeer (action 0x01)", () => {
+    const target = "rwooXFqJZc5cwuG3XJT5eWUgmdvKs2br4Q";
+    const chainId = 1;
+    const peer =
+      "bd9ea0c58c349b4c6768e005c0b794418c46c71a1953f59e089f181bf6d81457";
+    const hex =
+      "5841444D" + // "XADM"
+      "01" +
+      ethers.hexlify(decodeAccountID(target)).substring(2) +
+      ethers.toBeHex(chainId, 2).substring(2) +
+      peer;
+    const parsed = parseAdmin(Buffer.from(hex, "hex"));
+    expect(parsed.actionName).toBe("RegisterPeer");
+    expect(parsed.targetAccount).toBe(target);
+    expect(parsed.chainId).toBe(1);
+    expect(parsed.peerAddress).toBe(peer);
+  });
+
+  it("RotateAdmin (action 0x02)", () => {
+    const target = "rwooXFqJZc5cwuG3XJT5eWUgmdvKs2br4Q";
+    const newAdmin = "rnv8uG8r7mewUqTZ7us3KESFE4cAEqsjm1";
+    const hex =
+      "5841444D" +
+      "02" +
+      ethers.hexlify(decodeAccountID(target)).substring(2) +
+      ethers.hexlify(decodeAccountID(newAdmin)).substring(2);
+    const parsed = parseAdmin(Buffer.from(hex, "hex"));
+    expect(parsed.actionName).toBe("RotateAdmin");
+    expect(parsed.targetAccount).toBe(target);
+    expect(parsed.newAdmin).toBe(newAdmin);
+  });
+});
+
+describe("parseVaa — real testnet VAA (full_docs.md NTT redeem)", () => {
+  // VAA from full_docs.md `manual redeem 0100...` example (XRPL → Solana NTT transfer).
+  const VAA_HEX =
+    "01000000000100ce5c54ee4c4834b5baaeec8f94c2c930b90ec3a2265d583d1b518df23cabc5d15ee768d4fd3ee4b8cc6a78bd754353bca5b2ef7ab787a0e9a3dea6aadddb0b7e0069865efc0000000000421e201a713837dfa392d301657c9273933aa797379cf0e1d65d8aac2b8078fe9d00e0043100000001009945ff1000000000000000000000000030576ecdd1813fa5651de47350bd23395ca22afb0ba58b9c343d2f24031b992d78158bc9a752318b88b4fb56bf87503b1c785499009100000000000000000000000000000000000000000000000000e00431000000010000000000000000000000000a98339b479125caaed23f4c6b02f275f39889ae004f994e5454060000000000000064000000000000000000000000000000000000000000000000000000000000000083718b7ec89617b7040685e01bdcca03214022980daae91340e0c3f840c005ef00010000";
+
+  it("decodes the envelope with emitter chain 66 (XRPL)", () => {
+    const vaa = parseVaa(Buffer.from(VAA_HEX, "hex"));
+    expect(vaa.version).toBe(1);
+    expect(vaa.emitterChain).toBe(66); // XRPL
+    expect(vaa.signatures.length).toBe(1);
+    // payload starts with the Wormhole transceiver prefix 0x9945FF10
+    expect(vaa.payload.subarray(0, 4).toString("hex")).toBe("9945ff10");
+  });
+
+  it("parsePayload decodes the inner NTT transfer", () => {
+    const vaa = parseVaa(Buffer.from(VAA_HEX, "hex"));
+    const parsed = parsePayload(vaa.payload);
+    expect(parsed.kind).toBe("NttTransfer");
+    if (parsed.kind !== "NttTransfer") throw new Error("unexpected");
+    // recipient chain is Solana in this transfer
+    expect(parsed.recipientChain).toBe(toChainId("Solana"));
+    // amount 0x64 = 100 (trimmed, 6 decimals), source token = XRP (zero)
+    expect(parsed.amount).toBe(100n);
+    expect(parsed.decimals).toBe(6);
+    expect(parsed.sourceToken).toBe("00".repeat(32));
+  });
+});

--- a/cli/src/__tests__/xrpl-payloads.test.ts
+++ b/cli/src/__tests__/xrpl-payloads.test.ts
@@ -14,7 +14,7 @@ function buildOnboardingHex(
   admin: string,
   initialTicket: number,
   ticketCount: number,
-  initDataHex: string,
+  initDataHex: string
 ): string {
   return (
     "5852504C" + // "XRPL"
@@ -41,7 +41,12 @@ describe("parseOnboarding — round-trips xrpl_accounts/init.ts encoding", () =>
   });
 
   it("dispatch via parsePayload tags it Onboarding", () => {
-    const hex = buildOnboardingHex("rypanhdnNhrtnDMGq6RRr497oDBLJnPeA", 1, 2, "06");
+    const hex = buildOnboardingHex(
+      "rypanhdnNhrtnDMGq6RRr497oDBLJnPeA",
+      1,
+      2,
+      "06"
+    );
     const parsed = parsePayload(Buffer.from(hex, "hex"));
     expect(parsed.kind).toBe("Onboarding");
   });

--- a/cli/src/__tests__/xrpl-tokenId.test.ts
+++ b/cli/src/__tests__/xrpl-tokenId.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "bun:test";
+import {
+  computeEmitterAddressFromRAddress,
+  iouToken,
+  mptToken,
+  xrpToken,
+  encodeCurrency,
+  decodeCurrency,
+  buildTokenIdForEmitter,
+  tokenIdFromFlags,
+  formatTokenId,
+} from "../xrpl/tokenId";
+
+// Known-good vectors from full_docs.md "New Sequencer Setups" — these are the
+// XRPL transceiver addresses of real testnet NTT deployments, which equal the
+// token-derived emitter keccak256("ntt" || manager || tokenId32).
+describe("computeEmitterAddress — known testnet vectors", () => {
+  it("XRP deployment (manager rfeMQr71KJQwNUbRwGTgCfVLoUVdWuvyny)", () => {
+    const emitter = computeEmitterAddressFromRAddress(
+      "rfeMQr71KJQwNUbRwGTgCfVLoUVdWuvyny",
+      xrpToken(),
+    );
+    expect(emitter.toString("hex")).toBe(
+      "3f7582b4a9df3bfd4f5b8b6634b1d1eaa4a4b96f33f0a56184a1c7584641e5e2",
+    );
+  });
+
+  it("IOU FOO deployment (manager+issuer rnv8uG8r7mewUqTZ7us3KESFE4cAEqsjm1)", () => {
+    const emitter = computeEmitterAddressFromRAddress(
+      "rnv8uG8r7mewUqTZ7us3KESFE4cAEqsjm1",
+      iouToken("FOO", "rnv8uG8r7mewUqTZ7us3KESFE4cAEqsjm1"),
+    );
+    expect(emitter.toString("hex")).toBe(
+      "23779ce2426c7ec8ef398cdf44bd6fc4d744aa80d0018cc34e7b86d6a30cd0e0",
+    );
+  });
+
+  it("MPT deployment (manager rf6VeCw74SzN9RQXm6qZUcUdJ1zziGRzU3)", () => {
+    const emitter = computeEmitterAddressFromRAddress(
+      "rf6VeCw74SzN9RQXm6qZUcUdJ1zziGRzU3",
+      mptToken("00F069F049794EF254FE5B399DBBC2622A50AE8747707B18"),
+    );
+    expect(emitter.toString("hex")).toBe(
+      "b97ab26d22bf8688ce7466aac3031abfde0af2ab86ca57854d773f485c3cbb8a",
+    );
+  });
+});
+
+describe("buildTokenIdForEmitter — type discriminants", () => {
+  it("XRP is 32 zero bytes", () => {
+    expect(buildTokenIdForEmitter(xrpToken()).toString("hex")).toBe(
+      "00".repeat(32),
+    );
+  });
+
+  it("IOU starts with 0x01", () => {
+    const id = buildTokenIdForEmitter(
+      iouToken("FOO", "rnv8uG8r7mewUqTZ7us3KESFE4cAEqsjm1"),
+    );
+    expect(id[0]).toBe(0x01);
+    expect(id.length).toBe(32);
+  });
+
+  it("MPT is 0x02 + 7 zeros + 24-byte issuance id", () => {
+    const issuance = "00F069F049794EF254FE5B399DBBC2622A50AE8747707B18";
+    const id = buildTokenIdForEmitter(mptToken(issuance));
+    expect(id[0]).toBe(0x02);
+    expect(id.subarray(1, 8).toString("hex")).toBe("00".repeat(7));
+    expect(id.subarray(8, 32).toString("hex").toUpperCase()).toBe(issuance);
+  });
+});
+
+describe("encodeCurrency / decodeCurrency", () => {
+  it("round-trips a 3-char code (FOO)", () => {
+    const encoded = encodeCurrency("FOO");
+    expect(encoded.length).toBe(20);
+    expect(encoded[0]).toBe(0x00); // standard-code marker
+    expect(decodeCurrency(encoded)).toBe("FOO");
+  });
+
+  it("RLUSD uses the 40-hex non-standard form", () => {
+    // RLUSD hex from DESIGN.md
+    const hex = "524C555344000000000000000000000000000000";
+    const encoded = encodeCurrency(hex);
+    expect(encoded.toString("hex").toUpperCase()).toBe(hex);
+  });
+
+  it("rejects XRP as an IOU currency", () => {
+    expect(() => encodeCurrency("XRP")).toThrow();
+  });
+});
+
+describe("tokenIdFromFlags", () => {
+  it("xrp", () => {
+    expect(tokenIdFromFlags({ type: "xrp" }).type).toBe("XRP");
+  });
+
+  it("iou requires currency + issuer", () => {
+    expect(() => tokenIdFromFlags({ type: "iou" })).toThrow();
+    const t = tokenIdFromFlags({
+      type: "iou",
+      currency: "FOO",
+      issuer: "rnv8uG8r7mewUqTZ7us3KESFE4cAEqsjm1",
+    });
+    expect(formatTokenId(t)).toBe("FOO/rnv8uG8r7mewUqTZ7us3KESFE4cAEqsjm1");
+  });
+
+  it("mpt requires mpt-id", () => {
+    expect(() => tokenIdFromFlags({ type: "mpt" })).toThrow();
+    const t = tokenIdFromFlags({
+      type: "mpt",
+      mptId: "00F069F049794EF254FE5B399DBBC2622A50AE8747707B18",
+    });
+    expect(t.type).toBe("MPT");
+  });
+
+  it("rejects unknown token type", () => {
+    expect(() => tokenIdFromFlags({ type: "doge" })).toThrow();
+  });
+});

--- a/cli/src/__tests__/xrpl-tokenId.test.ts
+++ b/cli/src/__tests__/xrpl-tokenId.test.ts
@@ -18,30 +18,30 @@ describe("computeEmitterAddress — known testnet vectors", () => {
   it("XRP deployment (manager rfeMQr71KJQwNUbRwGTgCfVLoUVdWuvyny)", () => {
     const emitter = computeEmitterAddressFromRAddress(
       "rfeMQr71KJQwNUbRwGTgCfVLoUVdWuvyny",
-      xrpToken(),
+      xrpToken()
     );
     expect(emitter.toString("hex")).toBe(
-      "3f7582b4a9df3bfd4f5b8b6634b1d1eaa4a4b96f33f0a56184a1c7584641e5e2",
+      "3f7582b4a9df3bfd4f5b8b6634b1d1eaa4a4b96f33f0a56184a1c7584641e5e2"
     );
   });
 
   it("IOU FOO deployment (manager+issuer rnv8uG8r7mewUqTZ7us3KESFE4cAEqsjm1)", () => {
     const emitter = computeEmitterAddressFromRAddress(
       "rnv8uG8r7mewUqTZ7us3KESFE4cAEqsjm1",
-      iouToken("FOO", "rnv8uG8r7mewUqTZ7us3KESFE4cAEqsjm1"),
+      iouToken("FOO", "rnv8uG8r7mewUqTZ7us3KESFE4cAEqsjm1")
     );
     expect(emitter.toString("hex")).toBe(
-      "23779ce2426c7ec8ef398cdf44bd6fc4d744aa80d0018cc34e7b86d6a30cd0e0",
+      "23779ce2426c7ec8ef398cdf44bd6fc4d744aa80d0018cc34e7b86d6a30cd0e0"
     );
   });
 
   it("MPT deployment (manager rf6VeCw74SzN9RQXm6qZUcUdJ1zziGRzU3)", () => {
     const emitter = computeEmitterAddressFromRAddress(
       "rf6VeCw74SzN9RQXm6qZUcUdJ1zziGRzU3",
-      mptToken("00F069F049794EF254FE5B399DBBC2622A50AE8747707B18"),
+      mptToken("00F069F049794EF254FE5B399DBBC2622A50AE8747707B18")
     );
     expect(emitter.toString("hex")).toBe(
-      "b97ab26d22bf8688ce7466aac3031abfde0af2ab86ca57854d773f485c3cbb8a",
+      "b97ab26d22bf8688ce7466aac3031abfde0af2ab86ca57854d773f485c3cbb8a"
     );
   });
 });
@@ -49,13 +49,13 @@ describe("computeEmitterAddress — known testnet vectors", () => {
 describe("buildTokenIdForEmitter — type discriminants", () => {
   it("XRP is 32 zero bytes", () => {
     expect(buildTokenIdForEmitter(xrpToken()).toString("hex")).toBe(
-      "00".repeat(32),
+      "00".repeat(32)
     );
   });
 
   it("IOU starts with 0x01", () => {
     const id = buildTokenIdForEmitter(
-      iouToken("FOO", "rnv8uG8r7mewUqTZ7us3KESFE4cAEqsjm1"),
+      iouToken("FOO", "rnv8uG8r7mewUqTZ7us3KESFE4cAEqsjm1")
     );
     expect(id[0]).toBe(0x01);
     expect(id.length).toBe(32);

--- a/cli/src/commands/index.ts
+++ b/cli/src/commands/index.ts
@@ -14,3 +14,4 @@ export { createSuiCommand } from "./sui";
 export { createTransferOwnershipCommand } from "./transfer-ownership";
 export { createUpdateCommand } from "./update";
 export { createUpgradeCommand } from "./upgrade";
+export { createXrplCommand } from "./xrpl";

--- a/cli/src/commands/xrpl/README.md
+++ b/cli/src/commands/xrpl/README.md
@@ -1,15 +1,18 @@
 # `ntt xrpl` commands
 
-Low-level XRP Ledger token-setup commands used when preparing an NTT deployment
-on XRPL. XRPL has no smart contracts, so NTT relies on a Guardian-controlled
-custody model (see [`ripple/SPEC.md`](../../../../ripple/SPEC.md) and
-[`ripple/DESIGN.md`](../../../../ripple/DESIGN.md)). Before that onboarding can
-happen, an operator must create/configure the underlying XRPL token.
+XRP Ledger commands used when preparing an NTT deployment on XRPL. XRPL has no
+smart contracts, so NTT relies on a Guardian-controlled custody model (see
+[`ripple/SPEC.md`](../../../../ripple/SPEC.md) and
+[`ripple/DESIGN.md`](../../../../ripple/DESIGN.md)). These commands cover the two
+prerequisites: (1) creating/configuring the underlying XRPL token, and (2)
+sending the `XRPLAppOnboarding` message that registers the custody account with
+the Guardians.
 
-These are **pure, single-purpose** commands — each submits exactly one kind of
-XRPL transaction. The XRPL plumbing they share (client connection, signing,
+These are **pure, single-purpose** commands — each submits exactly one XRPL
+transaction. The shared XRPL plumbing (client connection, signing,
 flag/metadata parsing, validation) lives in
-[`../../xrpl/helpers.ts`](../../xrpl/helpers.ts).
+[`../../xrpl/helpers.ts`](../../xrpl/helpers.ts), and the onboarding payload
+encoding lives in [`../../xrpl/onboarding.ts`](../../xrpl/onboarding.ts).
 
 ## Commands
 
@@ -19,9 +22,11 @@ flag/metadata parsing, validation) lives in
 | `trust-set` | holder | `TrustSet` | Open a trust line so a holder can receive an IOU |
 | `create-mpt` | issuer | `MPTokenIssuanceCreate` | Create a Multi-Purpose Token issuance |
 | `authorize-mpt` | holder | `MPTokenAuthorize` | Opt a holder into an MPT |
+| `init` | custody | `Payment` + onboarding memo | Onboard a custody account to the Wormhole Core |
 
 "Creating" an IOU is just `enable-rippling` (issuer) + `trust-set` (each holder).
-An MPT is `create-mpt` (issuer) + `authorize-mpt` (each holder).
+An MPT is `create-mpt` (issuer) + `authorize-mpt` (each holder). Once the token
+exists, `init` registers the custody account for that token with the Guardians.
 
 ### `enable-rippling`
 Sets the `asfDefaultRipple` flag on the issuer account so balances of its IOU can
@@ -80,6 +85,40 @@ wants to receive the issuer's MPT.
 ntt xrpl authorize-mpt -n Testnet --mpt-id 00EE5E8C... --seed sEd7...
 ```
 
+### `init`
+Sends the `XRPLAppOnboarding` message — a `Payment` to the Wormhole Core (GMP)
+account carrying an onboarding memo — so the Guardians start watching the custody
+account. Signed by the **custody account** being onboarded (`--seed`).
+
+The memo carries: prefix `"XRPL"`, the `--admin` account, the `--app` type
+(left-padded to 32 bytes), the ticket range (`--initial-ticket` / `--ticket-count`),
+and the token `init_data` (decimals + token identifier) selected via `--token`:
+
+| `--token` | extra args | `init_data` tail |
+|---|---|---|
+| `xrp` | `--decimals` (6) | `<decimals>` (short form) |
+| `iou` | `--decimals`, `--currency` (3-char or 40-hex), `--issuer` | `<decimals>` + `0x01` + currency[20] + issuer[20], right-padded to 42 bytes |
+| `mpt` | `--decimals`, `--mpt-id` (48-hex) | `<decimals>` + `0x02` + mpt_id[24], right-padded to 42 bytes |
+
+Other options:
+- `--core-account` — destination Wormhole Core account (default: the testnet
+  account `rpuMNy2dBzimaQHTFpXsfoCoqicgd8etQQ`; set this for other networks)
+- `--amount` — XRP sent with the message (default `0.000001`)
+- `--seed` (or env `SEED`)
+
+```
+# XRP custody account
+ntt xrpl init -n Testnet --admin r9qA... --initial-ticket 100 --ticket-count 150 \
+  --token xrp --seed sEd7...
+
+# MPT custody account
+ntt xrpl init -n Testnet --admin r9qA... --initial-ticket 100 --ticket-count 150 \
+  --token mpt --decimals 9 --mpt-id 00EE5E8C... --seed sEd7...
+```
+
+The memo uses `MemoFormat: application/x-wormhole-publish` and
+`MemoData = 01 + 00000000 + payload`.
+
 ## Common options
 
 Every subcommand accepts:
@@ -98,4 +137,5 @@ need not appear in shell history:
 
 - Issuer-signed commands (`enable-rippling`, `create-mpt`) → `--issuer-seed` /
   `ISSUER_SEED`.
-- Holder-signed commands (`trust-set`, `authorize-mpt`) → `--seed` / `SEED`.
+- Holder-/custody-signed commands (`trust-set`, `authorize-mpt`, `init`) →
+  `--seed` / `SEED`.

--- a/cli/src/commands/xrpl/README.md
+++ b/cli/src/commands/xrpl/README.md
@@ -1,0 +1,101 @@
+# `ntt xrpl` commands
+
+Low-level XRP Ledger token-setup commands used when preparing an NTT deployment
+on XRPL. XRPL has no smart contracts, so NTT relies on a Guardian-controlled
+custody model (see [`ripple/SPEC.md`](../../../../ripple/SPEC.md) and
+[`ripple/DESIGN.md`](../../../../ripple/DESIGN.md)). Before that onboarding can
+happen, an operator must create/configure the underlying XRPL token.
+
+These are **pure, single-purpose** commands — each submits exactly one kind of
+XRPL transaction. The XRPL plumbing they share (client connection, signing,
+flag/metadata parsing, validation) lives in
+[`../../xrpl/helpers.ts`](../../xrpl/helpers.ts).
+
+## Commands
+
+| Command | Signed by | XRPL transaction | Purpose |
+|---|---|---|---|
+| `enable-rippling` | issuer | `AccountSet(asfDefaultRipple)` | Enable DefaultRipple on an IOU issuer account |
+| `trust-set` | holder | `TrustSet` | Open a trust line so a holder can receive an IOU |
+| `create-mpt` | issuer | `MPTokenIssuanceCreate` | Create a Multi-Purpose Token issuance |
+| `authorize-mpt` | holder | `MPTokenAuthorize` | Opt a holder into an MPT |
+
+"Creating" an IOU is just `enable-rippling` (issuer) + `trust-set` (each holder).
+An MPT is `create-mpt` (issuer) + `authorize-mpt` (each holder).
+
+### `enable-rippling`
+Sets the `asfDefaultRipple` flag on the issuer account so balances of its IOU can
+ripple between trust lines — a prerequisite for the issuer's currency to be
+usable. Signed by the **issuer**.
+
+- `--issuer-seed` (or env `ISSUER_SEED`)
+
+```
+ntt xrpl enable-rippling -n Testnet --issuer-seed sEd7...
+```
+
+### `trust-set`
+Opens a trust line from a **holder** to an issuer for a given currency, letting
+that holder receive and hold the IOU up to `--limit`. Signed by the holder that
+wants to receive the tokens.
+
+- `--currency` — 3-char ASCII or 40-char hex code
+- `--issuer` — issuer account address
+- `--limit` — max amount the holder will hold
+- `--seed` (or env `SEED`)
+
+```
+ntt xrpl trust-set -n Testnet --currency FOO --issuer r9qA... --limit 1000000 --seed sEd7...
+```
+
+### `create-mpt`
+Creates a Multi-Purpose Token issuance and prints the resulting
+`mpt_issuance_id` (needed for `authorize-mpt` and transfers). Signed by the
+**issuer**. Parameters are validated client-side before submission.
+
+- `--issuer-seed` (or env `ISSUER_SEED`)
+- `--asset-scale` — decimal places, `0`–`255` (default `0`)
+- `--max-amount` — `MaximumAmount`, a UInt64 (`≤ 2^63-1`); omitted = protocol max
+- `--transfer-fee` — secondary-sale fee in tenths of a basis point, `0`–`50000`
+  (`50000` = 50%); requires the `tfMPTCanTransfer` flag
+- `--flags` — comma-separated MPT flags or a raw integer. Valid names:
+  `tfMPTCanLock`, `tfMPTRequireAuth`, `tfMPTCanEscrow`, `tfMPTCanTrade`,
+  `tfMPTCanTransfer`, `tfMPTCanClawback`
+- `--metadata-json` — inline JSON or a path to a `.json` file (hex-encoded into
+  `MPTokenMetadata`; `≤ 1024` bytes; see XLS-89 for the recommended schema)
+
+```
+ntt xrpl create-mpt -n Testnet --asset-scale 9 --max-amount 10000000000000 \
+  --flags tfMPTCanTransfer --issuer-seed sEd7...
+```
+
+### `authorize-mpt`
+A **holder** opts into an MPT so they can hold it. Signed by the account that
+wants to receive the issuer's MPT.
+
+- `--mpt-id` — MPT issuance ID (48-char hex, from `create-mpt`)
+- `--seed` (or env `SEED`)
+
+```
+ntt xrpl authorize-mpt -n Testnet --mpt-id 00EE5E8C... --seed sEd7...
+```
+
+## Common options
+
+Every subcommand accepts:
+
+- `-n, --network` (required) — `Mainnet` | `Testnet` | `Devnet`. Selects a default
+  public XRPL WebSocket endpoint.
+- `--rpc` — override the endpoint. Resolution order: `--rpc` > `overrides.json`
+  (`chains.Xrpl.rpc`) > the network default.
+- `--algorithm` — `ed25519` | `secp256k1`. Forces the key algorithm used to derive
+  the wallet from the seed (default: xrpl auto-detects from the seed prefix).
+
+## Seeds
+
+Seeds are read from the flag, falling back to an environment variable so they
+need not appear in shell history:
+
+- Issuer-signed commands (`enable-rippling`, `create-mpt`) → `--issuer-seed` /
+  `ISSUER_SEED`.
+- Holder-signed commands (`trust-set`, `authorize-mpt`) → `--seed` / `SEED`.

--- a/cli/src/commands/xrpl/README.md
+++ b/cli/src/commands/xrpl/README.md
@@ -50,6 +50,12 @@ An MPT is `create-mpt` (issuer) + `authorize-mpt` (each holder).
 | `emitter` | — *(offline)* | Compute the XRPL transceiver emitter address for a manager + token |
 | `parse-vaa` | — *(offline)* | Decode an XRPL-Wormhole VAA or payload (XREL/XRFL/XADM/onboarding/NTT) |
 | `relay` | relayer + Executor | Relay a VAA emitted by an XRPL tx to its destination via the Executor |
+| `register-peer` | admin | Register an NTT peer for the custody account (`XADM` RegisterPeer) |
+| `rotate-admin` | admin | Rotate the custody account's admin (`XADM` RotateAdmin) |
+
+`register-peer` and `rotate-admin` publish an `XADM` core message the same way as
+`init` — a `Payment` to the Wormhole Core account carrying an
+`application/x-wormhole-publish` memo — signed by the account's **admin**.
 
 ### `enable-rippling`
 Sets the `asfDefaultRipple` flag on the issuer account so balances of its IOU can
@@ -256,6 +262,39 @@ ntt xrpl relay -n Testnet --tx-hash <hash> --dst-chain Solana --executor r… \
   --request-type ern1 --src-manager 0x… --dst-addr 0x… --seed sEd7...
 ```
 
+### `register-peer`
+Registers an NTT peer (a transceiver emitter on another chain) for the custody
+account by publishing an `XADM` RegisterPeer (`0x01`) core message. Signed by the
+**admin** (`--admin-seed`).
+
+- `--manager` — custody account (default: `xrpl.manager` from the deployment file)
+- `--peer-chain` (required) — peer chain (Wormhole name or numeric id)
+- `--peer-address` (required) — peer transceiver emitter, 32-byte hex
+- `--core-account` — Wormhole Core account (default: the testnet account)
+- `--amount` — XRP sent with the message (default `0.000001`)
+- `--admin-seed` (or env `ADMIN_SEED`)
+
+```
+ntt xrpl register-peer -n Testnet --peer-chain Solana --peer-address 0x… --admin-seed sEd7...
+```
+
+### `rotate-admin`
+Rotates the custody account's admin by publishing an `XADM` RotateAdmin (`0x02`)
+core message. Signed by the **current admin** (`--admin-seed`).
+
+> ⚠️ **Not yet supported by the Sequencer.** The message is published but will
+> not take effect until Sequencer support lands. The command prints a warning and
+> prompts for confirmation (skip with `--yes`).
+
+- `--manager` — custody account (default: `xrpl.manager` from the deployment file)
+- `--new-admin` (required) — new admin r-address
+- `--core-account`, `--amount` — as for `register-peer`
+- `--admin-seed` (or env `ADMIN_SEED`); `--yes`
+
+```
+ntt xrpl rotate-admin -n Testnet --new-admin r9qA... --admin-seed sEd7...
+```
+
 ## deployment.json
 
 `set-manager` records the custody account in a dedicated top-level `xrpl` section
@@ -288,5 +327,6 @@ need not appear in shell history:
   `reserve-tickets`, `init`, `set-signer-list`) → `--issuer-seed` / `ISSUER_SEED`.
 - Holder & operational commands (`trust-set`, `authorize-mpt`, `relay`) →
   `--seed` / `SEED`.
+- Admin commands (`register-peer`, `rotate-admin`) → `--admin-seed` / `ADMIN_SEED`.
 - `fund`'s `Payment` source → `--from-seed` / `FUNDER_SEED`.
 - `set-manager` takes no seed — just `--account`.

--- a/cli/src/commands/xrpl/README.md
+++ b/cli/src/commands/xrpl/README.md
@@ -1,9 +1,7 @@
 # `ntt xrpl` commands
 
 XRP Ledger commands used when preparing an NTT deployment on XRPL. XRPL has no
-smart contracts, so NTT relies on a Guardian-controlled custody model (see
-[`ripple/SPEC.md`](../../../../ripple/SPEC.md) and
-[`ripple/DESIGN.md`](../../../../ripple/DESIGN.md)). These commands cover (1)
+smart contracts, so NTT relies on a Guardian-controlled custody model. These commands cover (1)
 creating/configuring the underlying XRPL token, (2) setting up the custody
 account and handing it off to the manager-set multisig, and (3) operating a live
 deployment (emitter derivation, VAA decoding, relaying).
@@ -23,41 +21,42 @@ request layouts ([`executor.ts`](../../xrpl/executor.ts),
 
 **Token setup**
 
-| Command | Signed by | XRPL transaction | Purpose |
-|---|---|---|---|
-| `enable-rippling` | issuer | `AccountSet(asfDefaultRipple)` | Enable DefaultRipple on an IOU issuer account |
-| `trust-set` | holder | `TrustSet` | Open a trust line so a holder can receive an IOU |
-| `create-mpt` | issuer | `MPTokenIssuanceCreate` | Create a Multi-Purpose Token issuance |
-| `authorize-mpt` | holder | `MPTokenAuthorize` | Opt a holder into an MPT |
+| Command           | Signed by | XRPL transaction               | Purpose                                          |
+| ----------------- | --------- | ------------------------------ | ------------------------------------------------ |
+| `enable-rippling` | issuer    | `AccountSet(asfDefaultRipple)` | Enable DefaultRipple on an IOU issuer account    |
+| `trust-set`       | holder    | `TrustSet`                     | Open a trust line so a holder can receive an IOU |
+| `create-mpt`      | issuer    | `MPTokenIssuanceCreate`        | Create a Multi-Purpose Token issuance            |
+| `authorize-mpt`   | holder    | `MPTokenAuthorize`             | Opt a holder into an MPT                         |
 
 "Creating" an IOU is just `enable-rippling` (issuer) + `trust-set` (each holder).
 An MPT is `create-mpt` (issuer) + `authorize-mpt` (each holder).
 
 **Custody-account setup** — run in order, while you still hold the account's key:
 
-| Command | Signed by | XRPL transaction | Purpose |
-|---|---|---|---|
-| `set-manager` | — | *(none — writes deployment.json)* | Record the custody account so later commands don't re-pass it |
-| `fund` | source / faucet | `Payment` / faucet | Fund the account for a signer list + tickets |
-| `reserve-tickets` | custody | `TicketCreate` | Pre-allocate tickets |
-| `init` | custody | `Payment` + onboarding memo | Onboard the account to the Wormhole Core |
-| `set-signer-list` | custody | `SignerListSet` | Hand off to the manager-set multisig (**irreversible-ish**) |
+| Command           | Signed by       | XRPL transaction                  | Purpose                                                       |
+| ----------------- | --------------- | --------------------------------- | ------------------------------------------------------------- |
+| `set-manager`     | —               | _(none — writes deployment.json)_ | Record the custody account so later commands don't re-pass it |
+| `fund`            | source / faucet | `Payment` / faucet                | Fund the account for a signer list + tickets                  |
+| `reserve-tickets` | custody         | `TicketCreate`                    | Pre-allocate tickets                                          |
+| `init`            | custody         | `Payment` + onboarding memo       | Onboard the account to the Wormhole Core                      |
+| `set-signer-list` | custody         | `SignerListSet`                   | Hand off to the manager-set multisig (**irreversible-ish**)   |
 
 **Operational** — once a deployment is live:
 
-| Command | Connects | Purpose |
-|---|---|---|
-| `emitter` | — *(offline)* | Compute the XRPL transceiver emitter address for a manager + token |
-| `parse-vaa` | — *(offline)* | Decode an XRPL-Wormhole VAA or payload (XREL/XRFL/XADM/onboarding/NTT) |
-| `relay` | relayer + Executor | Relay a VAA emitted by an XRPL tx to its destination via the Executor |
-| `register-peer` | admin | Register an NTT peer for the custody account (`XADM` RegisterPeer) |
-| `rotate-admin` | admin | Rotate the custody account's admin (`XADM` RotateAdmin) |
+| Command         | Connects           | Purpose                                                                |
+| --------------- | ------------------ | ---------------------------------------------------------------------- |
+| `emitter`       | — _(offline)_      | Compute the XRPL transceiver emitter address for a manager + token     |
+| `parse-vaa`     | — _(offline)_      | Decode an XRPL-Wormhole VAA or payload (XREL/XRFL/XADM/onboarding/NTT) |
+| `relay`         | relayer + Executor | Relay a VAA emitted by an XRPL tx to its destination via the Executor  |
+| `register-peer` | admin              | Register an NTT peer for the custody account (`XADM` RegisterPeer)     |
+| `rotate-admin`  | admin              | Rotate the custody account's admin (`XADM` RotateAdmin)                |
 
 `register-peer` and `rotate-admin` publish an `XADM` core message the same way as
 `init` — a `Payment` to the Wormhole Core account carrying an
 `application/x-wormhole-publish` memo — signed by the account's **admin**.
 
 ### `enable-rippling`
+
 Sets the `asfDefaultRipple` flag on the issuer account so balances of its IOU can
 ripple between trust lines — a prerequisite for the issuer's currency to be
 usable. Signed by the **issuer**.
@@ -69,6 +68,7 @@ ntt xrpl enable-rippling -n Testnet --issuer-seed sEd7...
 ```
 
 ### `trust-set`
+
 Opens a trust line from a **holder** to an issuer for a given currency, letting
 that holder receive and hold the IOU up to `--limit`. Signed by the holder that
 wants to receive the tokens.
@@ -83,6 +83,7 @@ ntt xrpl trust-set -n Testnet --currency FOO --issuer r9qA... --limit 1000000 --
 ```
 
 ### `create-mpt`
+
 Creates a Multi-Purpose Token issuance and prints the resulting
 `mpt_issuance_id` (needed for `authorize-mpt` and transfers). Signed by the
 **issuer**. Parameters are validated client-side before submission.
@@ -104,6 +105,7 @@ ntt xrpl create-mpt -n Testnet --asset-scale 9 --max-amount 10000000000000 \
 ```
 
 ### `authorize-mpt`
+
 A **holder** opts into an MPT so they can hold it. Signed by the account that
 wants to receive the issuer's MPT.
 
@@ -115,6 +117,7 @@ ntt xrpl authorize-mpt -n Testnet --mpt-id 00EE5E8C... --seed sEd7...
 ```
 
 ### `set-manager`
+
 Records the chosen custody account in the deployment file (`xrpl.manager`) so the
 other custody commands can default `--account` to it. No XRPL transaction.
 
@@ -126,6 +129,7 @@ ntt xrpl set-manager --account r9qA...
 ```
 
 ### `fund`
+
 Funds the custody account with enough XRP to cover the reserve for a signer list
 plus tickets. The default `--amount` is computed from the ledger's live reserve
 settings: `base + inc × (tickets + 1) + buffer`.
@@ -142,6 +146,7 @@ ntt xrpl fund -n Mainnet --account r9qA... --amount 50 --from-seed sEd7...  # pa
 ```
 
 ### `reserve-tickets`
+
 Pre-allocates tickets on the custody account (`TicketCreate`), signed by the
 creator before hand-off. Tickets decouple Guardian signing from sequence order.
 
@@ -153,6 +158,7 @@ ntt xrpl reserve-tickets -n Testnet --count 200 --issuer-seed sEd7...
 ```
 
 ### `init`
+
 Sends the `XRPLAppOnboarding` message — a `Payment` to the Wormhole Core (GMP)
 account carrying an onboarding memo — so the Guardians start watching the custody
 account. Signed by the **custody account** being onboarded (`--issuer-seed`).
@@ -161,13 +167,14 @@ The memo carries: prefix `"XRPL"`, the `--admin` account, the `--app` type
 (left-padded to 32 bytes), the ticket range (`--initial-ticket` / `--ticket-count`),
 and the token `init_data` (decimals + token identifier) selected via `--token`:
 
-| `--token` | extra args | `init_data` tail |
-|---|---|---|
-| `xrp` | `--decimals` (6) | `<decimals>` (short form) |
-| `iou` | `--decimals`, `--currency` (3-char or 40-hex), `--issuer` | `<decimals>` + `0x01` + currency[20] + issuer[20], right-padded to 42 bytes |
-| `mpt` | `--decimals`, `--mpt-id` (48-hex) | `<decimals>` + `0x02` + mpt_id[24], right-padded to 42 bytes |
+| `--token` | extra args                                                | `init_data` tail                                                            |
+| --------- | --------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `xrp`     | `--decimals` (6)                                          | `<decimals>` (short form)                                                   |
+| `iou`     | `--decimals`, `--currency` (3-char or 40-hex), `--issuer` | `<decimals>` + `0x01` + currency[20] + issuer[20], right-padded to 42 bytes |
+| `mpt`     | `--decimals`, `--mpt-id` (48-hex)                         | `<decimals>` + `0x02` + mpt_id[24], right-padded to 42 bytes                |
 
 Other options:
+
 - `--core-account` — destination Wormhole Core account (default: the testnet
   account `rpuMNy2dBzimaQHTFpXsfoCoqicgd8etQQ`; set this for other networks)
 - `--amount` — XRP sent with the message (default `0.000001`)
@@ -187,16 +194,19 @@ The memo uses `MemoFormat: application/x-wormhole-publish` and
 `MemoData = 01 + 00000000 + payload`.
 
 ### `set-signer-list`
+
 Replaces single-key control with the manager-set multisig (`SignerListSet`). The
 signer set is either fetched from the delegated-manager-set EVM contract or given
 explicitly. **This is the hand-off** — it prompts for confirmation unless `--yes`.
 (The master key stays enabled until disabled separately.)
 
 Fetch from EVM — the quorum is the manager-set threshold (not overridable):
+
 - `--manager-chain-id` (default 66), `--manager-set-index` (default `latest`,
   resolved on-chain), `--rpc-eth`, `--delegated-manager-set-addr`
 
 Explicit signers:
+
 - `--signers` — comma-separated r-addresses; `--quorum` (required)
 
 Common: `--issuer-seed` (or env `ISSUER_SEED`), `--yes`.
@@ -211,6 +221,7 @@ ntt xrpl set-signer-list -n Testnet --signers r1,r2,r3 --quorum 2 --issuer-seed 
 ```
 
 ### `emitter`
+
 Computes the Wormhole transceiver emitter address for an XRPL custody account +
 token — `keccak256("ntt" + manager[32] + tokenId[32])`. Offline (no XRPL/RPC
 connection). Use the printed `0x…` value with `ntt manual set-transceiver-peer`.
@@ -225,6 +236,7 @@ ntt xrpl emitter --manager rnv8... --token iou --currency FOO --issuer rnv8...
 ```
 
 ### `parse-vaa`
+
 Decodes an XRPL-Wormhole VAA envelope and its inner payload (XREL release, XRFL
 ticket-refill, XADM admin, XRPL onboarding, or a wrapped NTT transfer). Offline.
 
@@ -237,6 +249,7 @@ ntt xrpl parse-vaa 5852504c... --payload-only  # bare payload
 ```
 
 ### `relay`
+
 Relays a VAA emitted by an XRPL transaction to its destination via the w7
 Executor: looks up the tx → derives emitter/sequence → polls the guardian for the
 signed VAA → fetches an Executor quote → submits a `Payment` to the Executor
@@ -263,6 +276,7 @@ ntt xrpl relay -n Testnet --tx-hash <hash> --dst-chain Solana --executor r… \
 ```
 
 ### `register-peer`
+
 Registers an NTT peer (a transceiver emitter on another chain) for the custody
 account by publishing an `XADM` RegisterPeer (`0x01`) core message. Signed by the
 **admin** (`--admin-seed`).
@@ -279,6 +293,7 @@ ntt xrpl register-peer -n Testnet --peer-chain Solana --peer-address 0x… --adm
 ```
 
 ### `rotate-admin`
+
 Rotates the custody account's admin by publishing an `XADM` RotateAdmin (`0x02`)
 core message. Signed by the **current admin** (`--admin-seed`).
 

--- a/cli/src/commands/xrpl/README.md
+++ b/cli/src/commands/xrpl/README.md
@@ -97,7 +97,7 @@ ntt xrpl authorize-mpt -n Testnet --mpt-id 00EE5E8C... --seed sEd7...
 Records the chosen custody account in the deployment file (`xrpl.manager`) so the
 other custody commands can default `--account` to it. No XRPL transaction.
 
-- `--account` — custody r-address, **or** `--seed` (env `SEED`) to derive it
+- `--account` (required) — custody r-address
 - `--path` — deployment file (default `deployment.json`)
 
 ```
@@ -112,11 +112,11 @@ settings: `base + inc × (tickets + 1) + buffer`.
 - `--account` — target (defaults to `xrpl.manager`)
 - `--amount` — XRP to fund (default: computed)
 - `--tickets` — ticket count to size the reserve for (default 200)
-- `--faucet` — use the testnet/devnet faucet (requires `--seed` for the account)
+- `--faucet` — use the testnet/devnet faucet to fund `--account` directly
 - `--from-seed` (env `FUNDER_SEED`) — funding source for a `Payment` (any network)
 
 ```
-ntt xrpl fund -n Testnet --faucet --seed sEd7...                            # faucet
+ntt xrpl fund -n Testnet --account r9qA... --faucet                         # faucet
 ntt xrpl fund -n Mainnet --account r9qA... --amount 50 --from-seed sEd7...  # payment
 ```
 
@@ -125,16 +125,16 @@ Pre-allocates tickets on the custody account (`TicketCreate`), signed by the
 creator before hand-off. Tickets decouple Guardian signing from sequence order.
 
 - `--count` — number of tickets, `1`–`250` (default 200)
-- `--seed` (or env `SEED`)
+- `--issuer-seed` (or env `ISSUER_SEED`)
 
 ```
-ntt xrpl reserve-tickets -n Testnet --count 200 --seed sEd7...
+ntt xrpl reserve-tickets -n Testnet --count 200 --issuer-seed sEd7...
 ```
 
 ### `init`
 Sends the `XRPLAppOnboarding` message — a `Payment` to the Wormhole Core (GMP)
 account carrying an onboarding memo — so the Guardians start watching the custody
-account. Signed by the **custody account** being onboarded (`--seed`).
+account. Signed by the **custody account** being onboarded (`--issuer-seed`).
 
 The memo carries: prefix `"XRPL"`, the `--admin` account, the `--app` type
 (left-padded to 32 bytes), the ticket range (`--initial-ticket` / `--ticket-count`),
@@ -150,16 +150,16 @@ Other options:
 - `--core-account` — destination Wormhole Core account (default: the testnet
   account `rpuMNy2dBzimaQHTFpXsfoCoqicgd8etQQ`; set this for other networks)
 - `--amount` — XRP sent with the message (default `0.000001`)
-- `--seed` (or env `SEED`)
+- `--issuer-seed` (or env `ISSUER_SEED`)
 
 ```
 # XRP custody account
 ntt xrpl init -n Testnet --admin r9qA... --initial-ticket 100 --ticket-count 150 \
-  --token xrp --seed sEd7...
+  --token xrp --issuer-seed sEd7...
 
 # MPT custody account
 ntt xrpl init -n Testnet --admin r9qA... --initial-ticket 100 --ticket-count 150 \
-  --token mpt --decimals 9 --mpt-id 00EE5E8C... --seed sEd7...
+  --token mpt --decimals 9 --mpt-id 00EE5E8C... --issuer-seed sEd7...
 ```
 
 The memo uses `MemoFormat: application/x-wormhole-publish` and
@@ -172,21 +172,21 @@ explicitly. **This is the hand-off** — it prompts for confirmation unless `--y
 (The master key stays enabled until disabled separately.)
 
 Fetch from EVM — the quorum is the manager-set threshold (not overridable):
-- `--manager-chain-id` (default 66), `--manager-set-index`, `--rpc-eth`,
-  `--delegated-manager-set-addr`
+- `--manager-chain-id` (default 66), `--manager-set-index` (default `latest`,
+  resolved on-chain), `--rpc-eth`, `--delegated-manager-set-addr`
 
 Explicit signers:
 - `--signers` — comma-separated r-addresses; `--quorum` (required)
 
-Common: `--seed` (or env `SEED`), `--yes`.
+Common: `--issuer-seed` (or env `ISSUER_SEED`), `--yes`.
 
 ```
-# from the manager set on an EVM chain
-ntt xrpl set-signer-list -n Testnet --manager-set-index 0 \
-  --rpc-eth https://... --delegated-manager-set-addr 0x... --seed sEd7...
+# from the latest manager set on an EVM chain
+ntt xrpl set-signer-list -n Testnet \
+  --rpc-eth https://... --delegated-manager-set-addr 0x... --issuer-seed sEd7...
 
 # explicit signers
-ntt xrpl set-signer-list -n Testnet --signers r1,r2,r3 --quorum 2 --seed sEd7...
+ntt xrpl set-signer-list -n Testnet --signers r1,r2,r3 --quorum 2 --issuer-seed sEd7...
 ```
 
 ## deployment.json
@@ -217,8 +217,8 @@ Every subcommand accepts:
 Seeds are read from the flag, falling back to an environment variable so they
 need not appear in shell history:
 
-- Issuer-signed commands (`enable-rippling`, `create-mpt`) → `--issuer-seed` /
-  `ISSUER_SEED`.
-- Holder-/custody-signed commands (`trust-set`, `authorize-mpt`, `set-manager`,
-  `reserve-tickets`, `init`, `set-signer-list`) → `--seed` / `SEED`.
+- Issuer/custody-creator commands (`enable-rippling`, `create-mpt`,
+  `reserve-tickets`, `init`, `set-signer-list`) → `--issuer-seed` / `ISSUER_SEED`.
+- Holder commands (`trust-set`, `authorize-mpt`) → `--seed` / `SEED`.
 - `fund`'s `Payment` source → `--from-seed` / `FUNDER_SEED`.
+- `set-manager` takes no seed — just `--account`.

--- a/cli/src/commands/xrpl/README.md
+++ b/cli/src/commands/xrpl/README.md
@@ -4,13 +4,20 @@ XRP Ledger commands used when preparing an NTT deployment on XRPL. XRPL has no
 smart contracts, so NTT relies on a Guardian-controlled custody model (see
 [`ripple/SPEC.md`](../../../../ripple/SPEC.md) and
 [`ripple/DESIGN.md`](../../../../ripple/DESIGN.md)). These commands cover (1)
-creating/configuring the underlying XRPL token, and (2) setting up the custody
-account and handing it off to the manager-set multisig.
+creating/configuring the underlying XRPL token, (2) setting up the custody
+account and handing it off to the manager-set multisig, and (3) operating a live
+deployment (emitter derivation, VAA decoding, relaying).
 
 Most are **pure, single-purpose** commands — each submits one XRPL transaction.
 Shared plumbing lives in [`../../xrpl/helpers.ts`](../../xrpl/helpers.ts), the
 onboarding payload encoding in [`../../xrpl/onboarding.ts`](../../xrpl/onboarding.ts),
 and the manager-set fetch in [`../../xrpl/manager-set.ts`](../../xrpl/manager-set.ts).
+The operational commands add emitter/token-id derivation
+([`tokenId.ts`](../../xrpl/tokenId.ts)), VAA/payload decoding
+([`payloads.ts`](../../xrpl/payloads.ts)), and the Executor/guardian clients +
+request layouts ([`executor.ts`](../../xrpl/executor.ts),
+[`guardian.ts`](../../xrpl/guardian.ts),
+[`executorLayouts.ts`](../../xrpl/executorLayouts.ts)).
 
 ## Commands
 
@@ -35,6 +42,14 @@ An MPT is `create-mpt` (issuer) + `authorize-mpt` (each holder).
 | `reserve-tickets` | custody | `TicketCreate` | Pre-allocate tickets |
 | `init` | custody | `Payment` + onboarding memo | Onboard the account to the Wormhole Core |
 | `set-signer-list` | custody | `SignerListSet` | Hand off to the manager-set multisig (**irreversible-ish**) |
+
+**Operational** — once a deployment is live:
+
+| Command | Connects | Purpose |
+|---|---|---|
+| `emitter` | — *(offline)* | Compute the XRPL transceiver emitter address for a manager + token |
+| `parse-vaa` | — *(offline)* | Decode an XRPL-Wormhole VAA or payload (XREL/XRFL/XADM/onboarding/NTT) |
+| `relay` | relayer + Executor | Relay a VAA emitted by an XRPL tx to its destination via the Executor |
 
 ### `enable-rippling`
 Sets the `asfDefaultRipple` flag on the issuer account so balances of its IOU can
@@ -189,6 +204,58 @@ ntt xrpl set-signer-list -n Testnet \
 ntt xrpl set-signer-list -n Testnet --signers r1,r2,r3 --quorum 2 --issuer-seed sEd7...
 ```
 
+### `emitter`
+Computes the Wormhole transceiver emitter address for an XRPL custody account +
+token — `keccak256("ntt" + manager[32] + tokenId[32])`. Offline (no XRPL/RPC
+connection). Use the printed `0x…` value with `ntt manual set-transceiver-peer`.
+
+- `--manager` (required) — custody account (r-address or 20-byte hex)
+- `--token` (required) — `xrp` | `iou` | `mpt`
+- `--currency`, `--issuer` [`--token iou`]; `--mpt-id` [`--token mpt`]
+
+```
+ntt xrpl emitter --manager rfeMQr71KJQwNUbRwGTgCfVLoUVdWuvyny --token xrp
+ntt xrpl emitter --manager rnv8... --token iou --currency FOO --issuer rnv8...
+```
+
+### `parse-vaa`
+Decodes an XRPL-Wormhole VAA envelope and its inner payload (XREL release, XRFL
+ticket-refill, XADM admin, XRPL onboarding, or a wrapped NTT transfer). Offline.
+
+- `<vaa>` (positional) — hex bytes, with or without `0x`
+- `--payload-only` — treat the input as a bare payload instead of a full VAA
+
+```
+ntt xrpl parse-vaa 01000000...                 # full VAA + payload
+ntt xrpl parse-vaa 5852504c... --payload-only  # bare payload
+```
+
+### `relay`
+Relays a VAA emitted by an XRPL transaction to its destination via the w7
+Executor: looks up the tx → derives emitter/sequence → polls the guardian for the
+signed VAA → fetches an Executor quote → submits a `Payment` to the Executor
+carrying an `application/x-executor-request` memo → triggers indexing. Signed by
+the relaying account (`--seed`).
+
+- `--tx-hash` (required) — XRPL tx that emitted the VAA
+- `--dst-chain` (required) — destination chain (name or id)
+- `--request-type` — `ern1` (NTT transfer) or `erv1` (onboarding / register-peer)
+- `--dst-addr` — destination address (hex32; recipient NTT manager for `ern1`)
+- `--src-manager` / `--manager` — source NTT manager emitter (hex32), or derive it
+  from the manager r-address/hex
+- `--token` (+ `--currency`/`--issuer`/`--mpt-id`) — defaults to the token inferred
+  from the tx's delivered amount
+- `--executor` (required) — Executor XRPL address to pay
+- `--executor-api`, `--guardian-api` — API base URLs (default: testnet)
+- `--gas-limit`, `--msg-value`, `--relay-instructions` — relay sizing
+- `--poll-interval`, `--poll-timeout` — VAA polling (ms)
+- `--seed` (or env `SEED`)
+
+```
+ntt xrpl relay -n Testnet --tx-hash <hash> --dst-chain Solana --executor r… \
+  --request-type ern1 --src-manager 0x… --dst-addr 0x… --seed sEd7...
+```
+
 ## deployment.json
 
 `set-manager` records the custody account in a dedicated top-level `xrpl` section
@@ -219,6 +286,7 @@ need not appear in shell history:
 
 - Issuer/custody-creator commands (`enable-rippling`, `create-mpt`,
   `reserve-tickets`, `init`, `set-signer-list`) → `--issuer-seed` / `ISSUER_SEED`.
-- Holder commands (`trust-set`, `authorize-mpt`) → `--seed` / `SEED`.
+- Holder & operational commands (`trust-set`, `authorize-mpt`, `relay`) →
+  `--seed` / `SEED`.
 - `fund`'s `Payment` source → `--from-seed` / `FUNDER_SEED`.
 - `set-manager` takes no seed — just `--account`.

--- a/cli/src/commands/xrpl/README.md
+++ b/cli/src/commands/xrpl/README.md
@@ -3,18 +3,18 @@
 XRP Ledger commands used when preparing an NTT deployment on XRPL. XRPL has no
 smart contracts, so NTT relies on a Guardian-controlled custody model (see
 [`ripple/SPEC.md`](../../../../ripple/SPEC.md) and
-[`ripple/DESIGN.md`](../../../../ripple/DESIGN.md)). These commands cover the two
-prerequisites: (1) creating/configuring the underlying XRPL token, and (2)
-sending the `XRPLAppOnboarding` message that registers the custody account with
-the Guardians.
+[`ripple/DESIGN.md`](../../../../ripple/DESIGN.md)). These commands cover (1)
+creating/configuring the underlying XRPL token, and (2) setting up the custody
+account and handing it off to the manager-set multisig.
 
-These are **pure, single-purpose** commands — each submits exactly one XRPL
-transaction. The shared XRPL plumbing (client connection, signing,
-flag/metadata parsing, validation) lives in
-[`../../xrpl/helpers.ts`](../../xrpl/helpers.ts), and the onboarding payload
-encoding lives in [`../../xrpl/onboarding.ts`](../../xrpl/onboarding.ts).
+Most are **pure, single-purpose** commands — each submits one XRPL transaction.
+Shared plumbing lives in [`../../xrpl/helpers.ts`](../../xrpl/helpers.ts), the
+onboarding payload encoding in [`../../xrpl/onboarding.ts`](../../xrpl/onboarding.ts),
+and the manager-set fetch in [`../../xrpl/manager-set.ts`](../../xrpl/manager-set.ts).
 
 ## Commands
+
+**Token setup**
 
 | Command | Signed by | XRPL transaction | Purpose |
 |---|---|---|---|
@@ -22,11 +22,19 @@ encoding lives in [`../../xrpl/onboarding.ts`](../../xrpl/onboarding.ts).
 | `trust-set` | holder | `TrustSet` | Open a trust line so a holder can receive an IOU |
 | `create-mpt` | issuer | `MPTokenIssuanceCreate` | Create a Multi-Purpose Token issuance |
 | `authorize-mpt` | holder | `MPTokenAuthorize` | Opt a holder into an MPT |
-| `init` | custody | `Payment` + onboarding memo | Onboard a custody account to the Wormhole Core |
 
 "Creating" an IOU is just `enable-rippling` (issuer) + `trust-set` (each holder).
-An MPT is `create-mpt` (issuer) + `authorize-mpt` (each holder). Once the token
-exists, `init` registers the custody account for that token with the Guardians.
+An MPT is `create-mpt` (issuer) + `authorize-mpt` (each holder).
+
+**Custody-account setup** — run in order, while you still hold the account's key:
+
+| Command | Signed by | XRPL transaction | Purpose |
+|---|---|---|---|
+| `set-manager` | — | *(none — writes deployment.json)* | Record the custody account so later commands don't re-pass it |
+| `fund` | source / faucet | `Payment` / faucet | Fund the account for a signer list + tickets |
+| `reserve-tickets` | custody | `TicketCreate` | Pre-allocate tickets |
+| `init` | custody | `Payment` + onboarding memo | Onboard the account to the Wormhole Core |
+| `set-signer-list` | custody | `SignerListSet` | Hand off to the manager-set multisig (**irreversible-ish**) |
 
 ### `enable-rippling`
 Sets the `asfDefaultRipple` flag on the issuer account so balances of its IOU can
@@ -85,6 +93,44 @@ wants to receive the issuer's MPT.
 ntt xrpl authorize-mpt -n Testnet --mpt-id 00EE5E8C... --seed sEd7...
 ```
 
+### `set-manager`
+Records the chosen custody account in the deployment file (`xrpl.manager`) so the
+other custody commands can default `--account` to it. No XRPL transaction.
+
+- `--account` — custody r-address, **or** `--seed` (env `SEED`) to derive it
+- `--path` — deployment file (default `deployment.json`)
+
+```
+ntt xrpl set-manager --account r9qA...
+```
+
+### `fund`
+Funds the custody account with enough XRP to cover the reserve for a signer list
+plus tickets. The default `--amount` is computed from the ledger's live reserve
+settings: `base + inc × (tickets + 1) + buffer`.
+
+- `--account` — target (defaults to `xrpl.manager`)
+- `--amount` — XRP to fund (default: computed)
+- `--tickets` — ticket count to size the reserve for (default 200)
+- `--faucet` — use the testnet/devnet faucet (requires `--seed` for the account)
+- `--from-seed` (env `FUNDER_SEED`) — funding source for a `Payment` (any network)
+
+```
+ntt xrpl fund -n Testnet --faucet --seed sEd7...                            # faucet
+ntt xrpl fund -n Mainnet --account r9qA... --amount 50 --from-seed sEd7...  # payment
+```
+
+### `reserve-tickets`
+Pre-allocates tickets on the custody account (`TicketCreate`), signed by the
+creator before hand-off. Tickets decouple Guardian signing from sequence order.
+
+- `--count` — number of tickets, `1`–`250` (default 200)
+- `--seed` (or env `SEED`)
+
+```
+ntt xrpl reserve-tickets -n Testnet --count 200 --seed sEd7...
+```
+
 ### `init`
 Sends the `XRPLAppOnboarding` message — a `Payment` to the Wormhole Core (GMP)
 account carrying an onboarding memo — so the Guardians start watching the custody
@@ -119,6 +165,42 @@ ntt xrpl init -n Testnet --admin r9qA... --initial-ticket 100 --ticket-count 150
 The memo uses `MemoFormat: application/x-wormhole-publish` and
 `MemoData = 01 + 00000000 + payload`.
 
+### `set-signer-list`
+Replaces single-key control with the manager-set multisig (`SignerListSet`). The
+signer set is either fetched from the delegated-manager-set EVM contract or given
+explicitly. **This is the hand-off** — it prompts for confirmation unless `--yes`.
+(The master key stays enabled until disabled separately.)
+
+Fetch from EVM — the quorum is the manager-set threshold (not overridable):
+- `--manager-chain-id` (default 66), `--manager-set-index`, `--rpc-eth`,
+  `--delegated-manager-set-addr`
+
+Explicit signers:
+- `--signers` — comma-separated r-addresses; `--quorum` (required)
+
+Common: `--seed` (or env `SEED`), `--yes`.
+
+```
+# from the manager set on an EVM chain
+ntt xrpl set-signer-list -n Testnet --manager-set-index 0 \
+  --rpc-eth https://... --delegated-manager-set-addr 0x... --seed sEd7...
+
+# explicit signers
+ntt xrpl set-signer-list -n Testnet --signers r1,r2,r3 --quorum 2 --seed sEd7...
+```
+
+## deployment.json
+
+`set-manager` records the custody account in a dedicated top-level `xrpl` section
+(kept out of `chains`, which expects a full NTT config):
+
+```json
+{ "network": "Testnet", "chains": { … }, "xrpl": { "manager": "r9qA..." } }
+```
+
+`fund`, `reserve-tickets`, and `set-signer-list` read `xrpl.manager` as the
+default account when `--account` is omitted.
+
 ## Common options
 
 Every subcommand accepts:
@@ -137,5 +219,6 @@ need not appear in shell history:
 
 - Issuer-signed commands (`enable-rippling`, `create-mpt`) → `--issuer-seed` /
   `ISSUER_SEED`.
-- Holder-/custody-signed commands (`trust-set`, `authorize-mpt`, `init`) →
-  `--seed` / `SEED`.
+- Holder-/custody-signed commands (`trust-set`, `authorize-mpt`, `set-manager`,
+  `reserve-tickets`, `init`, `set-signer-list`) → `--seed` / `SEED`.
+- `fund`'s `Payment` source → `--from-seed` / `FUNDER_SEED`.

--- a/cli/src/commands/xrpl/authorize-mpt.ts
+++ b/cli/src/commands/xrpl/authorize-mpt.ts
@@ -1,0 +1,59 @@
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { colors } from "../../colors.js";
+import {
+  loadSeed,
+  resolveXrplEndpoint,
+  runXrpl,
+  submitTx,
+  walletFromSeed,
+  withXrplClient,
+} from "../../xrpl/helpers";
+import { withCommon } from "./common";
+
+export function createAuthorizeMptCommand(
+  overrides: WormholeConfigOverrides<Network>
+) {
+  return {
+    command: "authorize-mpt",
+    describe: "Authorize (opt into) an MPT as a holder (MPTokenAuthorize)",
+    builder: (yargs: any) =>
+      withCommon(yargs)
+        .option("mpt-id", {
+          describe: "MPT issuance ID (48-char hex)",
+          type: "string",
+          demandOption: true,
+        })
+        .option("seed", {
+          describe: "Holder account seed (or env SEED)",
+          type: "string",
+        })
+        .example(
+          "$0 xrpl authorize-mpt -n Testnet --mpt-id 00EE5E8C... --seed sEd7...",
+          "Opt the holder account into the MPT"
+        ),
+    handler: (argv: any) =>
+      runXrpl(async () => {
+        const network = argv.network as Network;
+        const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
+        const seed = loadSeed(argv.seed, "seed", "SEED");
+        const wallet = walletFromSeed(seed, argv.algorithm);
+        console.log(
+          colors.blue(
+            `Authorizing MPT ${argv["mpt-id"]} for ${wallet.address} (${network})`
+          )
+        );
+        const result = await withXrplClient(endpoint, (client) =>
+          submitTx(client, wallet, {
+            TransactionType: "MPTokenAuthorize",
+            Account: wallet.address,
+            MPTokenIssuanceID: argv["mpt-id"],
+          })
+        );
+        console.log(colors.green("✅ MPT authorized"));
+        console.log(`   tx: ${result.result.hash}`);
+      }),
+  };
+}

--- a/cli/src/commands/xrpl/common.ts
+++ b/cli/src/commands/xrpl/common.ts
@@ -1,0 +1,18 @@
+import { options } from "../shared";
+
+/**
+ * Options common to every `ntt xrpl` subcommand: which network/endpoint to
+ * talk to, and (optionally) which key algorithm to derive the wallet with.
+ */
+export const withCommon = (yargs: any) =>
+  yargs
+    .option("network", options.network)
+    .option("rpc", {
+      describe: "XRPL WebSocket endpoint (overrides the network default)",
+      type: "string",
+    })
+    .option("algorithm", {
+      describe: "Key algorithm to derive the wallet from the seed",
+      type: "string",
+      choices: ["ed25519", "secp256k1"] as const,
+    });

--- a/cli/src/commands/xrpl/create-mpt.ts
+++ b/cli/src/commands/xrpl/create-mpt.ts
@@ -61,7 +61,11 @@ export function createCreateMptCommand(
       runXrpl(async () => {
         const network = argv.network as Network;
         const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
-        const seed = loadSeed(argv["issuer-seed"], "issuer-seed", "ISSUER_SEED");
+        const seed = loadSeed(
+          argv["issuer-seed"],
+          "issuer-seed",
+          "ISSUER_SEED"
+        );
         const wallet = walletFromSeed(seed, argv.algorithm);
         const flags = parseMptFlags(argv.flags);
         const metadata = loadMetadataHex(argv["metadata-json"]);
@@ -90,7 +94,9 @@ export function createCreateMptCommand(
         if (metadata !== undefined) tx.MPTokenMetadata = metadata;
 
         console.log(
-          colors.blue(`Creating MPT issuance from ${wallet.address} (${network})`)
+          colors.blue(
+            `Creating MPT issuance from ${wallet.address} (${network})`
+          )
         );
         const result = await withXrplClient(endpoint, (client) =>
           submitTx(client, wallet, tx)

--- a/cli/src/commands/xrpl/create-mpt.ts
+++ b/cli/src/commands/xrpl/create-mpt.ts
@@ -1,0 +1,112 @@
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { type MPTokenIssuanceCreate } from "xrpl";
+import { colors } from "../../colors.js";
+import {
+  loadMetadataHex,
+  loadSeed,
+  parseMptFlags,
+  resolveXrplEndpoint,
+  runXrpl,
+  submitTx,
+  validateMptIssuanceParams,
+  walletFromSeed,
+  withXrplClient,
+} from "../../xrpl/helpers";
+import { withCommon } from "./common";
+
+export function createCreateMptCommand(
+  overrides: WormholeConfigOverrides<Network>
+) {
+  return {
+    command: "create-mpt",
+    describe: "Create a Multi-Purpose Token issuance (MPTokenIssuanceCreate)",
+    builder: (yargs: any) =>
+      withCommon(yargs)
+        .option("issuer-seed", {
+          describe: "Issuer account seed (or env ISSUER_SEED)",
+          type: "string",
+        })
+        .option("asset-scale", {
+          describe: "Number of decimal places (AssetScale)",
+          type: "number",
+          default: 0,
+        })
+        .option("max-amount", {
+          describe: "Maximum issuance amount (MaximumAmount)",
+          type: "string",
+        })
+        .option("transfer-fee", {
+          describe:
+            "Secondary-sale fee in tenths of a basis point, 0-50000 (50000 = 50%); requires tfMPTCanTransfer",
+          type: "number",
+          default: 0,
+        })
+        .option("flags", {
+          describe:
+            "Comma-separated MPT flags (e.g. tfMPTCanTransfer,tfMPTCanClawback) or a raw integer",
+          type: "string",
+        })
+        .option("metadata-json", {
+          describe: "Inline JSON metadata, or a path to a .json file",
+          type: "string",
+        })
+        .example(
+          "$0 xrpl create-mpt -n Testnet --asset-scale 9 --max-amount 10000000000000 --flags tfMPTCanTransfer --issuer-seed sEd7...",
+          "Create a transferable MPT issuance"
+        ),
+    handler: (argv: any) =>
+      runXrpl(async () => {
+        const network = argv.network as Network;
+        const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
+        const seed = loadSeed(argv["issuer-seed"], "issuer-seed", "ISSUER_SEED");
+        const wallet = walletFromSeed(seed, argv.algorithm);
+        const flags = parseMptFlags(argv.flags);
+        const metadata = loadMetadataHex(argv["metadata-json"]);
+        const maxAmount =
+          argv["max-amount"] !== undefined
+            ? String(argv["max-amount"])
+            : undefined;
+
+        validateMptIssuanceParams({
+          assetScale: argv["asset-scale"],
+          transferFee: argv["transfer-fee"],
+          flags,
+          maxAmount,
+        });
+
+        const tx: MPTokenIssuanceCreate = {
+          TransactionType: "MPTokenIssuanceCreate",
+          Account: wallet.address,
+          AssetScale: argv["asset-scale"],
+          Flags: flags,
+        };
+        // Only set fields that XRPL treats as conditional, to avoid validation
+        // errors (e.g. TransferFee without tfMPTCanTransfer).
+        if (argv["transfer-fee"]) tx.TransferFee = argv["transfer-fee"];
+        if (maxAmount !== undefined) tx.MaximumAmount = maxAmount;
+        if (metadata !== undefined) tx.MPTokenMetadata = metadata;
+
+        console.log(
+          colors.blue(`Creating MPT issuance from ${wallet.address} (${network})`)
+        );
+        const result = await withXrplClient(endpoint, (client) =>
+          submitTx(client, wallet, tx)
+        );
+        const meta = result.result.meta;
+        const mptId =
+          meta && typeof meta !== "string"
+            ? (meta as { mpt_issuance_id?: string }).mpt_issuance_id
+            : undefined;
+        console.log(colors.green("✅ MPT issuance created"));
+        console.log(
+          `   mpt_issuance_id: ${colors.yellow(
+            mptId ?? "(not found in transaction metadata)"
+          )}`
+        );
+        console.log(`   tx: ${result.result.hash}`);
+      }),
+  };
+}

--- a/cli/src/commands/xrpl/emitter.ts
+++ b/cli/src/commands/xrpl/emitter.ts
@@ -1,0 +1,80 @@
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { colors } from "../../colors.js";
+import { runXrpl } from "../../xrpl/helpers";
+import {
+  accountIdFrom,
+  computeEmitterAddress,
+  formatTokenId,
+  tokenIdFromFlags,
+  type TokenId,
+} from "../../xrpl/tokenId";
+
+export function createXrplEmitterCommand(
+  _overrides: WormholeConfigOverrides<Network>
+) {
+  return {
+    command: "emitter",
+    describe:
+      "Compute the XRPL transceiver emitter address for a manager + token (no tx)",
+    builder: (yargs: any) =>
+      yargs
+        .option("manager", {
+          describe:
+            "XRPL NTT manager / custody account (r-address or 20-byte hex)",
+          type: "string",
+          demandOption: true,
+        })
+        .option("token", {
+          describe: "XRPL token type",
+          type: "string",
+          choices: ["xrp", "iou", "mpt"] as const,
+          demandOption: true,
+        })
+        .option("currency", {
+          describe: "IOU currency: 3-4 char ASCII or 40-char hex [--token iou]",
+          type: "string",
+        })
+        .option("issuer", {
+          describe: "IOU issuer r-address [--token iou]",
+          type: "string",
+        })
+        .option("mpt-id", {
+          describe: "MPT issuance ID, 48-char hex [--token mpt]",
+          type: "string",
+        })
+        .example(
+          "$0 xrpl emitter --manager rfeMQr71KJQwNUbRwGTgCfVLoUVdWuvyny --token xrp",
+          "Emitter for an XRP custody account"
+        )
+        .example(
+          "$0 xrpl emitter --manager rnv8... --token iou --currency FOO --issuer rnv8...",
+          "Emitter for an IOU deployment"
+        ),
+    handler: (argv: any) =>
+      runXrpl(async () => {
+        const token: TokenId = tokenIdFromFlags({
+          type: argv.token,
+          currency: argv.currency,
+          issuer: argv.issuer,
+          mptId: argv["mpt-id"],
+        });
+        const accountId = accountIdFrom(argv.manager);
+        const emitter = computeEmitterAddress(accountId, token);
+        const hex = emitter.toString("hex");
+
+        console.log(colors.blue("🧮 XRPL transceiver emitter"));
+        console.log(`  manager: ${colors.yellow(argv.manager)}`);
+        console.log(`  token:   ${colors.yellow(formatTokenId(token))}`);
+        console.log(`  emitter: ${colors.green(hex)}`);
+        console.log(`  0x form: ${colors.green("0x" + hex)}`);
+        console.log(
+          colors.dim(
+            "\nUse this with `ntt manual set-transceiver-peer Xrpl 0x… --chain <other>`"
+          )
+        );
+      }),
+  };
+}

--- a/cli/src/commands/xrpl/enable-rippling.ts
+++ b/cli/src/commands/xrpl/enable-rippling.ts
@@ -34,10 +34,16 @@ export function createEnableRipplingCommand(
       runXrpl(async () => {
         const network = argv.network as Network;
         const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
-        const seed = loadSeed(argv["issuer-seed"], "issuer-seed", "ISSUER_SEED");
+        const seed = loadSeed(
+          argv["issuer-seed"],
+          "issuer-seed",
+          "ISSUER_SEED"
+        );
         const wallet = walletFromSeed(seed, argv.algorithm);
         console.log(
-          colors.blue(`Enabling DefaultRipple on ${wallet.address} (${network})`)
+          colors.blue(
+            `Enabling DefaultRipple on ${wallet.address} (${network})`
+          )
         );
         const result = await withXrplClient(endpoint, (client) =>
           submitTx(client, wallet, {

--- a/cli/src/commands/xrpl/enable-rippling.ts
+++ b/cli/src/commands/xrpl/enable-rippling.ts
@@ -1,0 +1,53 @@
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { AccountSetAsfFlags } from "xrpl";
+import { colors } from "../../colors.js";
+import {
+  loadSeed,
+  resolveXrplEndpoint,
+  runXrpl,
+  submitTx,
+  walletFromSeed,
+  withXrplClient,
+} from "../../xrpl/helpers";
+import { withCommon } from "./common";
+
+export function createEnableRipplingCommand(
+  overrides: WormholeConfigOverrides<Network>
+) {
+  return {
+    command: "enable-rippling",
+    describe: "Enable DefaultRipple on an IOU issuer account (AccountSet)",
+    builder: (yargs: any) =>
+      withCommon(yargs)
+        .option("issuer-seed", {
+          describe: "Issuer account seed (or env ISSUER_SEED)",
+          type: "string",
+        })
+        .example(
+          "$0 xrpl enable-rippling -n Testnet --issuer-seed sEd7...",
+          "Enable rippling on the issuer account"
+        ),
+    handler: (argv: any) =>
+      runXrpl(async () => {
+        const network = argv.network as Network;
+        const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
+        const seed = loadSeed(argv["issuer-seed"], "issuer-seed", "ISSUER_SEED");
+        const wallet = walletFromSeed(seed, argv.algorithm);
+        console.log(
+          colors.blue(`Enabling DefaultRipple on ${wallet.address} (${network})`)
+        );
+        const result = await withXrplClient(endpoint, (client) =>
+          submitTx(client, wallet, {
+            TransactionType: "AccountSet",
+            Account: wallet.address,
+            SetFlag: AccountSetAsfFlags.asfDefaultRipple,
+          })
+        );
+        console.log(colors.green("✅ DefaultRipple enabled"));
+        console.log(`   tx: ${result.result.hash}`);
+      }),
+  };
+}

--- a/cli/src/commands/xrpl/fund.ts
+++ b/cli/src/commands/xrpl/fund.ts
@@ -1,0 +1,182 @@
+import fs from "fs";
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { xrpToDrops } from "xrpl";
+import { colors } from "../../colors.js";
+import { loadConfig } from "../../deployments";
+import {
+  getReserveBase,
+  loadSeed,
+  resolveXrplEndpoint,
+  runXrpl,
+  submitTx,
+  validateRAddress,
+  walletFromSeed,
+  withXrplClient,
+} from "../../xrpl/helpers";
+import { withCommon } from "./common";
+
+// Buffer (XRP) added on top of the strict reserve so the account can still pay
+// transaction fees after locking up the reserve.
+const FEE_BUFFER_XRP = 2;
+
+export function createXrplFundCommand(
+  overrides: WormholeConfigOverrides<Network>
+) {
+  return {
+    command: "fund",
+    describe:
+      "Fund a custody account with enough XRP for a signer list + tickets",
+    builder: (yargs: any) =>
+      withCommon(yargs)
+        .option("account", {
+          describe: "Account to fund (defaults to xrpl.manager from the deployment file)",
+          type: "string",
+        })
+        .option("amount", {
+          describe: "XRP to fund (default: computed from on-ledger reserves)",
+          type: "string",
+        })
+        .option("tickets", {
+          describe: "Ticket count to size the reserve for",
+          type: "number",
+          default: 200,
+        })
+        .option("faucet", {
+          describe: "Use the testnet/devnet faucet (requires --seed for the account)",
+          type: "boolean",
+          default: false,
+        })
+        .option("seed", {
+          describe: "Account seed, for the --faucet path (or env SEED)",
+          type: "string",
+        })
+        .option("from-seed", {
+          describe: "Funding source seed for a Payment (or env FUNDER_SEED)",
+          type: "string",
+        })
+        .option("path", {
+          describe: "Path to the deployment file",
+          type: "string",
+          default: "deployment.json",
+        })
+        .example(
+          "$0 xrpl fund -n Testnet --faucet --seed sEd7...",
+          "Fund the account from the testnet faucet"
+        )
+        .example(
+          "$0 xrpl fund -n Mainnet --account r9qA... --amount 50 --from-seed sEd7...",
+          "Send 50 XRP to the account from a funded source"
+        ),
+    handler: (argv: any) =>
+      runXrpl(async () => {
+        const network = argv.network as Network;
+        const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
+
+        // Resolve the target account: --account, else the deployment's xrpl.manager,
+        // else derive it from --seed.
+        let target: string | undefined = argv.account;
+        if (!target && fs.existsSync(argv.path)) {
+          target = loadConfig(argv.path).xrpl?.manager;
+        }
+        if (!target && (argv.seed || process.env.SEED)) {
+          target = walletFromSeed(
+            loadSeed(argv.seed, "seed", "SEED"),
+            argv.algorithm
+          ).address;
+        }
+        if (!target) {
+          throw new Error(
+            "No target account: pass --account, set xrpl.manager (ntt xrpl set-manager), or pass --seed"
+          );
+        }
+        validateRAddress(target);
+
+        await withXrplClient(endpoint, async (client) => {
+          const { baseXrp, incXrp } = await getReserveBase(client);
+          // +1 object for the signer list itself.
+          const requiredXrp =
+            baseXrp + incXrp * (argv.tickets + 1) + FEE_BUFFER_XRP;
+          console.log(
+            colors.gray(
+              `Reserve for ${argv.tickets} tickets + signer list: base ${baseXrp} + inc ${incXrp} × ${argv.tickets + 1} + ${FEE_BUFFER_XRP} buffer = ${requiredXrp} XRP`
+            )
+          );
+
+          if (argv.faucet) {
+            if (network === "Mainnet") {
+              throw new Error("--faucet is only available on Testnet/Devnet");
+            }
+            const wallet = walletFromSeed(
+              loadSeed(argv.seed, "seed", "SEED"),
+              argv.algorithm
+            );
+            if (wallet.address !== target) {
+              throw new Error(
+                `--seed derives ${wallet.address}, which does not match the target ${target}`
+              );
+            }
+            const amount = argv.amount ?? String(requiredXrp);
+            console.log(
+              colors.blue(`Funding ${target} via faucet (${amount} XRP requested)`)
+            );
+            const res = await client.fundWallet(wallet, { amount });
+            console.log(colors.green("✅ Funded via faucet"));
+            console.log(`   balance: ${res.balance} XRP`);
+            return;
+          }
+
+          const fromSeed = loadSeed(
+            argv["from-seed"],
+            "from-seed",
+            "FUNDER_SEED"
+          );
+          const funder = walletFromSeed(fromSeed, argv.algorithm);
+
+          // If the funding source is the account itself, there's nothing to send —
+          // just report whether it already holds the required reserve.
+          if (funder.address === target) {
+            let balance = 0;
+            try {
+              balance = await client.getXrpBalance(target);
+            } catch {
+              balance = 0; // account not found / unfunded
+            }
+            if (balance >= requiredXrp) {
+              console.log(
+                colors.green(
+                  `✅ ${target} already holds ${balance} XRP (≥ ${requiredXrp} required); no funding needed`
+                )
+              );
+            } else {
+              console.log(
+                colors.yellow(
+                  `⚠️  ${target} holds ${balance} XRP but needs ${requiredXrp} (short ${(
+                    requiredXrp - balance
+                  ).toFixed(6)}); fund it from another source or use --faucet`
+                )
+              );
+            }
+            return;
+          }
+
+          const amount = argv.amount ?? String(requiredXrp);
+          console.log(
+            colors.blue(`Funding ${target} on ${network} with ${amount} XRP`)
+          );
+          const result = await submitTx(client, funder, {
+            TransactionType: "Payment",
+            Account: funder.address,
+            Destination: target,
+            Amount: xrpToDrops(amount),
+          });
+          console.log(
+            colors.green(`✅ Sent ${amount} XRP from ${funder.address}`)
+          );
+          console.log(`   tx: ${result.result.hash}`);
+        });
+      }),
+  };
+}

--- a/cli/src/commands/xrpl/fund.ts
+++ b/cli/src/commands/xrpl/fund.ts
@@ -33,7 +33,8 @@ export function createXrplFundCommand(
     builder: (yargs: any) =>
       withCommon(yargs)
         .option("account", {
-          describe: "Account to fund (defaults to xrpl.manager from the deployment file)",
+          describe:
+            "Account to fund (defaults to xrpl.manager from the deployment file)",
           type: "string",
         })
         .option("amount", {
@@ -106,7 +107,9 @@ export function createXrplFundCommand(
               Math.ceil(Number(argv.amount ?? requiredXrp))
             );
             console.log(
-              colors.blue(`Funding ${target} via faucet (${xrpAmount} XRP requested)`)
+              colors.blue(
+                `Funding ${target} via faucet (${xrpAmount} XRP requested)`
+              )
             );
             // The faucet funds the `destination` address directly — no key needed.
             const res = await fetch(`https://${host}/accounts`, {

--- a/cli/src/commands/xrpl/fund.ts
+++ b/cli/src/commands/xrpl/fund.ts
@@ -7,6 +7,7 @@ import { xrpToDrops } from "xrpl";
 import { colors } from "../../colors.js";
 import { loadConfig } from "../../deployments";
 import {
+  XRPL_FAUCET_HOSTS,
   getReserveBase,
   loadSeed,
   resolveXrplEndpoint,
@@ -45,13 +46,9 @@ export function createXrplFundCommand(
           default: 200,
         })
         .option("faucet", {
-          describe: "Use the testnet/devnet faucet (requires --seed for the account)",
+          describe: "Use the testnet/devnet faucet to fund --account",
           type: "boolean",
           default: false,
-        })
-        .option("seed", {
-          describe: "Account seed, for the --faucet path (or env SEED)",
-          type: "string",
         })
         .option("from-seed", {
           describe: "Funding source seed for a Payment (or env FUNDER_SEED)",
@@ -63,7 +60,7 @@ export function createXrplFundCommand(
           default: "deployment.json",
         })
         .example(
-          "$0 xrpl fund -n Testnet --faucet --seed sEd7...",
+          "$0 xrpl fund -n Testnet --faucet --account r9qA...",
           "Fund the account from the testnet faucet"
         )
         .example(
@@ -75,21 +72,14 @@ export function createXrplFundCommand(
         const network = argv.network as Network;
         const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
 
-        // Resolve the target account: --account, else the deployment's xrpl.manager,
-        // else derive it from --seed.
+        // Resolve the target account: --account, else the deployment's xrpl.manager.
         let target: string | undefined = argv.account;
         if (!target && fs.existsSync(argv.path)) {
           target = loadConfig(argv.path).xrpl?.manager;
         }
-        if (!target && (argv.seed || process.env.SEED)) {
-          target = walletFromSeed(
-            loadSeed(argv.seed, "seed", "SEED"),
-            argv.algorithm
-          ).address;
-        }
         if (!target) {
           throw new Error(
-            "No target account: pass --account, set xrpl.manager (ntt xrpl set-manager), or pass --seed"
+            "No target account: pass --account or set xrpl.manager (ntt xrpl set-manager)"
           );
         }
         validateRAddress(target);
@@ -106,25 +96,34 @@ export function createXrplFundCommand(
           );
 
           if (argv.faucet) {
-            if (network === "Mainnet") {
+            const host = XRPL_FAUCET_HOSTS[network];
+            if (!host) {
               throw new Error("--faucet is only available on Testnet/Devnet");
             }
-            const wallet = walletFromSeed(
-              loadSeed(argv.seed, "seed", "SEED"),
-              argv.algorithm
+            // The faucet requires a whole-XRP integer amount; round up so it
+            // still covers the reserve.
+            const xrpAmount = String(
+              Math.ceil(Number(argv.amount ?? requiredXrp))
             );
-            if (wallet.address !== target) {
+            console.log(
+              colors.blue(`Funding ${target} via faucet (${xrpAmount} XRP requested)`)
+            );
+            // The faucet funds the `destination` address directly — no key needed.
+            const res = await fetch(`https://${host}/accounts`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ destination: target, xrpAmount }),
+            });
+            if (!res.ok) {
               throw new Error(
-                `--seed derives ${wallet.address}, which does not match the target ${target}`
+                `Faucet request failed (${res.status}): ${await res.text()}`
               );
             }
-            const amount = argv.amount ?? String(requiredXrp);
-            console.log(
-              colors.blue(`Funding ${target} via faucet (${amount} XRP requested)`)
-            );
-            const res = await client.fundWallet(wallet, { amount });
-            console.log(colors.green("✅ Funded via faucet"));
-            console.log(`   balance: ${res.balance} XRP`);
+            const body: any = await res.json().catch(() => ({}));
+            console.log(colors.green("✅ Faucet funded the account"));
+            if (body?.balance !== undefined) {
+              console.log(`   balance: ${body.balance} XRP`);
+            }
             return;
           }
 

--- a/cli/src/commands/xrpl/index.ts
+++ b/cli/src/commands/xrpl/index.ts
@@ -11,9 +11,13 @@ import { createXrplSetManagerCommand } from "./set-manager";
 import { createXrplFundCommand } from "./fund";
 import { createXrplReserveTicketsCommand } from "./reserve-tickets";
 import { createXrplSetSignerListCommand } from "./set-signer-list";
+import { createXrplEmitterCommand } from "./emitter";
+import { createXrplParseVaaCommand } from "./parse-vaa";
+import { createXrplRelayCommand } from "./relay";
 
 /**
- * `ntt xrpl <subcommand>` — XRPL commands for preparing an NTT deployment.
+ * `ntt xrpl <subcommand>` — XRPL commands for preparing and operating an NTT
+ * deployment.
  *
  * Token setup:
  *   enable-rippling  — issuer enables DefaultRipple (required for an IOU)
@@ -27,6 +31,11 @@ import { createXrplSetSignerListCommand } from "./set-signer-list";
  *   reserve-tickets  — pre-allocate tickets (TicketCreate)
  *   init             — send the XRPLAppOnboarding message
  *   set-signer-list  — hand off to the manager-set multisig (SignerListSet)
+ *
+ * Operational:
+ *   emitter          — compute the transceiver emitter for a manager + token
+ *   parse-vaa        — decode an XRPL-Wormhole VAA / payload
+ *   relay            — relay an XRPL-emitted VAA to its destination (Executor)
  *
  * "Creating" an IOU is just `enable-rippling` (issuer) + `trust-set` (holders).
  */
@@ -45,6 +54,9 @@ export function createXrplCommand(overrides: WormholeConfigOverrides<Network>) {
         .command(createXrplReserveTicketsCommand(overrides))
         .command(createXrplInitCommand(overrides))
         .command(createXrplSetSignerListCommand(overrides))
+        .command(createXrplEmitterCommand(overrides))
+        .command(createXrplParseVaaCommand(overrides))
+        .command(createXrplRelayCommand(overrides))
         .demandCommand(1, "Specify an xrpl subcommand")
         .strict(),
     handler: () => {},

--- a/cli/src/commands/xrpl/index.ts
+++ b/cli/src/commands/xrpl/index.ts
@@ -6,6 +6,7 @@ import { createAuthorizeMptCommand } from "./authorize-mpt";
 import { createCreateMptCommand } from "./create-mpt";
 import { createEnableRipplingCommand } from "./enable-rippling";
 import { createTrustSetCommand } from "./trust-set";
+import { createXrplInitCommand } from "./init";
 
 /**
  * `ntt xrpl <subcommand>` — low-level XRPL token setup used when preparing an
@@ -15,6 +16,7 @@ import { createTrustSetCommand } from "./trust-set";
  *   trust-set        — a holder opts into an IOU
  *   create-mpt       — issuer creates an MPT issuance (prints mpt_issuance_id)
  *   authorize-mpt    — a holder opts into an MPT
+ *   init             — send the XRPLAppOnboarding message for a custody account
  *
  * "Creating" an IOU is just `enable-rippling` (issuer) + `trust-set` (holders).
  */
@@ -28,6 +30,7 @@ export function createXrplCommand(overrides: WormholeConfigOverrides<Network>) {
         .command(createTrustSetCommand(overrides))
         .command(createCreateMptCommand(overrides))
         .command(createAuthorizeMptCommand(overrides))
+        .command(createXrplInitCommand(overrides))
         .demandCommand(1, "Specify an xrpl subcommand")
         .strict(),
     handler: () => {},

--- a/cli/src/commands/xrpl/index.ts
+++ b/cli/src/commands/xrpl/index.ts
@@ -14,6 +14,8 @@ import { createXrplSetSignerListCommand } from "./set-signer-list";
 import { createXrplEmitterCommand } from "./emitter";
 import { createXrplParseVaaCommand } from "./parse-vaa";
 import { createXrplRelayCommand } from "./relay";
+import { createXrplRegisterPeerCommand } from "./register-peer";
+import { createXrplRotateAdminCommand } from "./rotate-admin";
 
 /**
  * `ntt xrpl <subcommand>` — XRPL commands for preparing and operating an NTT
@@ -36,6 +38,8 @@ import { createXrplRelayCommand } from "./relay";
  *   emitter          — compute the transceiver emitter for a manager + token
  *   parse-vaa        — decode an XRPL-Wormhole VAA / payload
  *   relay            — relay an XRPL-emitted VAA to its destination (Executor)
+ *   register-peer    — register an NTT peer (XADM RegisterPeer)
+ *   rotate-admin     — rotate the custody account's admin (XADM RotateAdmin)
  *
  * "Creating" an IOU is just `enable-rippling` (issuer) + `trust-set` (holders).
  */
@@ -57,6 +61,8 @@ export function createXrplCommand(overrides: WormholeConfigOverrides<Network>) {
         .command(createXrplEmitterCommand(overrides))
         .command(createXrplParseVaaCommand(overrides))
         .command(createXrplRelayCommand(overrides))
+        .command(createXrplRegisterPeerCommand(overrides))
+        .command(createXrplRotateAdminCommand(overrides))
         .demandCommand(1, "Specify an xrpl subcommand")
         .strict(),
     handler: () => {},

--- a/cli/src/commands/xrpl/index.ts
+++ b/cli/src/commands/xrpl/index.ts
@@ -7,30 +7,44 @@ import { createCreateMptCommand } from "./create-mpt";
 import { createEnableRipplingCommand } from "./enable-rippling";
 import { createTrustSetCommand } from "./trust-set";
 import { createXrplInitCommand } from "./init";
+import { createXrplSetManagerCommand } from "./set-manager";
+import { createXrplFundCommand } from "./fund";
+import { createXrplReserveTicketsCommand } from "./reserve-tickets";
+import { createXrplSetSignerListCommand } from "./set-signer-list";
 
 /**
- * `ntt xrpl <subcommand>` — low-level XRPL token setup used when preparing an
- * NTT deployment on the XRP Ledger. These are pure, single-purpose commands:
+ * `ntt xrpl <subcommand>` — XRPL commands for preparing an NTT deployment.
  *
+ * Token setup:
  *   enable-rippling  — issuer enables DefaultRipple (required for an IOU)
  *   trust-set        — a holder opts into an IOU
  *   create-mpt       — issuer creates an MPT issuance (prints mpt_issuance_id)
  *   authorize-mpt    — a holder opts into an MPT
- *   init             — send the XRPLAppOnboarding message for a custody account
+ *
+ * Custody-account setup (run in order, while you still hold the account key):
+ *   set-manager      — record the custody account in the deployment file
+ *   fund             — fund the account for a signer list + tickets
+ *   reserve-tickets  — pre-allocate tickets (TicketCreate)
+ *   init             — send the XRPLAppOnboarding message
+ *   set-signer-list  — hand off to the manager-set multisig (SignerListSet)
  *
  * "Creating" an IOU is just `enable-rippling` (issuer) + `trust-set` (holders).
  */
 export function createXrplCommand(overrides: WormholeConfigOverrides<Network>) {
   return {
     command: ["xrpl"] as const,
-    describe: "XRP Ledger token commands",
+    describe: "XRP Ledger commands",
     builder: (yargs: any) =>
       yargs
         .command(createEnableRipplingCommand(overrides))
         .command(createTrustSetCommand(overrides))
         .command(createCreateMptCommand(overrides))
         .command(createAuthorizeMptCommand(overrides))
+        .command(createXrplSetManagerCommand(overrides))
+        .command(createXrplFundCommand(overrides))
+        .command(createXrplReserveTicketsCommand(overrides))
         .command(createXrplInitCommand(overrides))
+        .command(createXrplSetSignerListCommand(overrides))
         .demandCommand(1, "Specify an xrpl subcommand")
         .strict(),
     handler: () => {},

--- a/cli/src/commands/xrpl/index.ts
+++ b/cli/src/commands/xrpl/index.ts
@@ -1,0 +1,35 @@
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { createAuthorizeMptCommand } from "./authorize-mpt";
+import { createCreateMptCommand } from "./create-mpt";
+import { createEnableRipplingCommand } from "./enable-rippling";
+import { createTrustSetCommand } from "./trust-set";
+
+/**
+ * `ntt xrpl <subcommand>` — low-level XRPL token setup used when preparing an
+ * NTT deployment on the XRP Ledger. These are pure, single-purpose commands:
+ *
+ *   enable-rippling  — issuer enables DefaultRipple (required for an IOU)
+ *   trust-set        — a holder opts into an IOU
+ *   create-mpt       — issuer creates an MPT issuance (prints mpt_issuance_id)
+ *   authorize-mpt    — a holder opts into an MPT
+ *
+ * "Creating" an IOU is just `enable-rippling` (issuer) + `trust-set` (holders).
+ */
+export function createXrplCommand(overrides: WormholeConfigOverrides<Network>) {
+  return {
+    command: ["xrpl"] as const,
+    describe: "XRP Ledger token commands",
+    builder: (yargs: any) =>
+      yargs
+        .command(createEnableRipplingCommand(overrides))
+        .command(createTrustSetCommand(overrides))
+        .command(createCreateMptCommand(overrides))
+        .command(createAuthorizeMptCommand(overrides))
+        .demandCommand(1, "Specify an xrpl subcommand")
+        .strict(),
+    handler: () => {},
+  };
+}

--- a/cli/src/commands/xrpl/init.ts
+++ b/cli/src/commands/xrpl/init.ts
@@ -96,7 +96,8 @@ export function createXrplInitCommand(
           type: "string",
         })
         .option("core-account", {
-          describe: "Wormhole Core (GMP) account to send the onboarding message to",
+          describe:
+            "Wormhole Core (GMP) account to send the onboarding message to",
           type: "string",
           default: DEFAULT_TESTNET_CORE_ACCOUNT,
         })
@@ -121,7 +122,11 @@ export function createXrplInitCommand(
       runXrpl(async () => {
         const network = argv.network as Network;
         const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
-        const seed = loadSeed(argv["issuer-seed"], "issuer-seed", "ISSUER_SEED");
+        const seed = loadSeed(
+          argv["issuer-seed"],
+          "issuer-seed",
+          "ISSUER_SEED"
+        );
         const wallet = walletFromSeed(seed, argv.algorithm);
 
         const token = resolveTokenInit(argv);

--- a/cli/src/commands/xrpl/init.ts
+++ b/cli/src/commands/xrpl/init.ts
@@ -105,23 +105,23 @@ export function createXrplInitCommand(
           type: "string",
           default: "0.000001",
         })
-        .option("seed", {
-          describe: "Custody account seed (or env SEED)",
+        .option("issuer-seed", {
+          describe: "Custody account seed (or env ISSUER_SEED)",
           type: "string",
         })
         .example(
-          "$0 xrpl init -n Testnet --admin r9qA... --initial-ticket 100 --ticket-count 150 --token xrp --seed sEd7...",
+          "$0 xrpl init -n Testnet --admin r9qA... --initial-ticket 100 --ticket-count 150 --token xrp --issuer-seed sEd7...",
           "Onboard an XRP NTT custody account"
         )
         .example(
-          "$0 xrpl init -n Testnet --admin r9qA... --initial-ticket 100 --ticket-count 150 --token mpt --decimals 9 --mpt-id 00EE5E8C... --seed sEd7...",
+          "$0 xrpl init -n Testnet --admin r9qA... --initial-ticket 100 --ticket-count 150 --token mpt --decimals 9 --mpt-id 00EE5E8C... --issuer-seed sEd7...",
           "Onboard an MPT NTT custody account"
         ),
     handler: (argv: any) =>
       runXrpl(async () => {
         const network = argv.network as Network;
         const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
-        const seed = loadSeed(argv.seed, "seed", "SEED");
+        const seed = loadSeed(argv["issuer-seed"], "issuer-seed", "ISSUER_SEED");
         const wallet = walletFromSeed(seed, argv.algorithm);
 
         const token = resolveTokenInit(argv);

--- a/cli/src/commands/xrpl/init.ts
+++ b/cli/src/commands/xrpl/init.ts
@@ -1,0 +1,174 @@
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { xrpToDrops } from "xrpl";
+import { colors } from "../../colors.js";
+import {
+  loadSeed,
+  resolveXrplEndpoint,
+  runXrpl,
+  submitTx,
+  walletFromSeed,
+  withXrplClient,
+} from "../../xrpl/helpers";
+import {
+  DEFAULT_TESTNET_CORE_ACCOUNT,
+  WORMHOLE_PUBLISH_MEMO_FORMAT,
+  buildInitData,
+  buildOnboardingPayload,
+  buildPublishMemoData,
+  type TokenInit,
+} from "../../xrpl/onboarding";
+import { withCommon } from "./common";
+
+/** Resolve and validate the token selector args into a TokenInit. */
+function resolveTokenInit(argv: any): TokenInit {
+  switch (argv.token) {
+    case "xrp":
+      return { type: "xrp" };
+    case "iou":
+      if (!argv.currency || !argv.issuer) {
+        throw new Error("--token iou requires --currency and --issuer");
+      }
+      return { type: "iou", currency: argv.currency, issuer: argv.issuer };
+    case "mpt":
+      if (!argv["mpt-id"]) {
+        throw new Error("--token mpt requires --mpt-id");
+      }
+      return { type: "mpt", mptId: argv["mpt-id"] };
+    default:
+      throw new Error(`unknown token type: ${argv.token}`);
+  }
+}
+
+export function createXrplInitCommand(
+  overrides: WormholeConfigOverrides<Network>
+) {
+  return {
+    command: "init",
+    describe:
+      "Send an XRPLAppOnboarding message to onboard a custody account to the Wormhole Core",
+    builder: (yargs: any) =>
+      withCommon(yargs)
+        .option("admin", {
+          describe: "Admin XRPL r-address (registers peers / rotates admin)",
+          type: "string",
+          demandOption: true,
+        })
+        .option("initial-ticket", {
+          describe: "First ticket ID in the pre-allocated range",
+          type: "number",
+          demandOption: true,
+        })
+        .option("ticket-count", {
+          describe: "Number of tickets available",
+          type: "number",
+          demandOption: true,
+        })
+        .option("app", {
+          describe: "App type",
+          type: "string",
+          choices: ["NTT", "WTT", "Core"] as const,
+          default: "NTT",
+        })
+        .option("token", {
+          describe: "Token type for the NTT/WTT deployment",
+          type: "string",
+          choices: ["xrp", "iou", "mpt"] as const,
+          demandOption: true,
+        })
+        .option("decimals", {
+          describe: "Token decimals (XRPL native scale)",
+          type: "number",
+          default: 6,
+        })
+        .option("currency", {
+          describe: "IOU currency: 3-char ASCII or 40-char hex [--token iou]",
+          type: "string",
+        })
+        .option("issuer", {
+          describe: "IOU issuer r-address [--token iou]",
+          type: "string",
+        })
+        .option("mpt-id", {
+          describe: "MPT issuance ID, 48-char hex [--token mpt]",
+          type: "string",
+        })
+        .option("core-account", {
+          describe: "Wormhole Core (GMP) account to send the onboarding message to",
+          type: "string",
+          default: DEFAULT_TESTNET_CORE_ACCOUNT,
+        })
+        .option("amount", {
+          describe: "XRP amount to send with the onboarding message",
+          type: "string",
+          default: "0.000001",
+        })
+        .option("seed", {
+          describe: "Custody account seed (or env SEED)",
+          type: "string",
+        })
+        .example(
+          "$0 xrpl init -n Testnet --admin r9qA... --initial-ticket 100 --ticket-count 150 --token xrp --seed sEd7...",
+          "Onboard an XRP NTT custody account"
+        )
+        .example(
+          "$0 xrpl init -n Testnet --admin r9qA... --initial-ticket 100 --ticket-count 150 --token mpt --decimals 9 --mpt-id 00EE5E8C... --seed sEd7...",
+          "Onboard an MPT NTT custody account"
+        ),
+    handler: (argv: any) =>
+      runXrpl(async () => {
+        const network = argv.network as Network;
+        const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
+        const seed = loadSeed(argv.seed, "seed", "SEED");
+        const wallet = walletFromSeed(seed, argv.algorithm);
+
+        const token = resolveTokenInit(argv);
+        const decimals: number = argv.decimals;
+
+        const initData = buildInitData(decimals, token);
+        const payload = buildOnboardingPayload({
+          admin: argv.admin,
+          app: argv.app,
+          initialTicket: argv["initial-ticket"],
+          ticketCount: argv["ticket-count"],
+          initData,
+        });
+        const memoData = buildPublishMemoData(payload);
+
+        console.log(
+          colors.blue(
+            `Onboarding ${wallet.address} as ${argv.app} (${token.type.toUpperCase()}, ${decimals} decimals) on ${network}`
+          )
+        );
+        console.log(`   admin:        ${argv.admin}`);
+        console.log(
+          `   tickets:      ${argv["ticket-count"]} starting at ${argv["initial-ticket"]}`
+        );
+        console.log(`   core account: ${argv["core-account"]}`);
+
+        const result = await withXrplClient(endpoint, (client) =>
+          submitTx(client, wallet, {
+            TransactionType: "Payment",
+            Account: wallet.address,
+            Destination: argv["core-account"],
+            Amount: xrpToDrops(argv.amount),
+            Memos: [
+              {
+                Memo: {
+                  MemoFormat: Buffer.from(
+                    WORMHOLE_PUBLISH_MEMO_FORMAT,
+                    "ascii"
+                  ).toString("hex"),
+                  MemoData: memoData,
+                },
+              },
+            ],
+          })
+        );
+        console.log(colors.green("✅ Onboarding message sent"));
+        console.log(`   tx: ${result.result.hash}`);
+      }),
+  };
+}

--- a/cli/src/commands/xrpl/parse-vaa.ts
+++ b/cli/src/commands/xrpl/parse-vaa.ts
@@ -1,0 +1,69 @@
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { colors } from "../../colors.js";
+import { runXrpl } from "../../xrpl/helpers";
+import { parsePayload, parseVaa } from "../../xrpl/payloads";
+
+function hexToBuffer(input: string): Buffer {
+  let s = input.trim();
+  if (s.startsWith("0x") || s.startsWith("0X")) s = s.slice(2);
+  if (!/^[0-9a-fA-F]*$/.test(s) || s.length % 2 !== 0) {
+    throw new Error("Invalid hex input");
+  }
+  return Buffer.from(s, "hex");
+}
+
+function bigintReplacer(_key: string, value: unknown): unknown {
+  return typeof value === "bigint" ? value.toString() : value;
+}
+
+export function createXrplParseVaaCommand(
+  _overrides: WormholeConfigOverrides<Network>
+) {
+  return {
+    command: "parse-vaa <vaa>",
+    describe: "Decode an XRPL-Wormhole VAA (XREL/XRFL/XADM/onboarding) — no tx",
+    builder: (yargs: any) =>
+      yargs
+        .positional("vaa", {
+          describe: "Hex VAA bytes (with or without 0x), or --payload-only",
+          type: "string",
+          demandOption: true,
+        })
+        .option("payload-only", {
+          describe: "Treat the input as a bare payload (not a full VAA)",
+          type: "boolean",
+          default: false,
+        })
+        .example(
+          "$0 xrpl parse-vaa 01000000...",
+          "Decode a full VAA and its XRPL payload"
+        ),
+    handler: (argv: any) =>
+      runXrpl(async () => {
+        const bytes = hexToBuffer(argv.vaa);
+
+        if (argv["payload-only"]) {
+          const parsed = parsePayload(bytes);
+          console.log(colors.blue("📦 Payload"));
+          console.log(JSON.stringify(parsed, bigintReplacer, 2));
+          return;
+        }
+
+        const vaa = parseVaa(bytes);
+        console.log(colors.blue("✉️  VAA envelope"));
+        console.log(`  version:          ${vaa.version}`);
+        console.log(`  guardianSetIndex: ${vaa.guardianSetIndex}`);
+        console.log(`  signatures:       ${vaa.signatures.length}`);
+        console.log(`  emitterChain:     ${vaa.emitterChain}`);
+        console.log(`  emitterAddress:   ${vaa.emitterAddress}`);
+        console.log(`  sequence:         ${vaa.sequence}`);
+        console.log(`  consistency:      ${vaa.consistencyLevel}`);
+        console.log(colors.blue("\n📦 Payload"));
+        const parsed = parsePayload(vaa.payload);
+        console.log(JSON.stringify(parsed, bigintReplacer, 2));
+      }),
+  };
+}

--- a/cli/src/commands/xrpl/register-peer.ts
+++ b/cli/src/commands/xrpl/register-peer.ts
@@ -1,0 +1,125 @@
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { xrpToDrops } from "xrpl";
+import { colors } from "../../colors.js";
+import { loadConfig } from "../../deployments";
+import {
+  loadSeed,
+  resolveChainId,
+  resolveXrplEndpoint,
+  runXrpl,
+  submitTx,
+  validateRAddress,
+  walletFromSeed,
+  withXrplClient,
+} from "../../xrpl/helpers";
+import { buildRegisterPeerPayload } from "../../xrpl/admin";
+import {
+  DEFAULT_TESTNET_CORE_ACCOUNT,
+  WORMHOLE_PUBLISH_MEMO_FORMAT,
+  buildPublishMemoData,
+} from "../../xrpl/onboarding";
+import { options } from "../shared";
+import { withCommon } from "./common";
+
+export function createXrplRegisterPeerCommand(
+  overrides: WormholeConfigOverrides<Network>
+) {
+  return {
+    command: "register-peer",
+    describe:
+      "Register an NTT peer for the custody account (XADM RegisterPeer)",
+    builder: (yargs: any) =>
+      withCommon(yargs)
+        .option("manager", {
+          describe:
+            "XRPL custody (manager) account r-address (default: xrpl.manager)",
+          type: "string",
+        })
+        .option("peer-chain", {
+          describe: "Peer chain (Wormhole name or numeric id)",
+          type: "string",
+          demandOption: true,
+        })
+        .option("peer-address", {
+          describe: "Peer transceiver emitter address, 32-byte hex",
+          type: "string",
+          demandOption: true,
+        })
+        .option("core-account", {
+          describe: "Wormhole Core (GMP) account to publish the message to",
+          type: "string",
+          default: DEFAULT_TESTNET_CORE_ACCOUNT,
+        })
+        .option("amount", {
+          describe: "XRP amount to send with the message",
+          type: "string",
+          default: "0.000001",
+        })
+        .option("admin-seed", {
+          describe: "Admin account seed (or env ADMIN_SEED)",
+          type: "string",
+        })
+        .option("path", options.deploymentPath)
+        .example(
+          "$0 xrpl register-peer -n Testnet --peer-chain Solana --peer-address 0x… --admin-seed sEd7...",
+          "Register a Solana peer for the recorded custody account"
+        ),
+    handler: (argv: any) =>
+      runXrpl(async () => {
+        const network = argv.network as Network;
+        const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
+        const seed = loadSeed(argv["admin-seed"], "admin-seed", "ADMIN_SEED");
+        const wallet = walletFromSeed(seed, argv.algorithm);
+
+        const managerArg = argv.manager || loadConfig(argv.path).xrpl?.manager;
+        if (!managerArg) {
+          throw new Error(
+            "Provide --manager or record one with `ntt xrpl set-manager`"
+          );
+        }
+        const manager = validateRAddress(managerArg);
+        const peerChainId = resolveChainId(argv["peer-chain"]);
+
+        const payload = buildRegisterPeerPayload({
+          manager,
+          peerChainId,
+          peerAddress: argv["peer-address"],
+        });
+        const memoData = buildPublishMemoData(payload);
+
+        console.log(
+          colors.blue(
+            `Registering peer for ${manager} (admin ${wallet.address}) on ${network}`
+          )
+        );
+        console.log(`   peer chain:   ${argv["peer-chain"]} (${peerChainId})`);
+        console.log(`   peer address: ${argv["peer-address"]}`);
+        console.log(`   core account: ${argv["core-account"]}`);
+
+        const result = await withXrplClient(endpoint, (client) =>
+          submitTx(client, wallet, {
+            TransactionType: "Payment",
+            Account: wallet.address,
+            Destination: argv["core-account"],
+            Amount: xrpToDrops(argv.amount),
+            Memos: [
+              {
+                Memo: {
+                  MemoFormat: Buffer.from(
+                    WORMHOLE_PUBLISH_MEMO_FORMAT,
+                    "ascii"
+                  ).toString("hex"),
+                  MemoData: memoData,
+                },
+              },
+            ],
+          })
+        );
+        console.log(colors.green("✅ RegisterPeer message sent"));
+        console.log(`   tx: ${result.result.hash}`);
+      }),
+  };
+}

--- a/cli/src/commands/xrpl/relay.ts
+++ b/cli/src/commands/xrpl/relay.ts
@@ -1,0 +1,371 @@
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { toChainId, type Chain } from "@wormhole-foundation/sdk";
+import { ethers } from "ethers";
+import { decodeAccountID } from "xrpl";
+import { colors } from "../../colors.js";
+import {
+  loadSeed,
+  resolveXrplEndpoint,
+  runXrpl,
+  submitTx,
+  walletFromSeed,
+  withXrplClient,
+} from "../../xrpl/helpers";
+import { DEFAULT_EXECUTOR_API, fetchQuote, submitStatusTx } from "../../xrpl/executor";
+import { CHAIN_ID_XRPL, DEFAULT_GUARDIAN_API, pollSignedVaa } from "../../xrpl/guardian";
+import {
+  RequestPrefix,
+  buildGasInstructionHex,
+  deserializeRelayInstructions,
+  deserializeSignedQuote,
+  serializeRequestForExecution,
+  type RequestForExecution,
+  type RequestLayout,
+} from "../../xrpl/executorLayouts";
+import {
+  accountIdFrom,
+  computeEmitterAddress,
+  tokenIdFromFlags,
+  tokenIdFromXrplAmount,
+  type TokenId,
+} from "../../xrpl/tokenId";
+import { withCommon } from "./common";
+
+/** Resolve a --dst-chain value (name or numeric id) to a Wormhole chain id. */
+function resolveChainId(value: string | number): number {
+  if (typeof value === "number") return value;
+  if (/^\d+$/.test(value)) return parseInt(value, 10);
+  return toChainId(value as Chain);
+}
+
+function buildRequest(opts: {
+  requestType: "ern1" | "erv1";
+  emitterHex: string;
+  sequence: bigint;
+  messageId: `0x${string}`;
+  srcManager?: string;
+  manager?: string;
+}): RequestLayout {
+  if (opts.requestType === "erv1") {
+    return {
+      request: {
+        prefix: RequestPrefix.ERV1,
+        chain: CHAIN_ID_XRPL,
+        address: `0x${opts.emitterHex}` as `0x${string}`,
+        sequence: opts.sequence,
+      },
+    };
+  }
+  // ERN1: srcManager is the source NTT manager emitter (32 bytes).
+  const srcManager =
+    opts.srcManager ??
+    (opts.manager
+      ? ethers.zeroPadValue(ethers.hexlify(accountIdFrom(opts.manager)), 32)
+      : undefined);
+  if (!srcManager) {
+    throw new Error(
+      "ERN1 relay requires --src-manager (hex32) or --manager (rAddress) to derive it"
+    );
+  }
+  return {
+    request: {
+      prefix: RequestPrefix.ERN1,
+      srcChain: CHAIN_ID_XRPL,
+      srcManager: ethers.zeroPadValue(srcManager as `0x${string}`, 32) as `0x${string}`,
+      messageId: opts.messageId,
+    },
+  };
+}
+
+export function createXrplRelayCommand(
+  overrides: WormholeConfigOverrides<Network>
+) {
+  return {
+    command: "relay",
+    describe:
+      "Relay a VAA emitted by an XRPL tx to the destination via the Executor",
+    builder: (yargs: any) =>
+      withCommon(yargs)
+        .option("tx-hash", {
+          describe: "XRPL transaction hash that emitted the VAA",
+          type: "string",
+          demandOption: true,
+        })
+        .option("dst-chain", {
+          describe:
+            "Destination chain (name or id). NTT: the other chain. Onboarding/peer: Solana.",
+          type: "string",
+          demandOption: true,
+        })
+        .option("request-type", {
+          describe:
+            "ern1 (NTT transfer) or erv1 (onboarding/register-peer → Sequencer)",
+          type: "string",
+          choices: ["ern1", "erv1"] as const,
+          default: "ern1",
+        })
+        .option("dst-addr", {
+          describe:
+            "Destination address (hex32). For ERN1 this is the recipient NTT manager.",
+          type: "string",
+        })
+        .option("src-manager", {
+          describe:
+            "ERN1: source NTT manager emitter (hex32). Default: derived from --manager.",
+          type: "string",
+        })
+        .option("manager", {
+          describe:
+            "XRPL NTT manager / custody account (r-address or 20-byte hex)",
+          type: "string",
+        })
+        .option("token", {
+          describe: "XRPL token type (default: inferred from the tx amount)",
+          type: "string",
+          choices: ["xrp", "iou", "mpt"] as const,
+        })
+        .option("currency", {
+          describe: "IOU currency: 3-4 char ASCII or 40-char hex [--token iou]",
+          type: "string",
+        })
+        .option("issuer", {
+          describe: "IOU issuer r-address [--token iou]",
+          type: "string",
+        })
+        .option("mpt-id", {
+          describe: "MPT issuance ID, 48-char hex [--token mpt]",
+          type: "string",
+        })
+        .option("executor", {
+          describe: "Executor XRPL address to send the request payment to",
+          type: "string",
+          demandOption: true,
+        })
+        .option("executor-api", {
+          describe: "Executor API base URL",
+          type: "string",
+          default: DEFAULT_EXECUTOR_API,
+        })
+        .option("guardian-api", {
+          describe: "Guardian / Wormholescan API base URL",
+          type: "string",
+          default: DEFAULT_GUARDIAN_API,
+        })
+        .option("gas-limit", {
+          describe: "Relay gas limit",
+          type: "string",
+          default: "250000",
+        })
+        .option("msg-value", {
+          describe: "Relay msg value (drops)",
+          type: "string",
+          default: "0",
+        })
+        .option("relay-instructions", {
+          describe:
+            "Pre-encoded relay instructions hex (overrides --gas-limit/--msg-value)",
+          type: "string",
+        })
+        .option("poll-interval", {
+          describe: "VAA poll interval (ms)",
+          type: "number",
+          default: 5_000,
+        })
+        .option("poll-timeout", {
+          describe: "VAA poll timeout (ms)",
+          type: "number",
+          default: 120_000,
+        })
+        .option("seed", {
+          describe: "XRPL seed of the relaying account (or env SEED)",
+          type: "string",
+        })
+        .example(
+          "$0 xrpl relay --tx-hash <hash> --dst-chain Solana --executor r… --request-type ern1 --src-manager 0x… --dst-addr 0x…",
+          "Relay an NTT transfer from XRPL to Solana"
+        ),
+    handler: (argv: any) => runXrpl(() => runRelay(argv, overrides)),
+  };
+}
+
+async function runRelay(
+  argv: any,
+  overrides: WormholeConfigOverrides<Network>
+): Promise<void> {
+  const network = argv.network as Network;
+  const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
+  const txHash: string = argv["tx-hash"];
+  const dstChain = resolveChainId(argv["dst-chain"]);
+  const requestType: "ern1" | "erv1" = argv["request-type"];
+  const executor: string = argv.executor;
+  const executorApi: string = argv["executor-api"];
+  const guardianApi: string = argv["guardian-api"];
+  const gasLimit = BigInt(argv["gas-limit"]);
+  const msgValue = BigInt(argv["msg-value"]);
+  const pollInterval = argv["poll-interval"];
+  const pollTimeout = argv["poll-timeout"];
+
+  const seed = loadSeed(argv.seed, "seed", "SEED");
+  const wallet = walletFromSeed(seed, argv.algorithm);
+
+  console.log(colors.blue("🚚 XRPL relay"));
+  console.log(`  tx hash:      ${colors.yellow(txHash)}`);
+  console.log(`  dst chain:    ${colors.yellow(String(dstChain))}`);
+  console.log(`  request type: ${colors.yellow(requestType)}`);
+  console.log(`  from wallet:  ${colors.yellow(wallet.address)}`);
+
+  // ── 1. Look up the XRPL tx → emitter + sequence (messageId) + token ──
+  const { emitterHex, sequence } = await withXrplClient(endpoint, async (client) => {
+    const resp = await client.request({ command: "tx", transaction: txHash });
+    const tx: any = resp.result;
+    const ledgerIndex = tx.ledger_index;
+    if (!ledgerIndex) throw new Error("Transaction not validated (no ledger_index)");
+    const meta = tx.meta ?? tx.metaData;
+    if (typeof meta !== "object" || meta === null || !("TransactionIndex" in meta)) {
+      throw new Error("Transaction metadata missing TransactionIndex");
+    }
+    const txIndex = (meta as any).TransactionIndex as number;
+
+    // Destination = custody account; delivered_amount → token (for emitter derivation)
+    const destination: string | undefined =
+      tx.Destination ?? tx.tx_json?.Destination;
+    if (!destination) throw new Error("Could not determine destination/custody address");
+
+    const deliveredAmount = (meta as any).delivered_amount;
+    let token: TokenId;
+    if (argv.token) {
+      token = tokenIdFromFlags({
+        type: argv.token,
+        currency: argv.currency,
+        issuer: argv.issuer,
+        mptId: argv["mpt-id"],
+      });
+    } else if (deliveredAmount) {
+      token = tokenIdFromXrplAmount(deliveredAmount);
+    } else {
+      token = { type: "XRP" };
+    }
+
+    const emitter = computeEmitterAddress(
+      Buffer.from(decodeAccountID(destination)),
+      token
+    );
+    const sequence = (BigInt(ledgerIndex) << 32n) | BigInt(txIndex);
+    return { emitterHex: emitter.toString("hex"), sequence };
+  });
+
+  const messageId = ethers.toBeHex(sequence, 32) as `0x${string}`;
+  console.log(`  emitter:      ${colors.gray(emitterHex)}`);
+  console.log(`  sequence:     ${colors.gray(sequence.toString())}`);
+
+  // ── 2. Poll the guardian API for the signed VAA ──
+  console.log(colors.blue("\n⏳ Waiting for guardian VAA..."));
+  await pollSignedVaa({
+    guardianApi,
+    chain: CHAIN_ID_XRPL,
+    emitterHex,
+    sequence,
+    pollIntervalMs: pollInterval,
+    pollTimeoutMs: pollTimeout,
+    onAttempt: (n, url) => console.log(colors.dim(`  attempt ${n}: ${url}`)),
+  });
+  console.log(colors.green("  VAA available."));
+
+  // ── 3. Fetch a quote ──
+  const relayInstructions =
+    (argv["relay-instructions"] as `0x${string}` | undefined) ??
+    buildGasInstructionHex(gasLimit, msgValue);
+
+  console.log(colors.blue("\n💱 Fetching executor quote..."));
+  const quote = await fetchQuote({
+    executorApi,
+    srcChain: CHAIN_ID_XRPL,
+    dstChain,
+    relayInstructions,
+  });
+  console.log(`  estimated cost: ${colors.yellow(quote.estimatedCost)} drops`);
+
+  // ── 4. Build the request + RequestForExecution ──
+  const request = buildRequest({
+    requestType,
+    emitterHex,
+    sequence,
+    messageId,
+    srcManager: argv["src-manager"],
+    manager: argv.manager,
+  });
+
+  if (!argv["dst-addr"]) {
+    throw new Error(
+      `--dst-addr is required (the destination ${requestType === "ern1" ? "NTT manager" : "contract"})`
+    );
+  }
+  const dstAddr = ethers.zeroPadValue(
+    argv["dst-addr"] as `0x${string}`,
+    32
+  ) as `0x${string}`;
+
+  const refundAddr = ethers.hexlify(
+    decodeAccountID(wallet.classicAddress)
+  ) as `0x${string}`;
+
+  const rfe: RequestForExecution = {
+    payload: {
+      version: 0,
+      dstChain,
+      dstAddr,
+      refundAddr,
+      signedQuote: deserializeSignedQuote(quote.signedQuote),
+      requestBytes: request,
+      relayInstructions: deserializeRelayInstructions(relayInstructions),
+    },
+  };
+
+  const serialized = serializeRequestForExecution(rfe);
+
+  // ── 5. Submit the XRPL Payment carrying the executor-request memo ──
+  console.log(colors.blue("\n📤 Submitting executor request payment..."));
+  const memoFormat = Buffer.from("application/x-executor-request")
+    .toString("hex")
+    .toUpperCase();
+  const memoData = serialized.slice(2).toUpperCase();
+
+  const result = await withXrplClient(endpoint, (client) =>
+    submitTx(client, wallet, {
+      TransactionType: "Payment",
+      Account: wallet.address,
+      Destination: executor,
+      Amount: quote.estimatedCost,
+      Memos: [{ Memo: { MemoFormat: memoFormat, MemoData: memoData } }],
+    })
+  );
+  const memoTxHash = result.result.hash;
+  console.log(colors.green("  tesSUCCESS"));
+  console.log(`  tx hash: ${colors.yellow(memoTxHash)}`);
+
+  // ── 6. Trigger executor indexing + report status ──
+  console.log(colors.blue("\n📡 Notifying executor (/v0/status/tx)..."));
+  const status = await submitStatusTx({
+    executorApi,
+    chainId: CHAIN_ID_XRPL,
+    txHash: memoTxHash,
+  });
+  console.log(
+    JSON.stringify(
+      status,
+      (_k, v) => (typeof v === "bigint" ? v.toString() : v),
+      2
+    )
+  );
+
+  console.log(colors.green("\n✅ relay dispatched"));
+  console.log(`  request tx: ${memoTxHash}`);
+  console.log(
+    colors.dim(
+      "Acks back to the Sequencer (XACK/XTCF/XBRN) are handled automatically by the executor's XRPL poller."
+    )
+  );
+}

--- a/cli/src/commands/xrpl/relay.ts
+++ b/cli/src/commands/xrpl/relay.ts
@@ -2,12 +2,13 @@ import type {
   Network,
   WormholeConfigOverrides,
 } from "@wormhole-foundation/sdk-connect";
-import { toChainId, type Chain } from "@wormhole-foundation/sdk";
+import { toChain, toUniversal, type Chain } from "@wormhole-foundation/sdk";
 import { ethers } from "ethers";
 import { decodeAccountID } from "xrpl";
 import { colors } from "../../colors.js";
 import {
   loadSeed,
+  resolveChainId,
   resolveXrplEndpoint,
   runXrpl,
   submitTx,
@@ -21,6 +22,7 @@ import {
   buildGasInstructionHex,
   deserializeRelayInstructions,
   deserializeSignedQuote,
+  serializeRequest,
   serializeRequestForExecution,
   type RequestForExecution,
   type RequestLayout,
@@ -30,15 +32,22 @@ import {
   computeEmitterAddress,
   tokenIdFromFlags,
   tokenIdFromXrplAmount,
+  xrplAccountToEmitter,
   type TokenId,
 } from "../../xrpl/tokenId";
 import { withCommon } from "./common";
 
-/** Resolve a --dst-chain value (name or numeric id) to a Wormhole chain id. */
-function resolveChainId(value: string | number): number {
-  if (typeof value === "number") return value;
-  if (/^\d+$/.test(value)) return parseInt(value, 10);
-  return toChainId(value as Chain);
+/**
+ * Resolve a destination address to a 32-byte universal hex. Accepts the
+ * destination chain's native format (e.g. Solana base58, EVM hex) — parsed via
+ * the Wormhole SDK — or an already-universal 32-byte hex (passed through).
+ */
+function resolveUniversalAddr(chain: Chain, addr: string): `0x${string}` {
+  const hex = addr.replace(/^0x/i, "");
+  if (/^[0-9a-fA-F]{64}$/.test(hex)) {
+    return `0x${hex.toLowerCase()}`;
+  }
+  return toUniversal(chain, addr).toString() as `0x${string}`;
 }
 
 function buildRequest(opts: {
@@ -109,7 +118,7 @@ export function createXrplRelayCommand(
         })
         .option("dst-addr", {
           describe:
-            "Destination address (hex32). For ERN1 this is the recipient NTT manager.",
+            "Destination address — chain-native (e.g. Solana base58, EVM hex) or 32-byte universal hex. For ERN1 this is the recipient NTT manager.",
           type: "string",
         })
         .option("src-manager", {
@@ -217,7 +226,11 @@ async function runRelay(
   console.log(`  request type: ${colors.yellow(requestType)}`);
   console.log(`  from wallet:  ${colors.yellow(wallet.address)}`);
 
-  // ── 1. Look up the XRPL tx → emitter + sequence (messageId) + token ──
+  // ── 1. Look up the XRPL tx → emitter + sequence (messageId) ──
+  // The emitter scheme differs by request type (see ripple xrpl-client
+  // export.ts): a core VAA (erv1: onboarding / admin / register-peer) uses the
+  // left-padded SENDER account, while an NTT transfer (ern1) uses the keccak
+  // transceiver emitter keccak256("ntt" || custody || token).
   const { emitterHex, sequence } = await withXrplClient(endpoint, async (client) => {
     const resp = await client.request({ command: "tx", transaction: txHash });
     const tx: any = resp.result;
@@ -228,33 +241,44 @@ async function runRelay(
       throw new Error("Transaction metadata missing TransactionIndex");
     }
     const txIndex = (meta as any).TransactionIndex as number;
-
-    // Destination = custody account; delivered_amount → token (for emitter derivation)
-    const destination: string | undefined =
-      tx.Destination ?? tx.tx_json?.Destination;
-    if (!destination) throw new Error("Could not determine destination/custody address");
-
-    const deliveredAmount = (meta as any).delivered_amount;
-    let token: TokenId;
-    if (argv.token) {
-      token = tokenIdFromFlags({
-        type: argv.token,
-        currency: argv.currency,
-        issuer: argv.issuer,
-        mptId: argv["mpt-id"],
-      });
-    } else if (deliveredAmount) {
-      token = tokenIdFromXrplAmount(deliveredAmount);
-    } else {
-      token = { type: "XRP" };
-    }
-
-    const emitter = computeEmitterAddress(
-      Buffer.from(decodeAccountID(destination)),
-      token
-    );
     const sequence = (BigInt(ledgerIndex) << 32n) | BigInt(txIndex);
-    return { emitterHex: emitter.toString("hex"), sequence };
+
+    let emitterHex: string;
+    if (requestType === "erv1") {
+      // Core VAA: emitter = the publishing (SENDER) account, left-padded to 32B.
+      const sender: string | undefined = tx.Account ?? tx.tx_json?.Account;
+      if (!sender) {
+        throw new Error("Could not determine the publishing account (tx.Account)");
+      }
+      emitterHex = xrplAccountToEmitter(Buffer.from(decodeAccountID(sender)));
+    } else {
+      // NTT transfer: emitter = keccak256("ntt" || custody || token), where the
+      // custody account is the tx destination and the token is the delivered asset.
+      const destination: string | undefined =
+        tx.Destination ?? tx.tx_json?.Destination;
+      if (!destination) {
+        throw new Error("Could not determine destination/custody address");
+      }
+      const deliveredAmount = (meta as any).delivered_amount;
+      let token: TokenId;
+      if (argv.token) {
+        token = tokenIdFromFlags({
+          type: argv.token,
+          currency: argv.currency,
+          issuer: argv.issuer,
+          mptId: argv["mpt-id"],
+        });
+      } else if (deliveredAmount) {
+        token = tokenIdFromXrplAmount(deliveredAmount);
+      } else {
+        token = { type: "XRP" };
+      }
+      emitterHex = computeEmitterAddress(
+        Buffer.from(decodeAccountID(destination)),
+        token
+      ).toString("hex");
+    }
+    return { emitterHex, sequence };
   });
 
   const messageId = ethers.toBeHex(sequence, 32) as `0x${string}`;
@@ -303,10 +327,7 @@ async function runRelay(
       `--dst-addr is required (the destination ${requestType === "ern1" ? "NTT manager" : "contract"})`
     );
   }
-  const dstAddr = ethers.zeroPadValue(
-    argv["dst-addr"] as `0x${string}`,
-    32
-  ) as `0x${string}`;
+  const dstAddr = resolveUniversalAddr(toChain(dstChain), argv["dst-addr"]);
 
   const refundAddr = ethers.hexlify(
     decodeAccountID(wallet.classicAddress)
@@ -326,6 +347,15 @@ async function runRelay(
 
   const serialized = serializeRequestForExecution(rfe);
 
+  // Debug: surface the generated executor request before submitting it.
+  console.log(colors.blue("\n🧾 Executor request (generated)"));
+  console.log(`  dst chain:            ${dstChain}`);
+  console.log(`  dst addr:             ${colors.gray(dstAddr)}`);
+  console.log(`  refund addr:          ${colors.gray(refundAddr)}`);
+  console.log(`  relay instructions:   ${colors.gray(relayInstructions)}`);
+  console.log(`  request (${requestType}):       ${colors.gray(serializeRequest(request))}`);
+  console.log(`  RequestForExecution:  ${colors.gray(serialized)}`);
+
   // ── 5. Submit the XRPL Payment carrying the executor-request memo ──
   console.log(colors.blue("\n📤 Submitting executor request payment..."));
   const memoFormat = Buffer.from("application/x-executor-request")
@@ -333,14 +363,20 @@ async function runRelay(
     .toUpperCase();
   const memoData = serialized.slice(2).toUpperCase();
 
+  const payment = {
+    TransactionType: "Payment" as const,
+    Account: wallet.address,
+    Destination: executor,
+    Amount: quote.estimatedCost,
+    Memos: [{ Memo: { MemoFormat: memoFormat, MemoData: memoData } }],
+  };
+  console.log(`  executor:             ${colors.gray(executor)}`);
+  console.log(`  amount (drops):       ${colors.gray(quote.estimatedCost)}`);
+  console.log(`  memo format:          ${colors.gray(memoFormat)}`);
+  console.log(`  memo data:            ${colors.gray(memoData)}`);
+
   const result = await withXrplClient(endpoint, (client) =>
-    submitTx(client, wallet, {
-      TransactionType: "Payment",
-      Account: wallet.address,
-      Destination: executor,
-      Amount: quote.estimatedCost,
-      Memos: [{ Memo: { MemoFormat: memoFormat, MemoData: memoData } }],
-    })
+    submitTx(client, wallet, payment)
   );
   const memoTxHash = result.result.hash;
   console.log(colors.green("  tesSUCCESS"));

--- a/cli/src/commands/xrpl/relay.ts
+++ b/cli/src/commands/xrpl/relay.ts
@@ -15,8 +15,16 @@ import {
   walletFromSeed,
   withXrplClient,
 } from "../../xrpl/helpers";
-import { DEFAULT_EXECUTOR_API, fetchQuote, submitStatusTx } from "../../xrpl/executor";
-import { CHAIN_ID_XRPL, DEFAULT_GUARDIAN_API, pollSignedVaa } from "../../xrpl/guardian";
+import {
+  DEFAULT_EXECUTOR_API,
+  fetchQuote,
+  submitStatusTx,
+} from "../../xrpl/executor";
+import {
+  CHAIN_ID_XRPL,
+  DEFAULT_GUARDIAN_API,
+  pollSignedVaa,
+} from "../../xrpl/guardian";
 import {
   RequestPrefix,
   buildGasInstructionHex,
@@ -83,7 +91,10 @@ function buildRequest(opts: {
     request: {
       prefix: RequestPrefix.ERN1,
       srcChain: CHAIN_ID_XRPL,
-      srcManager: ethers.zeroPadValue(srcManager as `0x${string}`, 32) as `0x${string}`,
+      srcManager: ethers.zeroPadValue(
+        srcManager as `0x${string}`,
+        32
+      ) as `0x${string}`,
       messageId: opts.messageId,
     },
   };
@@ -231,55 +242,65 @@ async function runRelay(
   // export.ts): a core VAA (erv1: onboarding / admin / register-peer) uses the
   // left-padded SENDER account, while an NTT transfer (ern1) uses the keccak
   // transceiver emitter keccak256("ntt" || custody || token).
-  const { emitterHex, sequence } = await withXrplClient(endpoint, async (client) => {
-    const resp = await client.request({ command: "tx", transaction: txHash });
-    const tx: any = resp.result;
-    const ledgerIndex = tx.ledger_index;
-    if (!ledgerIndex) throw new Error("Transaction not validated (no ledger_index)");
-    const meta = tx.meta ?? tx.metaData;
-    if (typeof meta !== "object" || meta === null || !("TransactionIndex" in meta)) {
-      throw new Error("Transaction metadata missing TransactionIndex");
-    }
-    const txIndex = (meta as any).TransactionIndex as number;
-    const sequence = (BigInt(ledgerIndex) << 32n) | BigInt(txIndex);
+  const { emitterHex, sequence } = await withXrplClient(
+    endpoint,
+    async (client) => {
+      const resp = await client.request({ command: "tx", transaction: txHash });
+      const tx: any = resp.result;
+      const ledgerIndex = tx.ledger_index;
+      if (!ledgerIndex)
+        throw new Error("Transaction not validated (no ledger_index)");
+      const meta = tx.meta ?? tx.metaData;
+      if (
+        typeof meta !== "object" ||
+        meta === null ||
+        !("TransactionIndex" in meta)
+      ) {
+        throw new Error("Transaction metadata missing TransactionIndex");
+      }
+      const txIndex = (meta as any).TransactionIndex as number;
+      const sequence = (BigInt(ledgerIndex) << 32n) | BigInt(txIndex);
 
-    let emitterHex: string;
-    if (requestType === "erv1") {
-      // Core VAA: emitter = the publishing (SENDER) account, left-padded to 32B.
-      const sender: string | undefined = tx.Account ?? tx.tx_json?.Account;
-      if (!sender) {
-        throw new Error("Could not determine the publishing account (tx.Account)");
-      }
-      emitterHex = xrplAccountToEmitter(Buffer.from(decodeAccountID(sender)));
-    } else {
-      // NTT transfer: emitter = keccak256("ntt" || custody || token), where the
-      // custody account is the tx destination and the token is the delivered asset.
-      const destination: string | undefined =
-        tx.Destination ?? tx.tx_json?.Destination;
-      if (!destination) {
-        throw new Error("Could not determine destination/custody address");
-      }
-      const deliveredAmount = (meta as any).delivered_amount;
-      let token: TokenId;
-      if (argv.token) {
-        token = tokenIdFromFlags({
-          type: argv.token,
-          currency: argv.currency,
-          issuer: argv.issuer,
-          mptId: argv["mpt-id"],
-        });
-      } else if (deliveredAmount) {
-        token = tokenIdFromXrplAmount(deliveredAmount);
+      let emitterHex: string;
+      if (requestType === "erv1") {
+        // Core VAA: emitter = the publishing (SENDER) account, left-padded to 32B.
+        const sender: string | undefined = tx.Account ?? tx.tx_json?.Account;
+        if (!sender) {
+          throw new Error(
+            "Could not determine the publishing account (tx.Account)"
+          );
+        }
+        emitterHex = xrplAccountToEmitter(Buffer.from(decodeAccountID(sender)));
       } else {
-        token = { type: "XRP" };
+        // NTT transfer: emitter = keccak256("ntt" || custody || token), where the
+        // custody account is the tx destination and the token is the delivered asset.
+        const destination: string | undefined =
+          tx.Destination ?? tx.tx_json?.Destination;
+        if (!destination) {
+          throw new Error("Could not determine destination/custody address");
+        }
+        const deliveredAmount = (meta as any).delivered_amount;
+        let token: TokenId;
+        if (argv.token) {
+          token = tokenIdFromFlags({
+            type: argv.token,
+            currency: argv.currency,
+            issuer: argv.issuer,
+            mptId: argv["mpt-id"],
+          });
+        } else if (deliveredAmount) {
+          token = tokenIdFromXrplAmount(deliveredAmount);
+        } else {
+          token = { type: "XRP" };
+        }
+        emitterHex = computeEmitterAddress(
+          Buffer.from(decodeAccountID(destination)),
+          token
+        ).toString("hex");
       }
-      emitterHex = computeEmitterAddress(
-        Buffer.from(decodeAccountID(destination)),
-        token
-      ).toString("hex");
+      return { emitterHex, sequence };
     }
-    return { emitterHex, sequence };
-  });
+  );
 
   const messageId = ethers.toBeHex(sequence, 32) as `0x${string}`;
   console.log(`  emitter:      ${colors.gray(emitterHex)}`);
@@ -353,7 +374,9 @@ async function runRelay(
   console.log(`  dst addr:             ${colors.gray(dstAddr)}`);
   console.log(`  refund addr:          ${colors.gray(refundAddr)}`);
   console.log(`  relay instructions:   ${colors.gray(relayInstructions)}`);
-  console.log(`  request (${requestType}):       ${colors.gray(serializeRequest(request))}`);
+  console.log(
+    `  request (${requestType}):       ${colors.gray(serializeRequest(request))}`
+  );
   console.log(`  RequestForExecution:  ${colors.gray(serialized)}`);
 
   // ── 5. Submit the XRPL Payment carrying the executor-request memo ──

--- a/cli/src/commands/xrpl/reserve-tickets.ts
+++ b/cli/src/commands/xrpl/reserve-tickets.ts
@@ -41,16 +41,24 @@ export function createXrplReserveTicketsCommand(
       runXrpl(async () => {
         const count: number = argv.count;
         if (!Number.isInteger(count) || count < 1 || count > MAX_TICKETS) {
-          throw new Error(`--count must be an integer between 1 and ${MAX_TICKETS}`);
+          throw new Error(
+            `--count must be an integer between 1 and ${MAX_TICKETS}`
+          );
         }
 
         const network = argv.network as Network;
         const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
-        const seed = loadSeed(argv["issuer-seed"], "issuer-seed", "ISSUER_SEED");
+        const seed = loadSeed(
+          argv["issuer-seed"],
+          "issuer-seed",
+          "ISSUER_SEED"
+        );
         const wallet = walletFromSeed(seed, argv.algorithm);
 
         console.log(
-          colors.blue(`Creating ${count} tickets on ${wallet.address} (${network})`)
+          colors.blue(
+            `Creating ${count} tickets on ${wallet.address} (${network})`
+          )
         );
         const result = await withXrplClient(endpoint, (client) =>
           submitTx(client, wallet, {

--- a/cli/src/commands/xrpl/reserve-tickets.ts
+++ b/cli/src/commands/xrpl/reserve-tickets.ts
@@ -1,0 +1,93 @@
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { colors } from "../../colors.js";
+import {
+  loadSeed,
+  resolveXrplEndpoint,
+  runXrpl,
+  submitTx,
+  walletFromSeed,
+  withXrplClient,
+} from "../../xrpl/helpers";
+import { withCommon } from "./common";
+
+// XRPL caps an account at 250 tickets.
+const MAX_TICKETS = 250;
+
+export function createXrplReserveTicketsCommand(
+  overrides: WormholeConfigOverrides<Network>
+) {
+  return {
+    command: "reserve-tickets",
+    describe: "Pre-allocate tickets on the custody account (TicketCreate)",
+    builder: (yargs: any) =>
+      withCommon(yargs)
+        .option("count", {
+          describe: `Number of tickets to create (1-${MAX_TICKETS})`,
+          type: "number",
+          default: 200,
+        })
+        .option("seed", {
+          describe: "Custody account seed (or env SEED)",
+          type: "string",
+        })
+        .example(
+          "$0 xrpl reserve-tickets -n Testnet --count 200 --seed sEd7...",
+          "Reserve 200 tickets on the custody account"
+        ),
+    handler: (argv: any) =>
+      runXrpl(async () => {
+        const count: number = argv.count;
+        if (!Number.isInteger(count) || count < 1 || count > MAX_TICKETS) {
+          throw new Error(`--count must be an integer between 1 and ${MAX_TICKETS}`);
+        }
+
+        const network = argv.network as Network;
+        const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
+        const seed = loadSeed(argv.seed, "seed", "SEED");
+        const wallet = walletFromSeed(seed, argv.algorithm);
+
+        console.log(
+          colors.blue(`Creating ${count} tickets on ${wallet.address} (${network})`)
+        );
+        const result = await withXrplClient(endpoint, (client) =>
+          submitTx(client, wallet, {
+            TransactionType: "TicketCreate",
+            Account: wallet.address,
+            TicketCount: count,
+          })
+        );
+
+        // Collect the created ticket sequence numbers from the metadata so we
+        // can report the allocated range (the first ticket feeds `xrpl init`'s
+        // --initial-ticket).
+        const meta = result.result.meta;
+        const ticketSeqs: number[] = [];
+        if (meta && typeof meta !== "string") {
+          for (const node of meta.AffectedNodes) {
+            const created = (node as any).CreatedNode;
+            if (created?.LedgerEntryType === "Ticket") {
+              const seq = created.NewFields?.TicketSequence;
+              if (typeof seq === "number") ticketSeqs.push(seq);
+            }
+          }
+        }
+        ticketSeqs.sort((a, b) => a - b);
+
+        console.log(colors.green(`✅ Created ${count} tickets`));
+        if (ticketSeqs.length > 0) {
+          const first = ticketSeqs[0];
+          const last = ticketSeqs[ticketSeqs.length - 1];
+          console.log(`   ticket range: ${first}–${last}`);
+          console.log(
+            colors.yellow(
+              `   for 'xrpl init': --initial-ticket ${first} --ticket-count ${ticketSeqs.length}`
+            )
+          );
+        }
+        console.log(`   tx: ${result.result.hash}`);
+      }),
+  };
+}

--- a/cli/src/commands/xrpl/reserve-tickets.ts
+++ b/cli/src/commands/xrpl/reserve-tickets.ts
@@ -29,12 +29,12 @@ export function createXrplReserveTicketsCommand(
           type: "number",
           default: 200,
         })
-        .option("seed", {
-          describe: "Custody account seed (or env SEED)",
+        .option("issuer-seed", {
+          describe: "Custody account seed (or env ISSUER_SEED)",
           type: "string",
         })
         .example(
-          "$0 xrpl reserve-tickets -n Testnet --count 200 --seed sEd7...",
+          "$0 xrpl reserve-tickets -n Testnet --count 200 --issuer-seed sEd7...",
           "Reserve 200 tickets on the custody account"
         ),
     handler: (argv: any) =>
@@ -46,7 +46,7 @@ export function createXrplReserveTicketsCommand(
 
         const network = argv.network as Network;
         const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
-        const seed = loadSeed(argv.seed, "seed", "SEED");
+        const seed = loadSeed(argv["issuer-seed"], "issuer-seed", "ISSUER_SEED");
         const wallet = walletFromSeed(seed, argv.algorithm);
 
         console.log(

--- a/cli/src/commands/xrpl/rotate-admin.ts
+++ b/cli/src/commands/xrpl/rotate-admin.ts
@@ -1,0 +1,131 @@
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { xrpToDrops } from "xrpl";
+import { colors } from "../../colors.js";
+import { loadConfig } from "../../deployments";
+import { promptYesNo } from "../../prompts.js";
+import {
+  loadSeed,
+  resolveXrplEndpoint,
+  runXrpl,
+  submitTx,
+  validateRAddress,
+  walletFromSeed,
+  withXrplClient,
+} from "../../xrpl/helpers";
+import { buildRotateAdminPayload } from "../../xrpl/admin";
+import {
+  DEFAULT_TESTNET_CORE_ACCOUNT,
+  WORMHOLE_PUBLISH_MEMO_FORMAT,
+  buildPublishMemoData,
+} from "../../xrpl/onboarding";
+import { options } from "../shared";
+import { withCommon } from "./common";
+
+export function createXrplRotateAdminCommand(
+  overrides: WormholeConfigOverrides<Network>
+) {
+  return {
+    command: "rotate-admin",
+    describe: "Rotate the custody account's admin (XADM RotateAdmin)",
+    builder: (yargs: any) =>
+      withCommon(yargs)
+        .option("manager", {
+          describe: "XRPL custody (manager) account r-address (default: xrpl.manager)",
+          type: "string",
+        })
+        .option("new-admin", {
+          describe: "New admin XRPL r-address",
+          type: "string",
+          demandOption: true,
+        })
+        .option("core-account", {
+          describe: "Wormhole Core (GMP) account to publish the message to",
+          type: "string",
+          default: DEFAULT_TESTNET_CORE_ACCOUNT,
+        })
+        .option("amount", {
+          describe: "XRP amount to send with the message",
+          type: "string",
+          default: "0.000001",
+        })
+        .option("admin-seed", {
+          describe: "Current admin account seed (or env ADMIN_SEED)",
+          type: "string",
+        })
+        .option("yes", options.yes)
+        .option("path", options.deploymentPath)
+        .example(
+          "$0 xrpl rotate-admin -n Testnet --new-admin r9qA... --admin-seed sEd7...",
+          "Rotate the admin of the recorded custody account"
+        ),
+    handler: (argv: any) =>
+      runXrpl(async () => {
+        const network = argv.network as Network;
+        const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
+        const seed = loadSeed(argv["admin-seed"], "admin-seed", "ADMIN_SEED");
+        const wallet = walletFromSeed(seed, argv.algorithm);
+
+        const managerArg = argv.manager || loadConfig(argv.path).xrpl?.manager;
+        if (!managerArg) {
+          throw new Error(
+            "Provide --manager or record one with `ntt xrpl set-manager`"
+          );
+        }
+        const manager = validateRAddress(managerArg);
+        const newAdmin = validateRAddress(argv["new-admin"]);
+
+        const payload = buildRotateAdminPayload({ manager, newAdmin });
+        const memoData = buildPublishMemoData(payload);
+
+        console.log(
+          colors.blue(
+            `Rotating admin of ${manager} (current admin ${wallet.address}) on ${network}`
+          )
+        );
+        console.log(`   new admin:    ${newAdmin}`);
+        console.log(`   core account: ${argv["core-account"]}`);
+        console.log(
+          colors.yellow(
+            "⚠️  RotateAdmin (XADM/0x02) is not yet processed by the Sequencer.\n" +
+              "    The message will be published but will NOT take effect until\n" +
+              "    Sequencer support lands."
+          )
+        );
+
+        if (!argv.yes) {
+          const ok = await promptYesNo("Publish the rotate-admin message anyway?", {
+            defaultYes: false,
+          });
+          if (!ok) {
+            console.log(colors.gray("Aborted."));
+            return;
+          }
+        }
+
+        const result = await withXrplClient(endpoint, (client) =>
+          submitTx(client, wallet, {
+            TransactionType: "Payment",
+            Account: wallet.address,
+            Destination: argv["core-account"],
+            Amount: xrpToDrops(argv.amount),
+            Memos: [
+              {
+                Memo: {
+                  MemoFormat: Buffer.from(
+                    WORMHOLE_PUBLISH_MEMO_FORMAT,
+                    "ascii"
+                  ).toString("hex"),
+                  MemoData: memoData,
+                },
+              },
+            ],
+          })
+        );
+        console.log(colors.green("✅ RotateAdmin message sent"));
+        console.log(`   tx: ${result.result.hash}`);
+      }),
+  };
+}

--- a/cli/src/commands/xrpl/rotate-admin.ts
+++ b/cli/src/commands/xrpl/rotate-admin.ts
@@ -33,7 +33,8 @@ export function createXrplRotateAdminCommand(
     builder: (yargs: any) =>
       withCommon(yargs)
         .option("manager", {
-          describe: "XRPL custody (manager) account r-address (default: xrpl.manager)",
+          describe:
+            "XRPL custody (manager) account r-address (default: xrpl.manager)",
           type: "string",
         })
         .option("new-admin", {
@@ -96,9 +97,12 @@ export function createXrplRotateAdminCommand(
         );
 
         if (!argv.yes) {
-          const ok = await promptYesNo("Publish the rotate-admin message anyway?", {
-            defaultYes: false,
-          });
+          const ok = await promptYesNo(
+            "Publish the rotate-admin message anyway?",
+            {
+              defaultYes: false,
+            }
+          );
           if (!ok) {
             console.log(colors.gray("Aborted."));
             return;

--- a/cli/src/commands/xrpl/set-manager.ts
+++ b/cli/src/commands/xrpl/set-manager.ts
@@ -1,0 +1,68 @@
+import fs from "fs";
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { colors } from "../../colors.js";
+import { loadConfig } from "../../deployments";
+import {
+  loadSeed,
+  runXrpl,
+  validateRAddress,
+  walletFromSeed,
+} from "../../xrpl/helpers";
+import { options } from "../shared";
+
+export function createXrplSetManagerCommand(
+  _overrides: WormholeConfigOverrides<Network>
+) {
+  return {
+    command: "set-manager",
+    describe: "Record the XRPL custody (manager) account in the deployment file",
+    builder: (yargs: any) =>
+      yargs
+        .option("account", {
+          describe: "XRPL custody account r-address",
+          type: "string",
+        })
+        .option("seed", {
+          describe: "Custody seed to derive the address from (or env SEED)",
+          type: "string",
+        })
+        .option("algorithm", {
+          describe: "Key algorithm when deriving the address from --seed",
+          type: "string",
+          choices: ["ed25519", "secp256k1"] as const,
+        })
+        .option("path", options.deploymentPath)
+        .example(
+          "$0 xrpl set-manager --account r9qA...",
+          "Record an existing custody account"
+        )
+        .example(
+          "$0 xrpl set-manager --seed sEd7...",
+          "Derive the account from its seed and record it"
+        ),
+    handler: (argv: any) =>
+      runXrpl(async () => {
+        const path = argv.path;
+        const config = loadConfig(path);
+
+        let manager: string;
+        if (argv.account) {
+          manager = validateRAddress(argv.account);
+        } else {
+          const seed = loadSeed(argv.seed, "seed", "SEED");
+          manager = walletFromSeed(seed, argv.algorithm).address;
+        }
+
+        config.xrpl = { ...config.xrpl, manager };
+        fs.writeFileSync(path, JSON.stringify(config, null, 2));
+
+        console.log(
+          colors.green(`✅ Recorded XRPL manager: ${colors.yellow(manager)}`)
+        );
+        console.log(`   ${path} → xrpl.manager`);
+      }),
+  };
+}

--- a/cli/src/commands/xrpl/set-manager.ts
+++ b/cli/src/commands/xrpl/set-manager.ts
@@ -13,7 +13,8 @@ export function createXrplSetManagerCommand(
 ) {
   return {
     command: "set-manager",
-    describe: "Record the XRPL custody (manager) account in the deployment file",
+    describe:
+      "Record the XRPL custody (manager) account in the deployment file",
     builder: (yargs: any) =>
       yargs
         .option("account", {

--- a/cli/src/commands/xrpl/set-manager.ts
+++ b/cli/src/commands/xrpl/set-manager.ts
@@ -5,12 +5,7 @@ import type {
 } from "@wormhole-foundation/sdk-connect";
 import { colors } from "../../colors.js";
 import { loadConfig } from "../../deployments";
-import {
-  loadSeed,
-  runXrpl,
-  validateRAddress,
-  walletFromSeed,
-} from "../../xrpl/helpers";
+import { runXrpl, validateRAddress } from "../../xrpl/helpers";
 import { options } from "../shared";
 
 export function createXrplSetManagerCommand(
@@ -24,37 +19,19 @@ export function createXrplSetManagerCommand(
         .option("account", {
           describe: "XRPL custody account r-address",
           type: "string",
-        })
-        .option("seed", {
-          describe: "Custody seed to derive the address from (or env SEED)",
-          type: "string",
-        })
-        .option("algorithm", {
-          describe: "Key algorithm when deriving the address from --seed",
-          type: "string",
-          choices: ["ed25519", "secp256k1"] as const,
+          demandOption: true,
         })
         .option("path", options.deploymentPath)
         .example(
           "$0 xrpl set-manager --account r9qA...",
-          "Record an existing custody account"
-        )
-        .example(
-          "$0 xrpl set-manager --seed sEd7...",
-          "Derive the account from its seed and record it"
+          "Record the custody account"
         ),
     handler: (argv: any) =>
       runXrpl(async () => {
         const path = argv.path;
         const config = loadConfig(path);
 
-        let manager: string;
-        if (argv.account) {
-          manager = validateRAddress(argv.account);
-        } else {
-          const seed = loadSeed(argv.seed, "seed", "SEED");
-          manager = walletFromSeed(seed, argv.algorithm).address;
-        }
+        const manager = validateRAddress(argv.account);
 
         config.xrpl = { ...config.xrpl, manager };
         fs.writeFileSync(path, JSON.stringify(config, null, 2));

--- a/cli/src/commands/xrpl/set-signer-list.ts
+++ b/cli/src/commands/xrpl/set-signer-list.ts
@@ -1,0 +1,163 @@
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { colors } from "../../colors.js";
+import { promptYesNo } from "../../prompts.js";
+import {
+  loadSeed,
+  resolveXrplEndpoint,
+  runXrpl,
+  submitTx,
+  walletFromSeed,
+  withXrplClient,
+} from "../../xrpl/helpers";
+import {
+  deriveSignerEntries,
+  fetchDelegatedManagerSet,
+  signerEntriesFromAddresses,
+  type SignerEntry,
+} from "../../xrpl/manager-set";
+import { options } from "../shared";
+import { withCommon } from "./common";
+
+export function createXrplSetSignerListCommand(
+  overrides: WormholeConfigOverrides<Network>
+) {
+  return {
+    command: "set-signer-list",
+    describe:
+      "Hand the custody account over to the manager-set multisig (SignerListSet)",
+    builder: (yargs: any) =>
+      withCommon(yargs)
+        .option("signers", {
+          describe: "Explicit comma-separated signer r-addresses (skips the EVM fetch)",
+          type: "string",
+        })
+        .option("manager-chain-id", {
+          describe: "Wormhole chain ID of the XRPL custody account",
+          type: "number",
+          default: 66,
+        })
+        .option("manager-set-index", {
+          describe: "Manager set index to fetch",
+          type: "number",
+        })
+        .option("rpc-eth", {
+          describe: "EVM RPC URL hosting the delegated manager set contract",
+          type: "string",
+        })
+        .option("delegated-manager-set-addr", {
+          describe: "Delegated manager set contract address (EVM)",
+          type: "string",
+        })
+        .option("quorum", {
+          describe:
+            "Signer quorum (required with --signers; the EVM fetch always uses the manager-set threshold)",
+          type: "number",
+        })
+        .option("seed", {
+          describe: "Custody account seed (or env SEED)",
+          type: "string",
+        })
+        .option("yes", options.yes)
+        .example(
+          "$0 xrpl set-signer-list -n Testnet --manager-set-index 0 --rpc-eth https://... --delegated-manager-set-addr 0x... --seed sEd7...",
+          "Fetch the manager set and set the signer list"
+        )
+        .example(
+          "$0 xrpl set-signer-list -n Testnet --signers r1,r2,r3 --quorum 2 --seed sEd7...",
+          "Set an explicit signer list"
+        ),
+    handler: (argv: any) =>
+      runXrpl(async () => {
+        const network = argv.network as Network;
+        const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
+        const seed = loadSeed(argv.seed, "seed", "SEED");
+        const wallet = walletFromSeed(seed, argv.algorithm);
+
+        // Resolve signer entries + quorum, either from an explicit list or by
+        // fetching the delegated manager set from an EVM contract.
+        let entries: SignerEntry[];
+        let quorum: number;
+        if (argv.signers) {
+          entries = signerEntriesFromAddresses(String(argv.signers).split(","));
+          if (argv.quorum === undefined) {
+            throw new Error("--quorum is required when using --signers");
+          }
+          quorum = argv.quorum;
+        } else {
+          if (
+            !argv["rpc-eth"] ||
+            !argv["delegated-manager-set-addr"] ||
+            argv["manager-set-index"] === undefined
+          ) {
+            throw new Error(
+              "Provide --signers, or all of --rpc-eth, --delegated-manager-set-addr and --manager-set-index"
+            );
+          }
+          if (argv.quorum !== undefined) {
+            throw new Error(
+              "Do not pass --quorum with the EVM fetch; the quorum is the manager-set threshold"
+            );
+          }
+          const managerSet = await fetchDelegatedManagerSet(
+            argv["manager-chain-id"],
+            argv["manager-set-index"],
+            argv["rpc-eth"],
+            argv["delegated-manager-set-addr"]
+          );
+          entries = deriveSignerEntries(managerSet.pubkeys);
+          // The quorum is fixed by the manager set; not user-overridable.
+          quorum = managerSet.mThreshold;
+          console.log(
+            colors.gray(
+              `   fetched manager set: ${managerSet.nTotal} signers, threshold ${managerSet.mThreshold}`
+            )
+          );
+        }
+
+        if (!Number.isInteger(quorum) || quorum < 1 || quorum > entries.length) {
+          throw new Error(
+            `quorum ${quorum} must be between 1 and the signer count (${entries.length})`
+          );
+        }
+
+        console.log(
+          colors.blue(
+            `Setting signer list on ${wallet.address} (${network}): ${entries.length} signers, quorum ${quorum}`
+          )
+        );
+        for (const e of entries) {
+          console.log(colors.gray(`   - ${e.SignerEntry.Account}`));
+        }
+        console.log(
+          colors.yellow(
+            "⚠️  This hands signing authority to the multisig. The master key remains\n" +
+              "    enabled until you disable it separately (asfDisableMaster)."
+          )
+        );
+
+        if (!argv.yes) {
+          const ok = await promptYesNo("Proceed with SignerListSet?", {
+            defaultYes: false,
+          });
+          if (!ok) {
+            console.log(colors.gray("Aborted."));
+            return;
+          }
+        }
+
+        const result = await withXrplClient(endpoint, (client) =>
+          submitTx(client, wallet, {
+            TransactionType: "SignerListSet",
+            Account: wallet.address,
+            SignerQuorum: quorum,
+            SignerEntries: entries,
+          })
+        );
+        console.log(colors.green("✅ Signer list set"));
+        console.log(`   tx: ${result.result.hash}`);
+      }),
+  };
+}

--- a/cli/src/commands/xrpl/set-signer-list.ts
+++ b/cli/src/commands/xrpl/set-signer-list.ts
@@ -40,8 +40,9 @@ export function createXrplSetSignerListCommand(
           default: 66,
         })
         .option("manager-set-index", {
-          describe: "Manager set index to fetch",
-          type: "number",
+          describe: "Manager set index to fetch, or 'latest'",
+          type: "string",
+          default: "latest",
         })
         .option("rpc-eth", {
           describe: "EVM RPC URL hosting the delegated manager set contract",
@@ -56,24 +57,24 @@ export function createXrplSetSignerListCommand(
             "Signer quorum (required with --signers; the EVM fetch always uses the manager-set threshold)",
           type: "number",
         })
-        .option("seed", {
-          describe: "Custody account seed (or env SEED)",
+        .option("issuer-seed", {
+          describe: "Custody account seed (or env ISSUER_SEED)",
           type: "string",
         })
         .option("yes", options.yes)
         .example(
-          "$0 xrpl set-signer-list -n Testnet --manager-set-index 0 --rpc-eth https://... --delegated-manager-set-addr 0x... --seed sEd7...",
-          "Fetch the manager set and set the signer list"
+          "$0 xrpl set-signer-list -n Testnet --rpc-eth https://... --delegated-manager-set-addr 0x... --issuer-seed sEd7...",
+          "Fetch the latest manager set and set the signer list"
         )
         .example(
-          "$0 xrpl set-signer-list -n Testnet --signers r1,r2,r3 --quorum 2 --seed sEd7...",
+          "$0 xrpl set-signer-list -n Testnet --signers r1,r2,r3 --quorum 2 --issuer-seed sEd7...",
           "Set an explicit signer list"
         ),
     handler: (argv: any) =>
       runXrpl(async () => {
         const network = argv.network as Network;
         const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
-        const seed = loadSeed(argv.seed, "seed", "SEED");
+        const seed = loadSeed(argv["issuer-seed"], "issuer-seed", "ISSUER_SEED");
         const wallet = walletFromSeed(seed, argv.algorithm);
 
         // Resolve signer entries + quorum, either from an explicit list or by
@@ -87,13 +88,9 @@ export function createXrplSetSignerListCommand(
           }
           quorum = argv.quorum;
         } else {
-          if (
-            !argv["rpc-eth"] ||
-            !argv["delegated-manager-set-addr"] ||
-            argv["manager-set-index"] === undefined
-          ) {
+          if (!argv["rpc-eth"] || !argv["delegated-manager-set-addr"]) {
             throw new Error(
-              "Provide --signers, or all of --rpc-eth, --delegated-manager-set-addr and --manager-set-index"
+              "Provide --signers, or both --rpc-eth and --delegated-manager-set-addr"
             );
           }
           if (argv.quorum !== undefined) {
@@ -101,9 +98,17 @@ export function createXrplSetSignerListCommand(
               "Do not pass --quorum with the EVM fetch; the quorum is the manager-set threshold"
             );
           }
+          const idxArg = argv["manager-set-index"];
+          const index: number | "latest" =
+            idxArg === "latest" ? "latest" : Number(idxArg);
+          if (index !== "latest" && (!Number.isInteger(index) || index < 0)) {
+            throw new Error(
+              "--manager-set-index must be a non-negative integer or 'latest'"
+            );
+          }
           const managerSet = await fetchDelegatedManagerSet(
             argv["manager-chain-id"],
-            argv["manager-set-index"],
+            index,
             argv["rpc-eth"],
             argv["delegated-manager-set-addr"]
           );
@@ -112,7 +117,7 @@ export function createXrplSetSignerListCommand(
           quorum = managerSet.mThreshold;
           console.log(
             colors.gray(
-              `   fetched manager set: ${managerSet.nTotal} signers, threshold ${managerSet.mThreshold}`
+              `   fetched manager set #${managerSet.index}: ${managerSet.nTotal} signers, threshold ${managerSet.mThreshold}`
             )
           );
         }

--- a/cli/src/commands/xrpl/set-signer-list.ts
+++ b/cli/src/commands/xrpl/set-signer-list.ts
@@ -31,7 +31,8 @@ export function createXrplSetSignerListCommand(
     builder: (yargs: any) =>
       withCommon(yargs)
         .option("signers", {
-          describe: "Explicit comma-separated signer r-addresses (skips the EVM fetch)",
+          describe:
+            "Explicit comma-separated signer r-addresses (skips the EVM fetch)",
           type: "string",
         })
         .option("manager-chain-id", {
@@ -74,7 +75,11 @@ export function createXrplSetSignerListCommand(
       runXrpl(async () => {
         const network = argv.network as Network;
         const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
-        const seed = loadSeed(argv["issuer-seed"], "issuer-seed", "ISSUER_SEED");
+        const seed = loadSeed(
+          argv["issuer-seed"],
+          "issuer-seed",
+          "ISSUER_SEED"
+        );
         const wallet = walletFromSeed(seed, argv.algorithm);
 
         // Resolve signer entries + quorum, either from an explicit list or by
@@ -122,7 +127,11 @@ export function createXrplSetSignerListCommand(
           );
         }
 
-        if (!Number.isInteger(quorum) || quorum < 1 || quorum > entries.length) {
+        if (
+          !Number.isInteger(quorum) ||
+          quorum < 1 ||
+          quorum > entries.length
+        ) {
           throw new Error(
             `quorum ${quorum} must be between 1 and the signer count (${entries.length})`
           );

--- a/cli/src/commands/xrpl/trust-set.ts
+++ b/cli/src/commands/xrpl/trust-set.ts
@@ -1,0 +1,75 @@
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { colors } from "../../colors.js";
+import {
+  loadSeed,
+  normalizeCurrency,
+  resolveXrplEndpoint,
+  runXrpl,
+  submitTx,
+  walletFromSeed,
+  withXrplClient,
+} from "../../xrpl/helpers";
+import { withCommon } from "./common";
+
+export function createTrustSetCommand(
+  overrides: WormholeConfigOverrides<Network>
+) {
+  return {
+    command: "trust-set",
+    describe: "Open a trust line so a holder can hold an IOU (TrustSet)",
+    builder: (yargs: any) =>
+      withCommon(yargs)
+        .option("currency", {
+          describe: "Currency code (3-char ASCII or 40-char hex)",
+          type: "string",
+          demandOption: true,
+        })
+        .option("issuer", {
+          describe: "IOU issuer account address",
+          type: "string",
+          demandOption: true,
+        })
+        .option("limit", {
+          describe: "Trust line limit (max amount the holder will hold)",
+          type: "string",
+          demandOption: true,
+        })
+        .option("seed", {
+          describe: "Holder account seed (or env SEED)",
+          type: "string",
+        })
+        .example(
+          "$0 xrpl trust-set -n Testnet --currency FOO --issuer r9qA... --limit 1000000 --seed sEd7...",
+          "Open a trust line to the issuer for FOO"
+        ),
+    handler: (argv: any) =>
+      runXrpl(async () => {
+        const network = argv.network as Network;
+        const endpoint = resolveXrplEndpoint(network, argv.rpc, overrides);
+        const seed = loadSeed(argv.seed, "seed", "SEED");
+        const wallet = walletFromSeed(seed, argv.algorithm);
+        const currency = normalizeCurrency(argv.currency);
+        console.log(
+          colors.blue(
+            `Trust line: ${wallet.address} trusts ${argv.issuer} for ${currency} (limit ${argv.limit})`
+          )
+        );
+        const result = await withXrplClient(endpoint, (client) =>
+          submitTx(client, wallet, {
+            TransactionType: "TrustSet",
+            Account: wallet.address,
+            LimitAmount: {
+              currency,
+              issuer: argv.issuer,
+              value: String(argv.limit),
+            },
+          })
+        );
+        console.log(colors.green("✅ Trust line set"));
+        console.log(`   tx: ${result.result.hash}`);
+      }),
+  };
+}

--- a/cli/src/deployments.ts
+++ b/cli/src/deployments.ts
@@ -28,6 +28,13 @@ export type HyperCoreConfig = {
   weiDecimals?: number;
 };
 
+// XRPL custody-account config. Kept as a dedicated top-level section (not under
+// `chains`) since the XRPL NTT account is set up incrementally and doesn't fit
+// the full ChainConfig shape.
+export type XrplConfig = {
+  manager?: string;
+};
+
 export type Config = {
   network: Network;
   chains: Partial<{
@@ -37,6 +44,7 @@ export type Config = {
     outbound: string;
   };
   hypercore?: HyperCoreConfig;
+  xrpl?: XrplConfig;
 };
 
 export function loadConfig(path: string): Config {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -30,6 +30,7 @@ import {
   createTransferOwnershipCommand,
   createUpdateCommand,
   createUpgradeCommand,
+  createXrplCommand,
 } from "./commands";
 import { loadOverrides } from "./overrides.js";
 import { formatNttVersion, nttVersion } from "./version.js";
@@ -65,6 +66,7 @@ yargs(hideBin(process.argv))
   .command(createHypeCommand(overrides))
   .command(createManualCommand(overrides))
   .command(createSuiCommand(overrides))
+  .command(createXrplCommand(overrides))
   .help()
   .strict()
   .demandCommand()

--- a/cli/src/xrpl/admin.ts
+++ b/cli/src/xrpl/admin.ts
@@ -1,0 +1,69 @@
+import { decodeAccountID } from "xrpl";
+
+// XADM (Admin) payload builders. Mirrors the reference scripts
+// (xrpl-scripts/register_peer.ts, rotate_admin.ts) and the decoder in
+// `payloads.ts` (parseAdmin). Published like XRPLAppOnboarding — wrap the
+// payload with buildPublishMemoData (see onboarding.ts) and send it as a
+// Payment to the Wormhole Core account.
+
+/** "XADM" prefix (0x5841444D) identifying an admin payload. */
+export const XADM_PREFIX = "5841444D";
+
+const ACTION_REGISTER_PEER = "01";
+const ACTION_ROTATE_ADMIN = "02";
+
+/** Decode an XRPL r-address to its 20-byte account ID (40 hex chars). */
+function accountIdHex(rAddress: string): string {
+  return Buffer.from(decodeAccountID(rAddress)).toString("hex");
+}
+
+/** Normalize a 32-byte address (e.g. a transceiver emitter) to 64 lowercase hex chars. */
+function normalizeAddress32(hex: string): string {
+  const h = hex.replace(/^0x/i, "").toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(h)) {
+    throw new Error(`expected a 32-byte (64 hex char) address, got "${hex}"`);
+  }
+  return h;
+}
+
+/** Encode a Wormhole chain id as a big-endian 2-byte (4 hex char) value. */
+function chainIdHex(chainId: number): string {
+  if (!Number.isInteger(chainId) || chainId < 0 || chainId > 0xffff) {
+    throw new Error(`chain id ${chainId} does not fit in a uint16`);
+  }
+  return chainId.toString(16).padStart(4, "0");
+}
+
+/**
+ * Build an XADM RegisterPeer (0x01) payload (hex, no 0x prefix):
+ *   prefix("XADM")[4] + 0x01 + manager[20] + peer_chain[2 BE] + peer_address[32]
+ */
+export function buildRegisterPeerPayload(params: {
+  manager: string;
+  peerChainId: number;
+  peerAddress: string;
+}): string {
+  return (
+    XADM_PREFIX +
+    ACTION_REGISTER_PEER +
+    accountIdHex(params.manager) +
+    chainIdHex(params.peerChainId) +
+    normalizeAddress32(params.peerAddress)
+  );
+}
+
+/**
+ * Build an XADM RotateAdmin (0x02) payload (hex, no 0x prefix):
+ *   prefix("XADM")[4] + 0x02 + manager[20] + new_admin[20]
+ */
+export function buildRotateAdminPayload(params: {
+  manager: string;
+  newAdmin: string;
+}): string {
+  return (
+    XADM_PREFIX +
+    ACTION_ROTATE_ADMIN +
+    accountIdHex(params.manager) +
+    accountIdHex(params.newAdmin)
+  );
+}

--- a/cli/src/xrpl/executor.ts
+++ b/cli/src/xrpl/executor.ts
@@ -1,0 +1,74 @@
+// Thin client for the w7-executor public HTTP API (/v0).
+//
+// Endpoints used (w7-executor/src/api):
+//   POST /v0/quote      { srcChain, dstChain, relayInstructions } → { signedQuote, estimatedCost }
+//   POST /v0/status/tx  { chainId, txHash } → RelayTransaction[]   (also triggers indexing)
+//
+// There is NO "submit request" endpoint: a relay request IS an XRPL Payment
+// carrying an `application/x-executor-request` memo. After submitting that
+// Payment, call submitStatusTx to trigger indexing and poll status.
+
+export const DEFAULT_EXECUTOR_API = "https://executor-testnet.labsapis.com";
+
+export interface QuoteResponse {
+  signedQuote: `0x${string}`;
+  estimatedCost: string; // drops (stringified)
+}
+
+/** POST /v0/quote — fetch a signed quote + estimated cost for a relay. */
+export async function fetchQuote(opts: {
+  executorApi: string;
+  srcChain: number;
+  dstChain: number;
+  relayInstructions: `0x${string}`;
+}): Promise<QuoteResponse> {
+  const res = await fetch(`${opts.executorApi}/v0/quote`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      srcChain: opts.srcChain,
+      dstChain: opts.dstChain,
+      relayInstructions: opts.relayInstructions,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Quote API ${res.status}: ${await res.text()}`);
+  }
+  const data = (await res.json()) as {
+    signedQuote?: `0x${string}`;
+    estimatedCost?: string;
+  };
+  if (!data.signedQuote || !data.estimatedCost) {
+    throw new Error("Quote response missing signedQuote or estimatedCost");
+  }
+  return { signedQuote: data.signedQuote, estimatedCost: data.estimatedCost };
+}
+
+export interface RelayTransaction {
+  id?: string;
+  status?: string;
+  failureCause?: string;
+  failureMessage?: string;
+  txs?: { txHash: string; chainId: number }[];
+  [k: string]: unknown;
+}
+
+/**
+ * POST /v0/status/tx — trigger indexing of `txHash` and return its relay status.
+ * `chainId` is the chain the request was emitted on (66 for XRPL).
+ */
+export async function submitStatusTx(opts: {
+  executorApi: string;
+  chainId: number;
+  txHash: string;
+}): Promise<RelayTransaction[]> {
+  const res = await fetch(`${opts.executorApi}/v0/status/tx`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ chainId: opts.chainId, txHash: opts.txHash }),
+  });
+  if (!res.ok) {
+    throw new Error(`Status API ${res.status}: ${await res.text()}`);
+  }
+  return (await res.json()) as RelayTransaction[];
+}

--- a/cli/src/xrpl/executorLayouts.ts
+++ b/cli/src/xrpl/executorLayouts.ts
@@ -1,0 +1,208 @@
+// Executor RequestForExecution layouts (binary-layout).
+//
+// Ported from ripple/xrpl-client/src/integration/executorLayouts.ts and
+// w7-executor/src/layouts/requestForExecution.ts. Adds ERV1 (VAA_V1) on top of
+// the ERN1 (NTT_V1) request the integration reference shipped, so the CLI can
+// relay both NTT transfers and XRPL-originated core VAAs (onboarding /
+// register-peer) to the Sequencer.
+
+import type { CustomConversion, DeriveType, Layout } from "binary-layout";
+import { deserialize, serialize } from "binary-layout";
+import { ethers } from "ethers";
+
+export const hexConversion = {
+  to: (encoded: Uint8Array) => ethers.hexlify(encoded) as `0x${string}`,
+  from: (decoded: `0x${string}`) => ethers.getBytes(decoded),
+} as const satisfies CustomConversion<Uint8Array, `0x${string}`>;
+
+export const dateConversion = {
+  to: (encoded: bigint) => new Date(Number(encoded * 1000n)),
+  from: (decoded: Date) => BigInt(decoded.getTime()) / 1000n,
+} as const satisfies CustomConversion<bigint, Date>;
+
+// ── Signed quote ─────────────────────────────────────────────────────────
+
+export const EQ01_PREFIX = 0x45513031;
+export const EQ02_PREFIX = 0x45513032;
+
+const sharedQuoteBody = [
+  { name: "quoterAddress", binary: "bytes", size: 20, custom: hexConversion },
+  { name: "payeeAddress", binary: "bytes", size: 32, custom: hexConversion },
+  { name: "srcChain", binary: "uint", size: 2 },
+  { name: "dstChain", binary: "uint", size: 2 },
+  { name: "expiryTime", binary: "uint", size: 8, custom: dateConversion },
+  { name: "baseFee", binary: "uint", size: 8 },
+  { name: "dstGasPrice", binary: "uint", size: 8 },
+  { name: "srcPrice", binary: "uint", size: 8 },
+  { name: "dstPrice", binary: "uint", size: 8 },
+] as const;
+
+export const signedQuoteLayout = [
+  {
+    name: "quote",
+    binary: "switch",
+    idSize: 4,
+    idTag: "prefix",
+    layouts: [
+      [
+        [EQ01_PREFIX, "EQ01"],
+        [
+          ...sharedQuoteBody,
+          { name: "signature", binary: "bytes", size: 65, custom: hexConversion },
+        ],
+      ],
+      [[EQ02_PREFIX, "EQ02"], sharedQuoteBody],
+    ],
+  },
+] as const satisfies Layout;
+
+export type SignedQuote = DeriveType<typeof signedQuoteLayout>;
+
+export function deserializeSignedQuote(
+  signedQuoteBytes: `0x${string}`,
+): SignedQuote {
+  return deserialize(signedQuoteLayout, ethers.getBytes(signedQuoteBytes));
+}
+
+// ── Relay instructions ─────────────────────────────────────────────────────
+
+export const gasInstructionLayout = [
+  { name: "gasLimit", binary: "uint", size: 16 },
+  { name: "msgValue", binary: "uint", size: 16 },
+] as const satisfies Layout;
+
+export const gasDropOffInstructionLayout = [
+  { name: "dropOff", binary: "uint", size: 16 },
+  { name: "recipient", binary: "bytes", size: 32, custom: hexConversion },
+] as const satisfies Layout;
+
+export const relayInstructionLayout = [
+  {
+    name: "request",
+    binary: "switch",
+    idSize: 1,
+    idTag: "type",
+    layouts: [
+      [[1, "GasInstruction"], gasInstructionLayout],
+      [[2, "GasDropOffInstruction"], gasDropOffInstructionLayout],
+    ],
+  },
+] as const satisfies Layout;
+
+export const relayInstructionsLayout = [
+  { name: "requests", binary: "array", layout: relayInstructionLayout },
+] as const satisfies Layout;
+
+export type RelayInstructions = DeriveType<typeof relayInstructionsLayout>;
+
+/** Decode a relay-instructions hex blob into structured form. */
+export function deserializeRelayInstructions(
+  hex: `0x${string}`,
+): RelayInstructions {
+  return deserialize(relayInstructionsLayout, ethers.getBytes(hex));
+}
+
+// ── Request (the per-protocol payload) ─────────────────────────────────────
+
+export enum RequestPrefix {
+  ERV1 = "ERV1", // VAA_V1   (chain + emitter + sequence) — onboarding / register-peer → Sequencer
+  ERN1 = "ERN1", // NTT_V1   (srcChain + srcManager + messageId) — NTT transfer
+}
+
+export const vaaV1RequestLayout = [
+  { name: "chain", binary: "uint", size: 2 },
+  { name: "address", binary: "bytes", size: 32, custom: hexConversion },
+  { name: "sequence", binary: "uint", size: 8 },
+] as const satisfies Layout;
+
+export type VAAv1Request = DeriveType<typeof vaaV1RequestLayout>;
+
+export const nttV1RequestLayout = [
+  { name: "srcChain", binary: "uint", size: 2 },
+  { name: "srcManager", binary: "bytes", size: 32, custom: hexConversion },
+  { name: "messageId", binary: "bytes", size: 32, custom: hexConversion },
+] as const satisfies Layout;
+
+export type NTTv1Request = DeriveType<typeof nttV1RequestLayout>;
+
+export const requestLayout = [
+  {
+    name: "request",
+    binary: "switch",
+    idSize: 4,
+    idTag: "prefix",
+    layouts: [
+      [[0x45525631, RequestPrefix.ERV1], vaaV1RequestLayout],
+      [[0x45524e31, RequestPrefix.ERN1], nttV1RequestLayout],
+    ],
+  },
+] as const satisfies Layout;
+
+export type RequestLayout = DeriveType<typeof requestLayout>;
+
+export function serializeRequest(instruction: RequestLayout): `0x${string}` {
+  return ethers.hexlify(serialize(requestLayout, instruction)) as `0x${string}`;
+}
+
+export function deserializeRequest(requestBytes: `0x${string}`): RequestLayout {
+  return deserialize(requestLayout, ethers.getBytes(requestBytes));
+}
+
+// ── RequestForExecution envelope (version 0) ───────────────────────────────
+
+export const REQUEST_FOR_EXECUTION_VERSION_0 = 0;
+
+const requestForExecutionV0Layout = [
+  { name: "dstChain", binary: "uint", size: 2 },
+  { name: "dstAddr", binary: "bytes", size: 32, custom: hexConversion },
+  { name: "refundAddr", binary: "bytes", size: 20, custom: hexConversion },
+  { name: "signedQuote", binary: "bytes", lengthSize: 2, layout: signedQuoteLayout },
+  { name: "requestBytes", binary: "bytes", lengthSize: 2, layout: requestLayout },
+  {
+    name: "relayInstructions",
+    binary: "bytes",
+    lengthSize: 2,
+    layout: relayInstructionsLayout,
+  },
+] as const satisfies Layout;
+
+export const requestForExecutionLayout = [
+  {
+    name: "payload",
+    binary: "switch",
+    idSize: 1,
+    idTag: "version",
+    layouts: [[[REQUEST_FOR_EXECUTION_VERSION_0, 0], requestForExecutionV0Layout]],
+  },
+] as const satisfies Layout;
+
+export type RequestForExecution = DeriveType<typeof requestForExecutionLayout>;
+
+export function serializeRequestForExecution(
+  request: RequestForExecution,
+): `0x${string}` {
+  return ethers.hexlify(serialize(requestForExecutionLayout, request)) as `0x${string}`;
+}
+
+export function deserializeRequestForExecution(
+  data: `0x${string}`,
+): RequestForExecution {
+  return deserialize(requestForExecutionLayout, ethers.getBytes(data));
+}
+
+/**
+ * Encode a GasInstruction relay instruction to hex.
+ * Format: 0x01 + gasLimit(16 bytes BE) + msgValue(16 bytes BE)
+ */
+export function buildGasInstructionHex(
+  gasLimit: bigint,
+  msgValue: bigint,
+): `0x${string}` {
+  const buf = Buffer.alloc(33);
+  buf[0] = 0x01; // GasInstruction type ID
+  buf.writeBigUInt64BE(0n, 1); // upper 8 bytes of 16-byte gasLimit
+  buf.writeBigUInt64BE(gasLimit, 9);
+  buf.writeBigUInt64BE(0n, 17); // upper 8 bytes of 16-byte msgValue
+  buf.writeBigUInt64BE(msgValue, 25);
+  return `0x${buf.toString("hex")}`;
+}

--- a/cli/src/xrpl/executorLayouts.ts
+++ b/cli/src/xrpl/executorLayouts.ts
@@ -48,7 +48,12 @@ export const signedQuoteLayout = [
         [EQ01_PREFIX, "EQ01"],
         [
           ...sharedQuoteBody,
-          { name: "signature", binary: "bytes", size: 65, custom: hexConversion },
+          {
+            name: "signature",
+            binary: "bytes",
+            size: 65,
+            custom: hexConversion,
+          },
         ],
       ],
       [[EQ02_PREFIX, "EQ02"], sharedQuoteBody],
@@ -59,7 +64,7 @@ export const signedQuoteLayout = [
 export type SignedQuote = DeriveType<typeof signedQuoteLayout>;
 
 export function deserializeSignedQuote(
-  signedQuoteBytes: `0x${string}`,
+  signedQuoteBytes: `0x${string}`
 ): SignedQuote {
   return deserialize(signedQuoteLayout, ethers.getBytes(signedQuoteBytes));
 }
@@ -97,7 +102,7 @@ export type RelayInstructions = DeriveType<typeof relayInstructionsLayout>;
 
 /** Decode a relay-instructions hex blob into structured form. */
 export function deserializeRelayInstructions(
-  hex: `0x${string}`,
+  hex: `0x${string}`
 ): RelayInstructions {
   return deserialize(relayInstructionsLayout, ethers.getBytes(hex));
 }
@@ -156,8 +161,18 @@ const requestForExecutionV0Layout = [
   { name: "dstChain", binary: "uint", size: 2 },
   { name: "dstAddr", binary: "bytes", size: 32, custom: hexConversion },
   { name: "refundAddr", binary: "bytes", size: 20, custom: hexConversion },
-  { name: "signedQuote", binary: "bytes", lengthSize: 2, layout: signedQuoteLayout },
-  { name: "requestBytes", binary: "bytes", lengthSize: 2, layout: requestLayout },
+  {
+    name: "signedQuote",
+    binary: "bytes",
+    lengthSize: 2,
+    layout: signedQuoteLayout,
+  },
+  {
+    name: "requestBytes",
+    binary: "bytes",
+    lengthSize: 2,
+    layout: requestLayout,
+  },
   {
     name: "relayInstructions",
     binary: "bytes",
@@ -172,20 +187,24 @@ export const requestForExecutionLayout = [
     binary: "switch",
     idSize: 1,
     idTag: "version",
-    layouts: [[[REQUEST_FOR_EXECUTION_VERSION_0, 0], requestForExecutionV0Layout]],
+    layouts: [
+      [[REQUEST_FOR_EXECUTION_VERSION_0, 0], requestForExecutionV0Layout],
+    ],
   },
 ] as const satisfies Layout;
 
 export type RequestForExecution = DeriveType<typeof requestForExecutionLayout>;
 
 export function serializeRequestForExecution(
-  request: RequestForExecution,
+  request: RequestForExecution
 ): `0x${string}` {
-  return ethers.hexlify(serialize(requestForExecutionLayout, request)) as `0x${string}`;
+  return ethers.hexlify(
+    serialize(requestForExecutionLayout, request)
+  ) as `0x${string}`;
 }
 
 export function deserializeRequestForExecution(
-  data: `0x${string}`,
+  data: `0x${string}`
 ): RequestForExecution {
   return deserialize(requestForExecutionLayout, ethers.getBytes(data));
 }
@@ -196,7 +215,7 @@ export function deserializeRequestForExecution(
  */
 export function buildGasInstructionHex(
   gasLimit: bigint,
-  msgValue: bigint,
+  msgValue: bigint
 ): `0x${string}` {
   const buf = Buffer.alloc(33);
   buf[0] = 0x01; // GasInstruction type ID

--- a/cli/src/xrpl/guardian.ts
+++ b/cli/src/xrpl/guardian.ts
@@ -1,0 +1,70 @@
+// Thin client for the Guardian / Wormholescan signed-VAA API.
+//
+// Ported from ripple/xrpl-client/src/integration/fetch-vaa.ts. The guardian
+// watcher synthesizes a VAA from an XRPL payment; this fetches it by
+// (chain, emitter, sequence) and polls until it is available.
+
+export const DEFAULT_GUARDIAN_API = "https://api.testnet.wormholescan.io";
+
+export const CHAIN_ID_XRPL = 66;
+
+/**
+ * Build the signed-VAA URL for a (chain, emitter, sequence) tuple.
+ * emitter is a 64-char hex string (no 0x).
+ */
+export function signedVaaUrl(
+  guardianApi: string,
+  chain: number,
+  emitterHex: string,
+  sequence: bigint,
+): string {
+  return `${guardianApi}/v1/signed_vaa/${chain}/${emitterHex}/${sequence}`;
+}
+
+/** Fetch a signed VAA once; returns base64 vaaBytes or null if not yet available. */
+export async function fetchSignedVaaOnce(
+  url: string,
+): Promise<string | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const data = (await res.json()) as { vaaBytes?: string };
+    return data.vaaBytes ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Poll the guardian API for a signed VAA until it appears or timeout. */
+export async function pollSignedVaa(opts: {
+  guardianApi: string;
+  chain: number;
+  emitterHex: string;
+  sequence: bigint;
+  pollIntervalMs?: number;
+  pollTimeoutMs?: number;
+  onAttempt?: (attempt: number, url: string) => void;
+}): Promise<string> {
+  const {
+    guardianApi,
+    chain,
+    emitterHex,
+    sequence,
+    pollIntervalMs = 5_000,
+    pollTimeoutMs = 120_000,
+  } = opts;
+  const url = signedVaaUrl(guardianApi, chain, emitterHex, sequence);
+
+  const start = Date.now();
+  let attempt = 0;
+  while (Date.now() - start < pollTimeoutMs) {
+    attempt++;
+    opts.onAttempt?.(attempt, url);
+    const vaa = await fetchSignedVaaOnce(url);
+    if (vaa) return vaa;
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+  throw new Error(
+    `VAA not found after ${Math.round(pollTimeoutMs / 1000)}s (${attempt} attempts): ${url}`,
+  );
+}

--- a/cli/src/xrpl/guardian.ts
+++ b/cli/src/xrpl/guardian.ts
@@ -16,15 +16,13 @@ export function signedVaaUrl(
   guardianApi: string,
   chain: number,
   emitterHex: string,
-  sequence: bigint,
+  sequence: bigint
 ): string {
   return `${guardianApi}/v1/signed_vaa/${chain}/${emitterHex}/${sequence}`;
 }
 
 /** Fetch a signed VAA once; returns base64 vaaBytes or null if not yet available. */
-export async function fetchSignedVaaOnce(
-  url: string,
-): Promise<string | null> {
+export async function fetchSignedVaaOnce(url: string): Promise<string | null> {
   try {
     const res = await fetch(url);
     if (!res.ok) return null;
@@ -65,6 +63,6 @@ export async function pollSignedVaa(opts: {
     await new Promise((r) => setTimeout(r, pollIntervalMs));
   }
   throw new Error(
-    `VAA not found after ${Math.round(pollTimeoutMs / 1000)}s (${attempt} attempts): ${url}`,
+    `VAA not found after ${Math.round(pollTimeoutMs / 1000)}s (${attempt} attempts): ${url}`
   );
 }

--- a/cli/src/xrpl/helpers.ts
+++ b/cli/src/xrpl/helpers.ts
@@ -11,6 +11,7 @@ import type {
   Network,
   WormholeConfigOverrides,
 } from "@wormhole-foundation/sdk-connect";
+import { toChainId, type Chain } from "@wormhole-foundation/sdk";
 import { colors } from "../colors.js";
 
 /** Default public XRPL WebSocket endpoints, keyed by Wormhole network. */
@@ -263,6 +264,13 @@ export function normalizeCurrency(code: string): string {
   throw new Error(
     `Invalid currency '${code}': expected a 3-character code or a 40-character hex code`
   );
+}
+
+/** Resolve a chain reference (Wormhole chain name or numeric id) to a chain id. */
+export function resolveChainId(value: string | number): number {
+  if (typeof value === "number") return value;
+  if (/^\d+$/.test(value)) return parseInt(value, 10);
+  return toChainId(value as Chain);
 }
 
 /** Run a command body, printing errors in the CLI's style and exiting 1. */

--- a/cli/src/xrpl/helpers.ts
+++ b/cli/src/xrpl/helpers.ts
@@ -3,6 +3,7 @@ import {
   Client,
   ECDSA,
   Wallet,
+  isValidClassicAddress,
   type SubmittableTransaction,
   type TxResponse,
 } from "xrpl";
@@ -72,6 +73,29 @@ export async function submitTx(
     );
   }
   return result;
+}
+
+/** Throw unless `address` is a valid XRPL classic (r-) address. */
+export function validateRAddress(address: string): string {
+  if (!isValidClassicAddress(address)) {
+    throw new Error(`Invalid XRPL address: ${address}`);
+  }
+  return address;
+}
+
+/**
+ * Account reserve settings from the connected server (in XRP): the base reserve
+ * plus the per-owned-object increment.
+ */
+export async function getReserveBase(
+  client: Client
+): Promise<{ baseXrp: number; incXrp: number }> {
+  const info = await client.request({ command: "server_info" });
+  const ledger = info.result.info.validated_ledger;
+  if (!ledger?.reserve_base_xrp || ledger.reserve_inc_xrp === undefined) {
+    throw new Error("Could not read reserve settings from server_info");
+  }
+  return { baseXrp: ledger.reserve_base_xrp, incXrp: ledger.reserve_inc_xrp };
 }
 
 /** Derive a wallet from a seed, optionally forcing the key algorithm. */

--- a/cli/src/xrpl/helpers.ts
+++ b/cli/src/xrpl/helpers.ts
@@ -20,6 +20,12 @@ export const XRPL_ENDPOINTS: Record<Network, string> = {
   Devnet: "wss://s.devnet.rippletest.net:51233",
 };
 
+/** Public XRPL faucet hosts (testnet/devnet only). */
+export const XRPL_FAUCET_HOSTS: Partial<Record<Network, string>> = {
+  Testnet: "faucet.altnet.rippletest.net",
+  Devnet: "faucet.devnet.rippletest.net",
+};
+
 /**
  * Resolve the XRPL endpoint to connect to. Precedence:
  *   --rpc flag  >  overrides.json (chains.Xrpl.rpc)  >  built-in network default.

--- a/cli/src/xrpl/helpers.ts
+++ b/cli/src/xrpl/helpers.ts
@@ -1,0 +1,248 @@
+import fs from "fs";
+import {
+  Client,
+  ECDSA,
+  Wallet,
+  type SubmittableTransaction,
+  type TxResponse,
+} from "xrpl";
+import type {
+  Network,
+  WormholeConfigOverrides,
+} from "@wormhole-foundation/sdk-connect";
+import { colors } from "../colors.js";
+
+/** Default public XRPL WebSocket endpoints, keyed by Wormhole network. */
+export const XRPL_ENDPOINTS: Record<Network, string> = {
+  Mainnet: "wss://xrplcluster.com",
+  Testnet: "wss://s.altnet.rippletest.net:51233",
+  Devnet: "wss://s.devnet.rippletest.net:51233",
+};
+
+/**
+ * Resolve the XRPL endpoint to connect to. Precedence:
+ *   --rpc flag  >  overrides.json (chains.Xrpl.rpc)  >  built-in network default.
+ */
+export function resolveXrplEndpoint(
+  network: Network,
+  rpcOverride?: string,
+  overrides?: WormholeConfigOverrides<Network>
+): string {
+  if (rpcOverride) return rpcOverride;
+  // `Xrpl` may not be a typed chain key in the SDK; access defensively.
+  const fromOverrides = (overrides?.chains as any)?.Xrpl?.rpc as
+    | string
+    | undefined;
+  if (fromOverrides) return fromOverrides;
+  return XRPL_ENDPOINTS[network];
+}
+
+/** Connect a client to `endpoint`, run `fn`, and always disconnect afterwards. */
+export async function withXrplClient<T>(
+  endpoint: string,
+  fn: (client: Client) => Promise<T>
+): Promise<T> {
+  const client = new Client(endpoint);
+  await client.connect();
+  try {
+    return await fn(client);
+  } finally {
+    await client.disconnect();
+  }
+}
+
+/**
+ * Autofill, sign, and submit a transaction, waiting for validation.
+ * Throws if the engine result is anything other than `tesSUCCESS`.
+ */
+export async function submitTx(
+  client: Client,
+  wallet: Wallet,
+  tx: SubmittableTransaction
+): Promise<TxResponse> {
+  const prepared = await client.autofill(tx);
+  const signed = wallet.sign(prepared);
+  const result = await client.submitAndWait(signed.tx_blob);
+  const meta = result.result.meta;
+  const code =
+    meta && typeof meta !== "string" ? meta.TransactionResult : undefined;
+  if (code !== "tesSUCCESS") {
+    throw new Error(
+      `${tx.TransactionType} failed: ${code ?? "unknown result"} (hash ${result.result.hash})`
+    );
+  }
+  return result;
+}
+
+/** Derive a wallet from a seed, optionally forcing the key algorithm. */
+export function walletFromSeed(
+  seed: string,
+  algorithm?: "ed25519" | "secp256k1"
+): Wallet {
+  const algo =
+    algorithm === "ed25519"
+      ? ECDSA.ed25519
+      : algorithm === "secp256k1"
+        ? ECDSA.secp256k1
+        : undefined;
+  return Wallet.fromSeed(seed, algo ? { algorithm: algo } : undefined);
+}
+
+/** Read a seed from a flag value, falling back to an environment variable. */
+export function loadSeed(
+  flagValue: string | undefined,
+  flagName: string,
+  envName: string
+): string {
+  const seed = flagValue ?? process.env[envName];
+  if (!seed) {
+    throw new Error(
+      `Missing seed: pass --${flagName} or set ${envName} in the environment`
+    );
+  }
+  return seed;
+}
+
+/** MPT issuance flags (see xrpl.org MPTokenIssuanceCreate). */
+export const MPT_FLAGS = {
+  tfMPTCanLock: 0x0002, // issuer can lock/freeze individual holders
+  tfMPTRequireAuth: 0x0004, // issuer must authorise each holder
+  tfMPTCanEscrow: 0x0008, // tokens can be escrowed
+  tfMPTCanTrade: 0x0010, // tokens can be placed on the DEX
+  tfMPTCanTransfer: 0x0020, // holders can transfer (omit = issuer-only)
+  tfMPTCanClawback: 0x0040, // issuer can claw back tokens from holders
+} as const;
+
+// MPTokenIssuanceCreate field limits (per the XRPL protocol reference).
+export const MPT_MAX_ASSET_SCALE = 255; // UInt8
+export const MPT_MAX_TRANSFER_FEE = 50_000; // tenths of a basis point (= 50%)
+export const MPT_MAX_METADATA_BYTES = 1024;
+export const MPT_MAX_AMOUNT = 2n ** 63n - 1n; // UInt64 ceiling for MaximumAmount
+
+/**
+ * Validate MPTokenIssuanceCreate parameters client-side so we fail with a clear
+ * message instead of an opaque XRPL `tem...` engine result.
+ */
+export function validateMptIssuanceParams(params: {
+  assetScale: number;
+  transferFee: number;
+  flags: number;
+  maxAmount?: string;
+}): void {
+  const { assetScale, transferFee, flags, maxAmount } = params;
+
+  if (
+    !Number.isInteger(assetScale) ||
+    assetScale < 0 ||
+    assetScale > MPT_MAX_ASSET_SCALE
+  ) {
+    throw new Error(
+      `--asset-scale must be an integer between 0 and ${MPT_MAX_ASSET_SCALE}`
+    );
+  }
+
+  if (
+    !Number.isInteger(transferFee) ||
+    transferFee < 0 ||
+    transferFee > MPT_MAX_TRANSFER_FEE
+  ) {
+    throw new Error(
+      `--transfer-fee must be an integer between 0 and ${MPT_MAX_TRANSFER_FEE} (tenths of a basis point; ${MPT_MAX_TRANSFER_FEE} = 50%)`
+    );
+  }
+
+  if (transferFee > 0 && !(flags & MPT_FLAGS.tfMPTCanTransfer)) {
+    throw new Error(
+      "--transfer-fee can only be set when the tfMPTCanTransfer flag is enabled"
+    );
+  }
+
+  if (maxAmount !== undefined) {
+    if (!/^\d+$/.test(maxAmount)) {
+      throw new Error("--max-amount must be a non-negative integer (UInt64)");
+    }
+    const value = BigInt(maxAmount);
+    if (value === 0n) {
+      throw new Error("--max-amount must be greater than 0");
+    }
+    if (value > MPT_MAX_AMOUNT) {
+      throw new Error(`--max-amount exceeds the maximum (2^63 - 1)`);
+    }
+  }
+}
+
+/**
+ * Parse a comma-separated list of MPT flag names (or raw integers) into the
+ * combined `Flags` bitfield. e.g. "tfMPTCanTransfer,tfMPTCanClawback" or "96".
+ */
+export function parseMptFlags(input?: string): number {
+  if (!input) return 0;
+  let flags = 0;
+  for (const raw of input.split(",")) {
+    const token = raw.trim();
+    if (token === "") continue;
+    if (token in MPT_FLAGS) {
+      flags |= MPT_FLAGS[token as keyof typeof MPT_FLAGS];
+    } else if (/^(0x[0-9a-fA-F]+|\d+)$/.test(token)) {
+      flags |= Number(token);
+    } else {
+      throw new Error(
+        `Unknown MPT flag '${token}'. Valid flags: ${Object.keys(
+          MPT_FLAGS
+        ).join(", ")}, or a raw integer.`
+      );
+    }
+  }
+  return flags;
+}
+
+/**
+ * Resolve `--metadata-json` (inline JSON string or a path to a .json file)
+ * into the uppercase hex string expected by `MPTokenMetadata`.
+ */
+export function loadMetadataHex(input?: string): string | undefined {
+  if (!input) return undefined;
+  const jsonStr = fs.existsSync(input) ? fs.readFileSync(input, "utf8") : input;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch {
+    throw new Error(
+      "--metadata-json must be valid JSON (inline) or a path to a .json file"
+    );
+  }
+  // Stored as a UTF-8 blob with minimal whitespace; XRPL caps it at 1024 bytes.
+  const bytes = Buffer.from(JSON.stringify(parsed));
+  if (bytes.length > MPT_MAX_METADATA_BYTES) {
+    throw new Error(
+      `--metadata-json is ${bytes.length} bytes; the MPTokenMetadata limit is ${MPT_MAX_METADATA_BYTES} bytes`
+    );
+  }
+  return bytes.toString("hex").toUpperCase();
+}
+
+/**
+ * Validate/normalise an IOU currency code: a 3-character ASCII code or a
+ * 40-character hex code (for non-standard codes like RLUSD).
+ */
+export function normalizeCurrency(code: string): string {
+  if (code.length === 3) return code;
+  if (code.length === 40 && /^[0-9a-fA-F]{40}$/.test(code)) {
+    return code.toUpperCase();
+  }
+  throw new Error(
+    `Invalid currency '${code}': expected a 3-character code or a 40-character hex code`
+  );
+}
+
+/** Run a command body, printing errors in the CLI's style and exiting 1. */
+export async function runXrpl(fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    console.error(
+      colors.red(`Error: ${err instanceof Error ? err.message : String(err)}`)
+    );
+    process.exit(1);
+  }
+}

--- a/cli/src/xrpl/manager-set.ts
+++ b/cli/src/xrpl/manager-set.ts
@@ -1,0 +1,94 @@
+import { ethers } from "ethers";
+import { decodeAccountID, deriveAddress } from "xrpl";
+
+// Fetches the Wormhole "delegated manager set" — the set of signer keys that
+// controls an XRPL custody account — from an EVM contract, and turns it into
+// XRPL signer entries. (This is the per-deployment delegated manager set, not
+// the canonical Wormhole guardian set.) Mirrors xrpl-scripts/guardian-manager.ts
+// (which uses viem) and xrpl-scripts/pks_to_accts.ts, using ethers to match the
+// rest of this CLI.
+
+export type ManagerSet = {
+  mThreshold: number;
+  nTotal: number;
+  pubkeys: Buffer[]; // 33-byte compressed secp256k1 keys
+};
+
+export type SignerEntry = {
+  SignerEntry: { Account: string; SignerWeight: number };
+};
+
+const GET_MANAGER_SET_ABI = [
+  "function getManagerSet(uint16 chainId, uint32 index) view returns (bytes)",
+];
+
+/**
+ * Parse the delegated manager set wire format (see Wormhole whitepaper 0016,
+ * delegated-manager governance):
+ *   [0] version (== 1), [1] mThreshold, [2] nTotal, [3..] nTotal × 33-byte pubkeys.
+ */
+export function parseManagerSet(bytes: Buffer): ManagerSet {
+  if (bytes[0] !== 1) {
+    throw new Error(`Unsupported manager set version: ${bytes[0]}`);
+  }
+  const mThreshold = bytes[1];
+  const nTotal = bytes[2];
+  const rest = bytes.subarray(3);
+  if (rest.length !== nTotal * 33) {
+    throw new Error(
+      `Manager set pubkey data is ${rest.length} bytes; expected ${nTotal} × 33`
+    );
+  }
+
+  const pubkeys: Buffer[] = [];
+  for (let i = 0; i < nTotal; i++) {
+    pubkeys.push(Buffer.from(rest.subarray(i * 33, i * 33 + 33)));
+  }
+  return { mThreshold, nTotal, pubkeys };
+}
+
+/**
+ * Read the delegated manager set for `chainId`/`index` from the EVM contract.
+ */
+export async function fetchDelegatedManagerSet(
+  chainId: number,
+  index: number,
+  rpcUrl: string,
+  address: string
+): Promise<ManagerSet> {
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const contract = new ethers.Contract(address, GET_MANAGER_SET_ABI, provider);
+  const hex: string = await contract.getManagerSet(chainId, index);
+  return parseManagerSet(Buffer.from(ethers.getBytes(hex)));
+}
+
+/** Sort signer entries by account ID — required by XRPL for SignerListSet. */
+function sortByAccountId(entries: SignerEntry[]): SignerEntry[] {
+  return entries.sort((a, b) =>
+    Buffer.compare(
+      Buffer.from(decodeAccountID(a.SignerEntry.Account)),
+      Buffer.from(decodeAccountID(b.SignerEntry.Account))
+    )
+  );
+}
+
+/** Derive sorted XRPL signer entries (weight 1) from compressed secp256k1 pubkeys. */
+export function deriveSignerEntries(pubkeys: Buffer[]): SignerEntry[] {
+  return sortByAccountId(
+    pubkeys.map((pk) => ({
+      SignerEntry: {
+        Account: deriveAddress(pk.toString("hex").toUpperCase()),
+        SignerWeight: 1,
+      },
+    }))
+  );
+}
+
+/** Build sorted XRPL signer entries (weight 1) from explicit r-addresses. */
+export function signerEntriesFromAddresses(addresses: string[]): SignerEntry[] {
+  return sortByAccountId(
+    addresses.map((a) => ({
+      SignerEntry: { Account: a.trim(), SignerWeight: 1 },
+    }))
+  );
+}

--- a/cli/src/xrpl/manager-set.ts
+++ b/cli/src/xrpl/manager-set.ts
@@ -8,18 +8,24 @@ import { decodeAccountID, deriveAddress } from "xrpl";
 // (which uses viem) and xrpl-scripts/pks_to_accts.ts, using ethers to match the
 // rest of this CLI.
 
-export type ManagerSet = {
+export type ParsedManagerSet = {
   mThreshold: number;
   nTotal: number;
   pubkeys: Buffer[]; // 33-byte compressed secp256k1 keys
+};
+
+export type ManagerSet = ParsedManagerSet & {
+  /** The resolved set index (meaningful when "latest" was requested). */
+  index: number;
 };
 
 export type SignerEntry = {
   SignerEntry: { Account: string; SignerWeight: number };
 };
 
-const GET_MANAGER_SET_ABI = [
+const MANAGER_SET_ABI = [
   "function getManagerSet(uint16 chainId, uint32 index) view returns (bytes)",
+  "function getCurrentManagerSetIndex(uint16 chainId) view returns (uint32)",
 ];
 
 /**
@@ -27,7 +33,7 @@ const GET_MANAGER_SET_ABI = [
  * delegated-manager governance):
  *   [0] version (== 1), [1] mThreshold, [2] nTotal, [3..] nTotal × 33-byte pubkeys.
  */
-export function parseManagerSet(bytes: Buffer): ManagerSet {
+export function parseManagerSet(bytes: Buffer): ParsedManagerSet {
   if (bytes[0] !== 1) {
     throw new Error(`Unsupported manager set version: ${bytes[0]}`);
   }
@@ -48,18 +54,26 @@ export function parseManagerSet(bytes: Buffer): ManagerSet {
 }
 
 /**
- * Read the delegated manager set for `chainId`/`index` from the EVM contract.
+ * Read the delegated manager set for `chainId` from the EVM contract. Pass a
+ * specific `index`, or "latest" to resolve the current index on-chain.
  */
 export async function fetchDelegatedManagerSet(
   chainId: number,
-  index: number,
+  index: number | "latest",
   rpcUrl: string,
   address: string
 ): Promise<ManagerSet> {
   const provider = new ethers.JsonRpcProvider(rpcUrl);
-  const contract = new ethers.Contract(address, GET_MANAGER_SET_ABI, provider);
-  const hex: string = await contract.getManagerSet(chainId, index);
-  return parseManagerSet(Buffer.from(ethers.getBytes(hex)));
+  const contract = new ethers.Contract(address, MANAGER_SET_ABI, provider);
+  const resolvedIndex =
+    index === "latest"
+      ? Number(await contract.getCurrentManagerSetIndex(chainId))
+      : index;
+  const hex: string = await contract.getManagerSet(chainId, resolvedIndex);
+  return {
+    index: resolvedIndex,
+    ...parseManagerSet(Buffer.from(ethers.getBytes(hex))),
+  };
 }
 
 /** Sort signer entries by account ID — required by XRPL for SignerListSet. */

--- a/cli/src/xrpl/onboarding.ts
+++ b/cli/src/xrpl/onboarding.ts
@@ -1,0 +1,142 @@
+import { decodeAccountID } from "xrpl";
+
+// XRPLAppOnboarding payload builders. Mirrors the reference scripts
+// (xrpl-scripts/init_iou.ts, init_mpt.ts) and the SPEC app-onboarding flow:
+// https://github.com/wormholelabs-xyz/ripple/blob/main/SPEC.md#app-onboarding-flow
+
+/** "XRPL" prefix (0x5852504C) identifying an onboarding payload. */
+export const XRPL_ONBOARDING_PREFIX = "5852504C";
+
+/** MemoFormat used to publish a Wormhole message via an XRPL transfer. */
+export const WORMHOLE_PUBLISH_MEMO_FORMAT = "application/x-wormhole-publish";
+
+/** Wormhole Core (GMP) account on XRPL Testnet that Guardians watch. */
+export const DEFAULT_TESTNET_CORE_ACCOUNT = "rpuMNy2dBzimaQHTFpXsfoCoqicgd8etQQ";
+
+const TOKEN_TYPE_IOU = "01";
+const TOKEN_TYPE_MPT = "02";
+
+// Size (in bytes) the token_id portion of init_data is right-padded to.
+const TOKEN_ID_PADDED_BYTES = 42;
+
+export type TokenInit =
+  | { type: "xrp" }
+  | { type: "iou"; currency: string; issuer: string }
+  | { type: "mpt"; mptId: string };
+
+/** Encode a non-negative integer as a 1-byte (2 hex char) value. */
+function u8Hex(n: number): string {
+  if (!Number.isInteger(n) || n < 0 || n > 0xff) {
+    throw new Error(`value ${n} does not fit in one unsigned byte`);
+  }
+  return n.toString(16).padStart(2, "0");
+}
+
+/** Encode a non-negative integer as a big-endian 8-byte (16 hex char) value. */
+function u64Hex(n: number): string {
+  if (!Number.isInteger(n) || n < 0) {
+    throw new Error(`value ${n} must be a non-negative integer`);
+  }
+  return BigInt(n).toString(16).padStart(16, "0");
+}
+
+/** Decode an XRPL r-address to its 20-byte account ID (40 hex chars). */
+function accountIdHex(rAddress: string): string {
+  return Buffer.from(decodeAccountID(rAddress)).toString("hex");
+}
+
+/** Right-pad a hex string to `bytes` bytes with zeros. */
+function padRight(hex: string, bytes: number): string {
+  const target = bytes * 2;
+  if (hex.length > target) {
+    throw new Error(`hex value is ${hex.length / 2} bytes, exceeds ${bytes}`);
+  }
+  return hex.padEnd(target, "0");
+}
+
+/**
+ * Encode an IOU currency code as a 40-char hex (20-byte) value.
+ * Accepts a 40-char hex code directly, or a 1-3 char ASCII code (standard
+ * format: ASCII placed at bytes 12-14, zeros elsewhere).
+ */
+export function currencyToHex40(currency: string): string {
+  if (currency.length === 40 && /^[0-9a-fA-F]{40}$/.test(currency)) {
+    return currency.toLowerCase();
+  }
+  if (currency.length >= 1 && currency.length <= 3) {
+    const buf = Buffer.alloc(20);
+    for (let i = 0; i < currency.length; i++) {
+      buf[12 + i] = currency.charCodeAt(i);
+    }
+    return buf.toString("hex");
+  }
+  throw new Error(
+    `Invalid currency '${currency}': expected a 3-char ASCII code or a 40-char hex code`
+  );
+}
+
+/**
+ * Build the NTT/WTT `init_data` tail (hex, no 0x prefix):
+ *  - xrp: short form — just the decimals byte.
+ *  - iou: decimals byte + (0x01 + currency[20] + issuer[20]) right-padded to 42 bytes.
+ *  - mpt: decimals byte + (0x02 + mpt_issuance_id[24]) right-padded to 42 bytes.
+ */
+export function buildInitData(decimals: number, token: TokenInit): string {
+  const dec = u8Hex(decimals);
+  switch (token.type) {
+    case "xrp":
+      return dec;
+    case "iou": {
+      const currency = currencyToHex40(token.currency);
+      const issuer = accountIdHex(token.issuer);
+      return (
+        dec + padRight(TOKEN_TYPE_IOU + currency + issuer, TOKEN_ID_PADDED_BYTES)
+      );
+    }
+    case "mpt": {
+      if (!/^[0-9a-fA-F]{48}$/.test(token.mptId)) {
+        throw new Error("expected mpt issuance id length of 48 (hex)");
+      }
+      return (
+        dec +
+        padRight(TOKEN_TYPE_MPT + token.mptId.toLowerCase(), TOKEN_ID_PADDED_BYTES)
+      );
+    }
+  }
+}
+
+/**
+ * Build the XRPLAppOnboarding payload (hex, no 0x prefix):
+ *   prefix("XRPL")[4] + admin[20] + app(left-padded)[32] + initial_ticket[8] +
+ *   ticket_count[8] + init_data
+ */
+export function buildOnboardingPayload(params: {
+  admin: string;
+  app: string;
+  initialTicket: number;
+  ticketCount: number;
+  initData: string;
+}): string {
+  const adminHex = accountIdHex(params.admin);
+  const appHex = Buffer.from(params.app, "utf8").toString("hex");
+  if (appHex.length > 64) {
+    throw new Error(`app type '${params.app}' exceeds 32 bytes`);
+  }
+  const appPadded = appHex.padStart(64, "0"); // left-padded to 32 bytes
+  return (
+    XRPL_ONBOARDING_PREFIX +
+    adminHex +
+    appPadded +
+    u64Hex(params.initialTicket) +
+    u64Hex(params.ticketCount) +
+    params.initData
+  );
+}
+
+/**
+ * Wrap an onboarding payload into the publish MemoData: a 1-byte version (0x01)
+ * + 4-byte nonce (0x00000000) + payload, uppercased.
+ */
+export function buildPublishMemoData(payloadHex: string): string {
+  return ("01" + "00000000" + payloadHex).toUpperCase();
+}

--- a/cli/src/xrpl/onboarding.ts
+++ b/cli/src/xrpl/onboarding.ts
@@ -11,7 +11,8 @@ export const XRPL_ONBOARDING_PREFIX = "5852504C";
 export const WORMHOLE_PUBLISH_MEMO_FORMAT = "application/x-wormhole-publish";
 
 /** Wormhole Core (GMP) account on XRPL Testnet that Guardians watch. */
-export const DEFAULT_TESTNET_CORE_ACCOUNT = "rpuMNy2dBzimaQHTFpXsfoCoqicgd8etQQ";
+export const DEFAULT_TESTNET_CORE_ACCOUNT =
+  "rpuMNy2dBzimaQHTFpXsfoCoqicgd8etQQ";
 
 const TOKEN_TYPE_IOU = "01";
 const TOKEN_TYPE_MPT = "02";
@@ -90,7 +91,8 @@ export function buildInitData(decimals: number, token: TokenInit): string {
       const currency = currencyToHex40(token.currency);
       const issuer = accountIdHex(token.issuer);
       return (
-        dec + padRight(TOKEN_TYPE_IOU + currency + issuer, TOKEN_ID_PADDED_BYTES)
+        dec +
+        padRight(TOKEN_TYPE_IOU + currency + issuer, TOKEN_ID_PADDED_BYTES)
       );
     }
     case "mpt": {
@@ -99,7 +101,10 @@ export function buildInitData(decimals: number, token: TokenInit): string {
       }
       return (
         dec +
-        padRight(TOKEN_TYPE_MPT + token.mptId.toLowerCase(), TOKEN_ID_PADDED_BYTES)
+        padRight(
+          TOKEN_TYPE_MPT + token.mptId.toLowerCase(),
+          TOKEN_ID_PADDED_BYTES
+        )
       );
     }
   }

--- a/cli/src/xrpl/payloads.ts
+++ b/cli/src/xrpl/payloads.ts
@@ -1,0 +1,418 @@
+// Decoders for XRPL-Wormhole VAA payloads and the full VAA envelope.
+//
+// Ported from xrpl_accounts/vaa.ts, ripple/xrpl-client/src/onboarding-codec.ts,
+// and the Sequencer payloads (ripple/solana/.../payloads.rs). Keep in sync.
+//
+// Payload prefixes (first 4 bytes, ASCII):
+//   XREL (Sequencer → guardian)  XrplRelease       — assign ticket to inbound transfer
+//   XRFL (Sequencer → guardian)  TicketRefill      — request new tickets
+//   XADM (admin tx)              Admin             — register peer / rotate admin
+//   XRPL (onboarding tx)         XRPLAppOnboarding — onboard a new NTT/WTT app
+//   0x994E5454 ("NTT")           NTT transfer manager payload
+//   0x9945FF10                   Wormhole transceiver message
+
+import { encodeAccountID } from "xrpl";
+
+export const PREFIX_XREL = "XREL";
+export const PREFIX_XRFL = "XRFL";
+export const PREFIX_XADM = "XADM";
+export const PREFIX_XRPL = "XRPL"; // onboarding
+export const PREFIX_XACK = "XACK";
+export const PREFIX_XTCF = "XTCF";
+export const PREFIX_XBRN = "XBRN";
+
+// Non-XRPL prefixes we recognise for nicer output (bytes, not ASCII):
+export const PREFIX_NTT_TRANSFER = "994e5454"; // 0x99 'N' 'T' 'T'
+export const PREFIX_WH_TRANSCEIVER = "9945ff10"; // Wormhole transceiver message
+
+export type ParsedPayload =
+  | ({ kind: "XrplRelease" } & XrelPayload)
+  | ({ kind: "TicketRefill" } & XrflPayload)
+  | ({ kind: "Admin" } & AdminPayload)
+  | ({ kind: "Onboarding" } & OnboardingPayload)
+  | ({ kind: "NttTransfer" } & NttTransferPayload)
+  | { kind: "Unknown"; prefix: string; hex: string };
+
+export interface NttTransferPayload {
+  sourceNttManager: string;
+  recipientNttManager: string;
+  managerPayloadLength: number;
+  id: string;
+  sender: string;
+  decimals: number;
+  amount: bigint;
+  sourceToken: string;
+  recipientAddress: string;
+  recipientChain: number;
+}
+
+export interface XrelPayload {
+  ticketId: bigint;
+  xrplCustodyAccount: string;
+  xrplRecipient: string;
+  amount: bigint;
+  tokenDecimals: number;
+  sourceChain: number;
+  sourceEmitter: string;
+  sourceSequence: bigint;
+  tokenId:
+    | { type: "XRP" }
+    | { type: "IOU"; currency: string; issuer: string }
+    | { type: "MPT"; mptIssuanceId: string };
+  memos: { data: string; format: string; type: string }[];
+}
+
+export interface XrflPayload {
+  xrplAccount: string;
+  useTicket: bigint;
+  requestCount: bigint;
+}
+
+export interface AdminPayload {
+  action: number;
+  actionName: string;
+  targetAccount: string;
+  // RegisterPeer (0x01)
+  chainId?: number;
+  peerAddress?: string;
+  // RotateAdmin (0x02)
+  newAdmin?: string;
+}
+
+export interface OnboardingPayload {
+  admin: string;
+  appType: string;
+  initialTicket: bigint;
+  ticketCount: bigint;
+  initDataHex: string;
+}
+
+function readAscii(buf: Buffer, offset: number, len: number): string {
+  return buf.subarray(offset, offset + len).toString("ascii");
+}
+
+/**
+ * Parse an XREL (XrplRelease) payload.
+ * Layout: prefix[4] ticket[8] custody[20] recipient[20] amount[8]
+ *   decimals[1] chain[2] emitter[32] seq[8] tokenId[1-41] memosLen[2] memos[...]
+ */
+export function parseXrel(buffer: Buffer): XrelPayload {
+  if (buffer.length < 106) {
+    throw new Error(`XREL payload too short: ${buffer.length} bytes (min 106)`);
+  }
+  let offset = 0;
+
+  const prefix = readAscii(buffer, offset, 4);
+  if (prefix !== PREFIX_XREL) {
+    throw new Error(`Invalid XREL prefix: "${prefix}"`);
+  }
+  offset += 4;
+
+  const ticketId = buffer.readBigUInt64BE(offset);
+  offset += 8;
+  const xrplCustodyAccount = encodeAccountID(buffer.subarray(offset, offset + 20));
+  offset += 20;
+  const xrplRecipient = encodeAccountID(buffer.subarray(offset, offset + 20));
+  offset += 20;
+  const amount = buffer.readBigUInt64BE(offset);
+  offset += 8;
+  const tokenDecimals = buffer.readUInt8(offset);
+  offset += 1;
+  const sourceChain = buffer.readUInt16BE(offset);
+  offset += 2;
+  const sourceEmitter = buffer.subarray(offset, offset + 32).toString("hex");
+  offset += 32;
+  const sourceSequence = buffer.readBigUInt64BE(offset);
+  offset += 8;
+
+  const tokenType = buffer.readUInt8(offset);
+  offset += 1;
+  let tokenId: XrelPayload["tokenId"];
+  if (tokenType === 0x00) {
+    tokenId = { type: "XRP" };
+  } else if (tokenType === 0x01) {
+    if (buffer.length < offset + 40) {
+      throw new Error("XREL: insufficient bytes for IOU token");
+    }
+    const currency = buffer.subarray(offset, offset + 20).toString("hex").toUpperCase();
+    offset += 20;
+    const issuer = encodeAccountID(buffer.subarray(offset, offset + 20));
+    offset += 20;
+    tokenId = { type: "IOU", currency, issuer };
+  } else if (tokenType === 0x02) {
+    if (buffer.length < offset + 24) {
+      throw new Error("XREL: insufficient bytes for MPT token");
+    }
+    const mptIssuanceId = buffer.subarray(offset, offset + 24).toString("hex").toUpperCase();
+    offset += 24;
+    tokenId = { type: "MPT", mptIssuanceId };
+  } else {
+    throw new Error(`Unknown XREL token type: 0x${tokenType.toString(16)}`);
+  }
+
+  const memos: XrelPayload["memos"] = [];
+  const memosLen = buffer.readUInt16BE(offset);
+  offset += 2;
+  for (let i = 0; i < memosLen; i++) {
+    const dataLen = buffer.readUInt16BE(offset);
+    offset += 2;
+    const data = buffer.subarray(offset, offset + dataLen).toString("hex");
+    offset += dataLen;
+    const formatLen = buffer.readUInt16BE(offset);
+    offset += 2;
+    const format = buffer.subarray(offset, offset + formatLen).toString("hex");
+    offset += formatLen;
+    const typeLen = buffer.readUInt16BE(offset);
+    offset += 2;
+    const type = buffer.subarray(offset, offset + typeLen).toString("hex");
+    offset += typeLen;
+    memos.push({ data, format, type });
+  }
+
+  return {
+    ticketId,
+    xrplCustodyAccount,
+    xrplRecipient,
+    amount,
+    tokenDecimals,
+    sourceChain,
+    sourceEmitter,
+    sourceSequence,
+    tokenId,
+    memos,
+  };
+}
+
+/** Parse an XRFL (TicketRefill) payload: prefix[4] account[20] useTicket[8] requestCount[8]. */
+export function parseXrfl(buffer: Buffer): XrflPayload {
+  if (buffer.length < 40) {
+    throw new Error(`XRFL payload too short: ${buffer.length} bytes (min 40)`);
+  }
+  const prefix = readAscii(buffer, 0, 4);
+  if (prefix !== PREFIX_XRFL) {
+    throw new Error(`Invalid XRFL prefix: "${prefix}"`);
+  }
+  return {
+    xrplAccount: encodeAccountID(buffer.subarray(4, 24)),
+    useTicket: buffer.readBigUInt64BE(24),
+    requestCount: buffer.readBigUInt64BE(32),
+  };
+}
+
+/**
+ * Parse an XADM (Admin) payload.
+ * prefix[4] action[1] target[20] then action-specific:
+ *   0x01 RegisterPeer: chainId[2] peerAddress[32]
+ *   0x02 RotateAdmin:  newAdmin[20]
+ */
+export function parseAdmin(buffer: Buffer): AdminPayload {
+  if (buffer.length < 25) {
+    throw new Error(`XADM payload too short: ${buffer.length} bytes (min 25)`);
+  }
+  const prefix = readAscii(buffer, 0, 4);
+  if (prefix !== PREFIX_XADM) {
+    throw new Error(`Invalid XADM prefix: "${prefix}"`);
+  }
+  const action = buffer.readUInt8(4);
+  const targetAccount = encodeAccountID(buffer.subarray(5, 25));
+
+  if (action === 0x01) {
+    if (buffer.length < 25 + 2 + 32) {
+      throw new Error("XADM RegisterPeer too short");
+    }
+    return {
+      action,
+      actionName: "RegisterPeer",
+      targetAccount,
+      chainId: buffer.readUInt16BE(25),
+      peerAddress: buffer.subarray(27, 59).toString("hex"),
+    };
+  }
+  if (action === 0x02) {
+    if (buffer.length < 25 + 20) {
+      throw new Error("XADM RotateAdmin too short");
+    }
+    return {
+      action,
+      actionName: "RotateAdmin",
+      targetAccount,
+      newAdmin: encodeAccountID(buffer.subarray(25, 45)),
+    };
+  }
+  return { action, actionName: `Unknown(0x${action.toString(16)})`, targetAccount };
+}
+
+/**
+ * Parse an XRPLAppOnboarding payload.
+ * prefix[4] admin[20] appType[32 left-padded] initialTicket[8] ticketCount[8] initData[var]
+ */
+export function parseOnboarding(buffer: Buffer): OnboardingPayload {
+  if (buffer.length < 72) {
+    throw new Error(`Onboarding payload too short: ${buffer.length} bytes (min 72)`);
+  }
+  const prefix = readAscii(buffer, 0, 4);
+  if (prefix !== PREFIX_XRPL) {
+    throw new Error(`Invalid onboarding prefix: "${prefix}"`);
+  }
+  let offset = 4;
+  const admin = encodeAccountID(buffer.subarray(offset, offset + 20));
+  offset += 20;
+  const appTypeRaw = buffer.subarray(offset, offset + 32);
+  let firstNonZero = 0;
+  while (firstNonZero < 32 && appTypeRaw[firstNonZero] === 0) firstNonZero++;
+  const appType = appTypeRaw.subarray(firstNonZero).toString("utf8");
+  offset += 32;
+  const initialTicket = buffer.readBigUInt64BE(offset);
+  offset += 8;
+  const ticketCount = buffer.readBigUInt64BE(offset);
+  offset += 8;
+  const initDataHex = buffer.subarray(offset).toString("hex");
+
+  return { admin, appType, initialTicket, ticketCount, initDataHex };
+}
+
+/**
+ * Parse a Wormhole transceiver message wrapping an NTT manager payload.
+ *
+ * Layout (see watcher README / NTT Transceiver spec):
+ *   transceiver prefix 0x9945FF10[4]
+ *   source_ntt_manager[32] recipient_ntt_manager[32] manager_payload_len[2]
+ *   manager payload: id[32] sender[32] payload_len[2] ntt prefix 0x994E5454[4]
+ *                    decimals[1] amount[8] source_token[32] recipient[32] recipient_chain[2]
+ */
+export function parseNttTransfer(buffer: Buffer): NttTransferPayload {
+  let offset = 0;
+  const transceiverPrefix = buffer.subarray(0, 4).toString("hex");
+  if (transceiverPrefix !== PREFIX_WH_TRANSCEIVER) {
+    throw new Error(`Invalid transceiver prefix: 0x${transceiverPrefix}`);
+  }
+  offset += 4;
+  const sourceNttManager = buffer.subarray(offset, offset + 32).toString("hex");
+  offset += 32;
+  const recipientNttManager = buffer.subarray(offset, offset + 32).toString("hex");
+  offset += 32;
+  const managerPayloadLength = buffer.readUInt16BE(offset);
+  offset += 2;
+
+  const id = buffer.subarray(offset, offset + 32).toString("hex");
+  offset += 32;
+  const sender = buffer.subarray(offset, offset + 32).toString("hex");
+  offset += 32;
+  // internal payload_length
+  offset += 2;
+  const nttPrefix = buffer.subarray(offset, offset + 4).toString("hex");
+  if (nttPrefix !== PREFIX_NTT_TRANSFER) {
+    throw new Error(`Invalid NTT manager prefix: 0x${nttPrefix}`);
+  }
+  offset += 4;
+  const decimals = buffer.readUInt8(offset);
+  offset += 1;
+  const amount = buffer.readBigUInt64BE(offset);
+  offset += 8;
+  const sourceToken = buffer.subarray(offset, offset + 32).toString("hex");
+  offset += 32;
+  const recipientAddress = buffer.subarray(offset, offset + 32).toString("hex");
+  offset += 32;
+  const recipientChain = buffer.readUInt16BE(offset);
+  offset += 2;
+
+  return {
+    sourceNttManager,
+    recipientNttManager,
+    managerPayloadLength,
+    id,
+    sender,
+    decimals,
+    amount,
+    sourceToken,
+    recipientAddress,
+    recipientChain,
+  };
+}
+
+/** Dispatch a payload to the right parser based on its prefix. */
+export function parsePayload(payload: Buffer): ParsedPayload {
+  const asciiPrefix = payload.length >= 4 ? readAscii(payload, 0, 4) : "";
+  const hexPrefix = payload.length >= 4 ? payload.subarray(0, 4).toString("hex") : "";
+  try {
+    switch (asciiPrefix) {
+      case PREFIX_XREL:
+        return { kind: "XrplRelease", ...parseXrel(payload) };
+      case PREFIX_XRFL:
+        return { kind: "TicketRefill", ...parseXrfl(payload) };
+      case PREFIX_XADM:
+        return { kind: "Admin", ...parseAdmin(payload) };
+      case PREFIX_XRPL:
+        return { kind: "Onboarding", ...parseOnboarding(payload) };
+    }
+    if (hexPrefix === PREFIX_WH_TRANSCEIVER) {
+      return { kind: "NttTransfer", ...parseNttTransfer(payload) };
+    }
+    return { kind: "Unknown", prefix: hexPrefix, hex: payload.toString("hex") };
+  } catch (e) {
+    // Fall back to Unknown so the CLI can still show the raw bytes + error.
+    return { kind: "Unknown", prefix: hexPrefix, hex: payload.toString("hex") };
+  }
+}
+
+// ── VAA envelope ─────────────────────────────────────────────────────────
+
+export interface ParsedVaa {
+  version: number;
+  guardianSetIndex: number;
+  signatures: { guardianIndex: number; signature: string }[];
+  timestamp: number;
+  nonce: number;
+  emitterChain: number;
+  emitterAddress: string;
+  sequence: bigint;
+  consistencyLevel: number;
+  payload: Buffer;
+}
+
+/** Parse a v1 VAA envelope (ported from xrpl_accounts/vaa.ts::parseVAA). */
+export function parseVaa(vaaBytes: Buffer): ParsedVaa {
+  let offset = 0;
+  const version = vaaBytes.readUInt8(offset);
+  offset += 1;
+  const guardianSetIndex = vaaBytes.readUInt32BE(offset);
+  offset += 4;
+  const numSignatures = vaaBytes.readUInt8(offset);
+  offset += 1;
+
+  const signatures: ParsedVaa["signatures"] = [];
+  for (let i = 0; i < numSignatures; i++) {
+    const guardianIndex = vaaBytes.readUInt8(offset);
+    offset += 1;
+    const signature = vaaBytes.subarray(offset, offset + 65).toString("hex");
+    offset += 65;
+    signatures.push({ guardianIndex, signature });
+  }
+
+  const timestamp = vaaBytes.readUInt32BE(offset);
+  offset += 4;
+  const nonce = vaaBytes.readUInt32BE(offset);
+  offset += 4;
+  const emitterChain = vaaBytes.readUInt16BE(offset);
+  offset += 2;
+  const emitterAddress = vaaBytes.subarray(offset, offset + 32).toString("hex");
+  offset += 32;
+  const sequence = vaaBytes.readBigUInt64BE(offset);
+  offset += 8;
+  const consistencyLevel = vaaBytes.readUInt8(offset);
+  offset += 1;
+  const payload = Buffer.from(vaaBytes.subarray(offset));
+
+  return {
+    version,
+    guardianSetIndex,
+    signatures,
+    timestamp,
+    nonce,
+    emitterChain,
+    emitterAddress,
+    sequence,
+    consistencyLevel,
+    payload,
+  };
+}

--- a/cli/src/xrpl/payloads.ts
+++ b/cli/src/xrpl/payloads.ts
@@ -110,7 +110,9 @@ export function parseXrel(buffer: Buffer): XrelPayload {
 
   const ticketId = buffer.readBigUInt64BE(offset);
   offset += 8;
-  const xrplCustodyAccount = encodeAccountID(buffer.subarray(offset, offset + 20));
+  const xrplCustodyAccount = encodeAccountID(
+    buffer.subarray(offset, offset + 20)
+  );
   offset += 20;
   const xrplRecipient = encodeAccountID(buffer.subarray(offset, offset + 20));
   offset += 20;
@@ -134,7 +136,10 @@ export function parseXrel(buffer: Buffer): XrelPayload {
     if (buffer.length < offset + 40) {
       throw new Error("XREL: insufficient bytes for IOU token");
     }
-    const currency = buffer.subarray(offset, offset + 20).toString("hex").toUpperCase();
+    const currency = buffer
+      .subarray(offset, offset + 20)
+      .toString("hex")
+      .toUpperCase();
     offset += 20;
     const issuer = encodeAccountID(buffer.subarray(offset, offset + 20));
     offset += 20;
@@ -143,7 +148,10 @@ export function parseXrel(buffer: Buffer): XrelPayload {
     if (buffer.length < offset + 24) {
       throw new Error("XREL: insufficient bytes for MPT token");
     }
-    const mptIssuanceId = buffer.subarray(offset, offset + 24).toString("hex").toUpperCase();
+    const mptIssuanceId = buffer
+      .subarray(offset, offset + 24)
+      .toString("hex")
+      .toUpperCase();
     offset += 24;
     tokenId = { type: "MPT", mptIssuanceId };
   } else {
@@ -239,7 +247,11 @@ export function parseAdmin(buffer: Buffer): AdminPayload {
       newAdmin: encodeAccountID(buffer.subarray(25, 45)),
     };
   }
-  return { action, actionName: `Unknown(0x${action.toString(16)})`, targetAccount };
+  return {
+    action,
+    actionName: `Unknown(0x${action.toString(16)})`,
+    targetAccount,
+  };
 }
 
 /**
@@ -248,7 +260,9 @@ export function parseAdmin(buffer: Buffer): AdminPayload {
  */
 export function parseOnboarding(buffer: Buffer): OnboardingPayload {
   if (buffer.length < 72) {
-    throw new Error(`Onboarding payload too short: ${buffer.length} bytes (min 72)`);
+    throw new Error(
+      `Onboarding payload too short: ${buffer.length} bytes (min 72)`
+    );
   }
   const prefix = readAscii(buffer, 0, 4);
   if (prefix !== PREFIX_XRPL) {
@@ -289,7 +303,9 @@ export function parseNttTransfer(buffer: Buffer): NttTransferPayload {
   offset += 4;
   const sourceNttManager = buffer.subarray(offset, offset + 32).toString("hex");
   offset += 32;
-  const recipientNttManager = buffer.subarray(offset, offset + 32).toString("hex");
+  const recipientNttManager = buffer
+    .subarray(offset, offset + 32)
+    .toString("hex");
   offset += 32;
   const managerPayloadLength = buffer.readUInt16BE(offset);
   offset += 2;
@@ -333,7 +349,8 @@ export function parseNttTransfer(buffer: Buffer): NttTransferPayload {
 /** Dispatch a payload to the right parser based on its prefix. */
 export function parsePayload(payload: Buffer): ParsedPayload {
   const asciiPrefix = payload.length >= 4 ? readAscii(payload, 0, 4) : "";
-  const hexPrefix = payload.length >= 4 ? payload.subarray(0, 4).toString("hex") : "";
+  const hexPrefix =
+    payload.length >= 4 ? payload.subarray(0, 4).toString("hex") : "";
   try {
     switch (asciiPrefix) {
       case PREFIX_XREL:

--- a/cli/src/xrpl/tokenId.ts
+++ b/cli/src/xrpl/tokenId.ts
@@ -1,0 +1,263 @@
+// Token ID encoding/decoding for XRPL tokens (XRP, IOUs, MPTs)
+//
+// Ported from ripple/xrpl-client/src/token-id.ts, which mirrors the Guardian
+// watcher (node/pkg/watchers/xrpl/parse.go) and the Solana Sequencer
+// (XrplTokenId in state.rs). Keep these in sync.
+//
+// Emitter format (32 bytes, for the Wormhole VAA emitter address):
+//   keccak256("ntt"[3] || padLeft(manager[20], 32)[32] || tokenId32[32])
+//   where tokenId32 is:
+//     XRP: 32 zeros
+//     IOU: 0x01 || last 31 bytes of keccak256(currency[20] || issuer[20])
+//     MPT: 0x02 || 7 zeros || 24-byte issuance ID
+
+import { ethers } from "ethers";
+import { decodeAccountID, encodeAccountID } from "xrpl";
+
+export type TokenType = "XRP" | "IOU" | "MPT";
+
+export const TOKEN_TYPE_XRP = 0x00;
+export const TOKEN_TYPE_IOU = 0x01;
+export const TOKEN_TYPE_MPT = 0x02;
+
+export interface XrpToken {
+  type: "XRP";
+}
+
+export interface IouToken {
+  type: "IOU";
+  currency: Buffer; // 20 bytes
+  issuer: Buffer; // 20 bytes (account ID)
+}
+
+export interface MptToken {
+  type: "MPT";
+  issuanceId: Buffer; // 24 bytes
+}
+
+export type TokenId = XrpToken | IouToken | MptToken;
+
+/** Create an XRP token identifier. */
+export function xrpToken(): XrpToken {
+  return { type: "XRP" };
+}
+
+/**
+ * Create an IOU token identifier.
+ *
+ * @param currency - Currency code (3-4 char ASCII or 40-char hex)
+ * @param issuer - Issuer r-address or 20-byte account ID
+ */
+export function iouToken(currency: string, issuer: string | Buffer): IouToken {
+  return {
+    type: "IOU",
+    currency: encodeCurrency(currency),
+    issuer:
+      typeof issuer === "string"
+        ? Buffer.from(decodeAccountID(issuer))
+        : issuer,
+  };
+}
+
+/**
+ * Create an MPT token identifier.
+ *
+ * @param issuanceId - 24-byte MPT issuance ID (48-char hex string or Buffer)
+ */
+export function mptToken(issuanceId: string | Buffer): MptToken {
+  const idBuf =
+    typeof issuanceId === "string"
+      ? Buffer.from(issuanceId.replace(/^0x/, ""), "hex")
+      : issuanceId;
+  if (idBuf.length !== 24) {
+    throw new Error(`MPT issuance ID must be 24 bytes, got ${idBuf.length}`);
+  }
+  return { type: "MPT", issuanceId: idBuf };
+}
+
+/** Accept an r-address or 20-byte hex and return the 20-byte account ID. */
+export function accountIdFrom(addr: string): Buffer {
+  if (addr.startsWith("r")) {
+    return Buffer.from(decodeAccountID(addr));
+  }
+  const hex = addr.replace(/^0x/, "");
+  if (hex.length !== 40) {
+    throw new Error(
+      `Expected an r-address or 20-byte hex (40 chars), got "${addr}"`,
+    );
+  }
+  return Buffer.from(hex, "hex");
+}
+
+/**
+ * Encode a currency code to 20 bytes.
+ *
+ * - 3-4 char ASCII codes: ASCII in bytes 12-14(15), byte 0 must be 0x00.
+ * - 40-char hex codes: stored as-is (20 bytes).
+ *
+ * "XRP" is not a valid IOU currency code.
+ */
+export function encodeCurrency(currency: string): Buffer {
+  const buf = Buffer.alloc(20);
+
+  if (currency.length === 40 && /^[0-9A-Fa-f]+$/.test(currency)) {
+    const decoded = Buffer.from(currency, "hex");
+    if (decoded.length !== 20) {
+      throw new Error(
+        `Invalid currency hex: expected 20 bytes, got ${decoded.length}`,
+      );
+    }
+    return decoded;
+  } else if (currency.length >= 3 && currency.length <= 4) {
+    if (currency.toUpperCase() === "XRP") {
+      throw new Error("XRP is not a valid IOU currency code");
+    }
+    for (let i = 0; i < currency.length; i++) {
+      buf[12 + i] = currency.charCodeAt(i);
+    }
+    return buf;
+  }
+  throw new Error(
+    `Invalid currency code: must be 3-4 ASCII chars or 40-char hex, got "${currency}"`,
+  );
+}
+
+/** Decode a 20-byte currency code to a display string. */
+export function decodeCurrency(buf: Buffer): string {
+  if (buf.length !== 20) {
+    throw new Error(`Currency must be 20 bytes, got ${buf.length}`);
+  }
+  if (buf[0] === 0x00) {
+    let code = "";
+    for (let i = 12; i < 15; i++) {
+      if (buf[i] !== 0) code += String.fromCharCode(buf[i]);
+    }
+    if (code.length > 0) return code;
+  }
+  return buf.toString("hex").toUpperCase();
+}
+
+/** Human-readable token id (for display). */
+export function formatTokenId(token: TokenId): string {
+  switch (token.type) {
+    case "XRP":
+      return "XRP";
+    case "IOU":
+      return `${decodeCurrency(token.currency)}/${encodeAccountID(token.issuer)}`;
+    case "MPT":
+      return `MPT:${token.issuanceId.toString("hex").toUpperCase()}`;
+  }
+}
+
+/**
+ * Build the 32-byte token id used in emitter address derivation.
+ *
+ * Matches the Guardian's parse.go token type constants:
+ *   XRP: 32 zeros
+ *   IOU: 0x01 || last 31 bytes of keccak256(currency[20] || issuer[20])
+ *   MPT: 0x02 || 7 zeros || 24-byte issuance ID
+ */
+export function buildTokenIdForEmitter(token: TokenId): Buffer {
+  const buf = Buffer.alloc(32);
+
+  switch (token.type) {
+    case "XRP":
+      break; // all zeros
+    case "IOU": {
+      buf[0] = 0x01;
+      const hashInput = Buffer.concat([token.currency, token.issuer]);
+      const hash = Buffer.from(ethers.getBytes(ethers.keccak256(hashInput)));
+      hash.copy(buf, 1, 1, 32); // last 31 bytes of hash into bytes 1..31
+      break;
+    }
+    case "MPT":
+      buf[0] = 0x02;
+      token.issuanceId.copy(buf, 8); // bytes 1..7 stay zero
+      break;
+  }
+
+  return buf;
+}
+
+/**
+ * Compute the Wormhole emitter address for an XRPL account + token pair.
+ *
+ * emitter = keccak256("ntt"[3] || padLeft(manager,32)[32] || tokenId[32])
+ *
+ * @param accountId - 20-byte XRPL account ID (manager/custody address)
+ */
+export function computeEmitterAddress(
+  accountId: Buffer,
+  token: TokenId,
+): Buffer {
+  if (accountId.length !== 20) {
+    throw new Error(`Account ID must be 20 bytes, got ${accountId.length}`);
+  }
+  const manager = ethers.zeroPadValue(ethers.hexlify(accountId), 32);
+  const tokenId = ethers.hexlify(buildTokenIdForEmitter(token));
+  const emitter = ethers.keccak256(
+    ethers.concat([ethers.hexlify(Buffer.from("ntt")), manager, tokenId]),
+  );
+  return Buffer.from(emitter.slice(2), "hex");
+}
+
+/** Convenience: compute emitter from an XRPL r-address. */
+export function computeEmitterAddressFromRAddress(
+  rAddress: string,
+  token: TokenId,
+): Buffer {
+  const accountId = Buffer.from(decodeAccountID(rAddress));
+  return computeEmitterAddress(accountId, token);
+}
+
+/**
+ * Parse an XRPL Amount field (from tx metadata) into a TokenId.
+ *
+ *   XRP: string (drops)
+ *   IOU: { currency, value, issuer }
+ *   MPT: { mpt_issuance_id, value }
+ */
+export function tokenIdFromXrplAmount(amount: unknown): TokenId {
+  if (typeof amount === "string") {
+    return { type: "XRP" };
+  }
+  if (amount && typeof amount === "object") {
+    const a = amount as Record<string, unknown>;
+    if ("mpt_issuance_id" in a) {
+      return mptToken(a.mpt_issuance_id as string);
+    }
+    if ("currency" in a && "issuer" in a) {
+      return iouToken(a.currency as string, a.issuer as string);
+    }
+  }
+  throw new Error(`Unknown XRPL amount format: ${JSON.stringify(amount)}`);
+}
+
+/**
+ * Resolve a TokenId from CLI-style flags.
+ *
+ * @param type - "xrp" | "iou" | "mpt"
+ */
+export function tokenIdFromFlags(opts: {
+  type: string;
+  currency?: string;
+  issuer?: string;
+  mptId?: string;
+}): TokenId {
+  switch (opts.type.toLowerCase()) {
+    case "xrp":
+      return xrpToken();
+    case "iou":
+      if (!opts.currency || !opts.issuer) {
+        throw new Error("IOU token requires --currency and --issuer");
+      }
+      return iouToken(opts.currency, opts.issuer);
+    case "mpt":
+      if (!opts.mptId) {
+        throw new Error("MPT token requires --mpt-id");
+      }
+      return mptToken(opts.mptId);
+    default:
+      throw new Error(`Unknown token type: ${opts.type} (expected xrp|iou|mpt)`);
+  }
+}

--- a/cli/src/xrpl/tokenId.ts
+++ b/cli/src/xrpl/tokenId.ts
@@ -211,6 +211,22 @@ export function computeEmitterAddressFromRAddress(
 }
 
 /**
+ * Convert a 20-byte XRPL account ID to a 32-byte emitter address, left-padded
+ * with 12 zero bytes. This is the emitter scheme for *core* VAAs synthesized
+ * from XRPL publishes (onboarding / admin / register-peer) — the emitter is the
+ * raw sending account, NOT the keccak NTT transceiver emitter. Mirrors
+ * ripple/xrpl-client/src/export.ts::xrplAccountToEmitter.
+ */
+export function xrplAccountToEmitter(accountId: Buffer): string {
+  if (accountId.length !== 20) {
+    throw new Error(`account ID must be 20 bytes, got ${accountId.length}`);
+  }
+  const padded = Buffer.alloc(32);
+  accountId.copy(padded, 12);
+  return padded.toString("hex");
+}
+
+/**
  * Parse an XRPL Amount field (from tx metadata) into a TokenId.
  *
  *   XRP: string (drops)

--- a/cli/src/xrpl/tokenId.ts
+++ b/cli/src/xrpl/tokenId.ts
@@ -83,7 +83,7 @@ export function accountIdFrom(addr: string): Buffer {
   const hex = addr.replace(/^0x/, "");
   if (hex.length !== 40) {
     throw new Error(
-      `Expected an r-address or 20-byte hex (40 chars), got "${addr}"`,
+      `Expected an r-address or 20-byte hex (40 chars), got "${addr}"`
     );
   }
   return Buffer.from(hex, "hex");
@@ -104,7 +104,7 @@ export function encodeCurrency(currency: string): Buffer {
     const decoded = Buffer.from(currency, "hex");
     if (decoded.length !== 20) {
       throw new Error(
-        `Invalid currency hex: expected 20 bytes, got ${decoded.length}`,
+        `Invalid currency hex: expected 20 bytes, got ${decoded.length}`
       );
     }
     return decoded;
@@ -118,7 +118,7 @@ export function encodeCurrency(currency: string): Buffer {
     return buf;
   }
   throw new Error(
-    `Invalid currency code: must be 3-4 ASCII chars or 40-char hex, got "${currency}"`,
+    `Invalid currency code: must be 3-4 ASCII chars or 40-char hex, got "${currency}"`
   );
 }
 
@@ -188,7 +188,7 @@ export function buildTokenIdForEmitter(token: TokenId): Buffer {
  */
 export function computeEmitterAddress(
   accountId: Buffer,
-  token: TokenId,
+  token: TokenId
 ): Buffer {
   if (accountId.length !== 20) {
     throw new Error(`Account ID must be 20 bytes, got ${accountId.length}`);
@@ -196,7 +196,7 @@ export function computeEmitterAddress(
   const manager = ethers.zeroPadValue(ethers.hexlify(accountId), 32);
   const tokenId = ethers.hexlify(buildTokenIdForEmitter(token));
   const emitter = ethers.keccak256(
-    ethers.concat([ethers.hexlify(Buffer.from("ntt")), manager, tokenId]),
+    ethers.concat([ethers.hexlify(Buffer.from("ntt")), manager, tokenId])
   );
   return Buffer.from(emitter.slice(2), "hex");
 }
@@ -204,7 +204,7 @@ export function computeEmitterAddress(
 /** Convenience: compute emitter from an XRPL r-address. */
 export function computeEmitterAddressFromRAddress(
   rAddress: string,
-  token: TokenId,
+  token: TokenId
 ): Buffer {
   const accountId = Buffer.from(decodeAccountID(rAddress));
   return computeEmitterAddress(accountId, token);
@@ -274,6 +274,8 @@ export function tokenIdFromFlags(opts: {
       }
       return mptToken(opts.mptId);
     default:
-      throw new Error(`Unknown token type: ${opts.type} (expected xrp|iou|mpt)`);
+      throw new Error(
+        `Unknown token type: ${opts.type} (expected xrp|iou|mpt)`
+      );
   }
 }


### PR DESCRIPTION
XRP Ledger commands used when preparing an NTT deployment on XRPL. XRPL has no smart contracts, so NTT relies on a Guardian-controlled custody model. These commands cover (1) creating/configuring the underlying XRPL token, (2) setting up the custody account and handing it off to the manager-set multisig, and (3) operating a live deployment (emitter derivation, VAA decoding, relaying).

For more detailed information see the `README.md` on the `cli/src/commands/xrpl` directory