### PR TITLE
fix: executor gas limit override for Tempo mainnet

### DIFF
--- a/evm/ts/src/executorGasLimits.ts
+++ b/evm/ts/src/executorGasLimits.ts
@@ -9,6 +9,7 @@ export const executorGasLimitOverrides: Partial<
 > = {
   Mainnet: {
     Arbitrum: 800_000n,
+    Tempo: 1_500_000n,
     CreditCoin: 1_500_000n,
     Monad: 1_000_000n,
     MegaETH: 1_000_000n,


### PR DESCRIPTION
Tempo meters gas several times a standard EVM estimate, so the default 500k executor gas limit fails the relay simulation on delivery ("Error due to low gas Limit when simulating"). Testnet already overrides Tempo to 1.5M; apply the same override on Mainnet.