### PR TITLE
fix: repair cli typecheck after Sui v2 / SDK 5.0.0 migration

### DIFF
--- a/cli/src/evm/signer.ts
+++ b/cli/src/evm/signer.ts
@@ -100,7 +100,7 @@ export class EvmNativeSigner<N extends Network, C extends EvmChains = EvmChains>
   }
 
   async sign(tx: UnsignedTransaction<N, C>[]): Promise<SignedTx[]> {
-    const chain = this.chain();
+    const chain: EvmChains = this.chain();
 
     const signed = [];
 
@@ -108,9 +108,6 @@ export class EvmNativeSigner<N extends Network, C extends EvmChains = EvmChains>
 
     // Per-chain gas limit overrides where the default 500k is insufficient
     switch (chain) {
-      case "Mantle":
-        gasLimit = 2600_000_000_000n;
-        break;
       case "ArbitrumSepolia":
         gasLimit = 4_000_000n;
         break;

--- a/cli/src/sui/signer.ts
+++ b/cli/src/sui/signer.ts
@@ -15,12 +15,12 @@ import {
   type SuiChains,
   _platform,
 } from "@wormhole-foundation/sdk-sui";
-import { SuiClient } from "@mysten/sui/client";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { Transaction } from "@mysten/sui/transactions";
 
 export async function getSuiSigner(
-  rpc: SuiClient,
+  rpc: SuiGrpcClient,
   key: string | Ed25519Keypair,
   opts?: {
     debug?: boolean;
@@ -43,7 +43,7 @@ export class SuiNativeSigner<N extends Network, C extends SuiChains = SuiChains>
     _chain: C,
     _address: string,
     _signer: Ed25519Keypair,
-    readonly client: SuiClient,
+    readonly client: SuiGrpcClient,
     readonly opts?: { debug?: boolean }
   ) {
     super(_chain, _address, _signer);
@@ -112,10 +112,7 @@ export class SuiNativeSigner<N extends Network, C extends SuiChains = SuiChains>
         console.error("ERROR: Transaction context at time of failure:");
         console.error("  - Description:", description);
         console.error("  - Transaction type:", typeof transaction);
-        console.error(
-          "  - Transaction blockData exists:",
-          !!transaction.blockData
-        );
+        console.error("  - Transaction data exists:", !!transaction.getData());
         console.error("  - Signer exists:", !!this._signer);
         console.error("  - Client exists:", !!this.client);
 


### PR DESCRIPTION
- sui/signer: SuiClient -> SuiGrpcClient (@mysten/sui v2 ESM API), transaction.blockData -> transaction.getData()
- evm/signer: type chain as EvmChains for literal comparison; drop the Mantle gas override (Mantle was removed from the chain registry in sdk-base 5.0.0)