### PR TITLE
cli(xrpl:) subcommand for "XRPL" prefix generated emitter address

### DIFF
--- a/cli/src/__tests__/xrpl-tokenId.test.ts
+++ b/cli/src/__tests__/xrpl-tokenId.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "bun:test";
+import { decodeAccountID } from "xrpl";
 import {
   computeEmitterAddressFromRAddress,
   iouToken,
@@ -9,6 +10,10 @@ import {
   buildTokenIdForEmitter,
   tokenIdFromFlags,
   formatTokenId,
+  xrplAccountToEmitter,
+  xrplGeneratedEmitter,
+  xrplGeneratedEmitterFromRAddress,
+  XRPL_GENERATED_EMITTER_PREFIX,
 } from "../xrpl/tokenId";
 
 // Known-good vectors from full_docs.md "New Sequencer Setups" — these are the
@@ -43,6 +48,46 @@ describe("computeEmitterAddress — known testnet vectors", () => {
     expect(emitter.toString("hex")).toBe(
       "b97ab26d22bf8688ce7466aac3031abfde0af2ab86ca57854d773f485c3cbb8a"
     );
+  });
+});
+
+describe("xrplGeneratedEmitter — watcher-generated message emitter", () => {
+  const rAddress = "rfeMQr71KJQwNUbRwGTgCfVLoUVdWuvyny";
+  const accountId = Buffer.from(decodeAccountID(rAddress));
+
+  it("is 32 bytes / 64 hex chars", () => {
+    expect(xrplGeneratedEmitter(accountId).length).toBe(64);
+  });
+
+  it("starts with the 'XRPL' (0x5852504c) prefix", () => {
+    expect(XRPL_GENERATED_EMITTER_PREFIX).toBe("5852504c");
+    expect(xrplGeneratedEmitter(accountId).startsWith("5852504c")).toBe(true);
+  });
+
+  it("has 8 zero bytes between the prefix and the account", () => {
+    const hex = xrplGeneratedEmitter(accountId);
+    expect(hex.slice(8, 24)).toBe("00".repeat(8));
+  });
+
+  it("preserves the account in the last 20 bytes", () => {
+    const hex = xrplGeneratedEmitter(accountId);
+    expect(hex.slice(24)).toBe(accountId.toString("hex"));
+  });
+
+  it("differs from the raw core account emitter for the same account", () => {
+    expect(xrplGeneratedEmitter(accountId)).not.toBe(
+      xrplAccountToEmitter(accountId)
+    );
+  });
+
+  it("FromRAddress matches the buffer form", () => {
+    expect(xrplGeneratedEmitterFromRAddress(rAddress)).toBe(
+      xrplGeneratedEmitter(accountId)
+    );
+  });
+
+  it("rejects a non-20-byte account id", () => {
+    expect(() => xrplGeneratedEmitter(Buffer.alloc(19))).toThrow();
   });
 });
 

--- a/cli/src/commands/xrpl/README.md
+++ b/cli/src/commands/xrpl/README.md
@@ -243,17 +243,27 @@ ntt xrpl set-signer-list -n Testnet --signers r1,r2,r3 --quorum 2 --issuer-seed 
 
 ### `emitter`
 
-Computes the Wormhole transceiver emitter address for an XRPL custody account +
-token — `keccak256("ntt" + manager[32] + tokenId[32])`. Offline (no XRPL/RPC
-connection). Use the printed `0x…` value with `ntt manual set-transceiver-peer`.
+Computes an XRPL emitter address for a custody account. Offline (no XRPL/RPC
+connection). Two kinds, selected with `--kind` (default `transceiver`):
+
+- `transceiver` — the Wormhole NTT transceiver emitter,
+  `keccak256("ntt" + manager[32] + tokenId[32])`. Use the printed `0x…` value
+  with `ntt manual set-transceiver-peer`. Requires `--token`.
+- `generated` — the emitter the watcher uses for the account's automated
+  messages (acks such as XACK/XTCF): `"XRPL"[4] + 00×8 + account[20]`. This
+  namespace is distinct from a core publish (`00×12 + account`), so such
+  messages can't be forged through the core bridge. Useful for looking the
+  resulting VAA up by `(chain, emitter, sequence)`. `--token` is ignored.
 
 - `--manager` (required) — custody account (r-address or 20-byte hex)
-- `--token` (required) — `xrp` | `iou` | `mpt`
+- `--kind` — `transceiver` (default) | `generated`
+- `--token` — `xrp` | `iou` | `mpt` (required for `--kind transceiver`)
 - `--currency`, `--issuer` [`--token iou`]; `--mpt-id` [`--token mpt`]
 
 ```
 ntt xrpl emitter --manager rfeMQr71KJQwNUbRwGTgCfVLoUVdWuvyny --token xrp
 ntt xrpl emitter --manager rnv8... --token iou --currency FOO --issuer rnv8...
+ntt xrpl emitter --manager rfeMQr71KJQwNUbRwGTgCfVLoUVdWuvyny --kind generated
 ```
 
 ### `parse-vaa`

--- a/cli/src/commands/xrpl/emitter.ts
+++ b/cli/src/commands/xrpl/emitter.ts
@@ -9,6 +9,7 @@ import {
   computeEmitterAddress,
   formatTokenId,
   tokenIdFromFlags,
+  xrplGeneratedEmitter,
   type TokenId,
 } from "../../xrpl/tokenId";
 
