### PR TITLE
ci: add typechecking for TS CLI

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -26,4 +26,5 @@ jobs:
           bun-version: "1.3.4"
       - run: bun ci
       - run: bun --if-present run build
+      - run: bun run typecheck:cli
       - run: bun run test


### PR DESCRIPTION
Add typechecking to the CI process for the CLI code. This replicates the CI we have in place on the monorepo.

Running this command reveals many errors with how the types are being handled in this code. All of them should be fixed so that we can restructure the code with higher confidence.