@@ -18,7 +19,7 @@ export function createXrplEmitterCommand(
   return {
     command: "emitter",
     describe:
-      "Compute the XRPL transceiver emitter address for a manager + token (no tx)",
+      "Compute an XRPL emitter address for a manager / custody account (no tx)",
     builder: (yargs: any) =>
       yargs
         .option("manager", {
@@ -27,11 +28,17 @@ export function createXrplEmitterCommand(
           type: "string",
           demandOption: true,
         })
+        .option("kind", {
+          describe:
+            "Emitter kind: transceiver (NTT, needs --token) or generated (watcher acks XACK/XTCF)",
+          type: "string",
+          choices: ["transceiver", "generated"] as const,
+          default: "transceiver",
+        })
         .option("token", {
-          describe: "XRPL token type",
+          describe: "XRPL token type [--kind transceiver]",
           type: "string",
           choices: ["xrp", "iou", "mpt"] as const,
-          demandOption: true,
         })
         .option("currency", {
           describe: "IOU currency: 3-4 char ASCII or 40-char hex [--token iou]",
@@ -47,21 +54,39 @@ export function createXrplEmitterCommand(
         })
         .example(
           "$0 xrpl emitter --manager rfeMQr71KJQwNUbRwGTgCfVLoUVdWuvyny --token xrp",
-          "Emitter for an XRP custody account"
+          "Transceiver emitter for an XRP custody account"
         )
         .example(
           "$0 xrpl emitter --manager rnv8... --token iou --currency FOO --issuer rnv8...",
-          "Emitter for an IOU deployment"
+          "Transceiver emitter for an IOU deployment"
+        )
+        .example(
+          "$0 xrpl emitter --manager rfeMQr71KJQwNUbRwGTgCfVLoUVdWuvyny --kind generated",
+          "Emitter the watcher uses for that account's automated acks (XACK/XTCF)"
         ),
     handler: (argv: any) =>
       runXrpl(async () => {
+        const accountId = accountIdFrom(argv.manager);
+
+        if (argv.kind === "generated") {
+          const hex = xrplGeneratedEmitter(accountId);
+          console.log(colors.blue("🧮 XRPL generated-message emitter"));
+          console.log(`  manager: ${colors.yellow(argv.manager)}`);
+          console.log(`  kind:    ${colors.yellow("generated (XACK/XTCF)")}`);
+          console.log(`  emitter: ${colors.green(hex)}`);
+          console.log(`  0x form: ${colors.green("0x" + hex)}`);
+          return;
+        }
+
+        if (!argv.token) {
+          throw new Error("--token is required for --kind transceiver");
+        }
         const token: TokenId = tokenIdFromFlags({
           type: argv.token,
           currency: argv.currency,
           issuer: argv.issuer,
           mptId: argv["mpt-id"],
         });
-        const accountId = accountIdFrom(argv.manager);
         const emitter = computeEmitterAddress(accountId, token);
         const hex = emitter.toString("hex");
 

--- a/cli/src/xrpl/tokenId.ts
+++ b/cli/src/xrpl/tokenId.ts
@@ -212,10 +212,13 @@ export function computeEmitterAddressFromRAddress(
 
 /**
  * Convert a 20-byte XRPL account ID to a 32-byte emitter address, left-padded
- * with 12 zero bytes. This is the emitter scheme for *core* VAAs synthesized
- * from XRPL publishes (onboarding / admin / register-peer) — the emitter is the
+ * with 12 zero bytes. This is the emitter scheme for *core* VAAs published by
+ * the account itself (onboarding / admin / register-peer) — the emitter is the
  * raw sending account, NOT the keccak NTT transceiver emitter. Mirrors
  * ripple/xrpl-client/src/export.ts::xrplAccountToEmitter.
+ *
+ * Do NOT use this for the watcher's automated messages (XACK / XTCF): those use
+ * {@link xrplGeneratedEmitter} so they cannot be forged via a core publish.
  */
 export function xrplAccountToEmitter(accountId: Buffer): string {
   if (accountId.length !== 20) {
@@ -224,6 +227,39 @@ export function xrplAccountToEmitter(accountId: Buffer): string {
   const padded = Buffer.alloc(32);
   accountId.copy(padded, 12);
   return padded.toString("hex");
+}
+
+/** ASCII "XRPL" (0x5852504C) — 4-byte prefix marking a watcher-generated emitter. */
+export const XRPL_GENERATED_EMITTER_PREFIX = "5852504c";
+
+/**
+ * Derive the 32-byte emitter address for a *watcher-generated* automated
+ * message (the acks the watcher synthesizes for custody txs — e.g. XACK / XTCF).
+ *
+ *   emitter = "XRPL"[4] || 0x00 * 8 || accountId[20]
+ *
+ * These messages are not published by the account, so giving them a distinct
+ * "XRPL"-prefixed namespace makes them impossible to forge with a core-bridge
+ * publish: a core publish always yields 0x00..00 || account (see
+ * {@link xrplAccountToEmitter}), never the "XRPL" prefix. The account is still
+ * recoverable as the last 20 bytes — but note the first 4 bytes are no longer
+ * zero, so anything asserting the leading 12 bytes are zero must be updated.
+ *
+ * @param accountId - 20-byte XRPL account ID
+ */
+export function xrplGeneratedEmitter(accountId: Buffer): string {
+  if (accountId.length !== 20) {
+    throw new Error(`account ID must be 20 bytes, got ${accountId.length}`);
+  }
+  const emitter = Buffer.alloc(32);
+  emitter.write(XRPL_GENERATED_EMITTER_PREFIX, 0, "hex");
+  accountId.copy(emitter, 12);
+  return emitter.toString("hex");
+}
+
+/** Convenience: derive the watcher-generated emitter from an XRPL r-address. */
+export function xrplGeneratedEmitterFromRAddress(rAddress: string): string {
+  return xrplGeneratedEmitter(Buffer.from(decodeAccountID(rAddress)));
 }
 
 /**


### PR DESCRIPTION
Used for XACK and XCTF payload types